### PR TITLE
chore: bootstrap public tap distribution

### DIFF
--- a/.changeset/bootstrap-public-tap.md
+++ b/.changeset/bootstrap-public-tap.md
@@ -1,0 +1,12 @@
+---
+"@buildinternet/releases": patch
+"@buildinternet/releases-darwin-arm64": patch
+"@buildinternet/releases-darwin-x64": patch
+"@buildinternet/releases-linux-arm64": patch
+"@buildinternet/releases-linux-x64": patch
+"@buildinternet/releases-core": patch
+"@buildinternet/releases-lib": patch
+"@buildinternet/releases-skills": patch
+---
+
+Bootstrap public tap distribution — first release cut from the extracted OSS repo. Publishes binaries to `buildinternet/releases-cli` GitHub Releases and regenerates the Homebrew formula at `buildinternet/homebrew-tap`.


### PR DESCRIPTION
## Summary

First release cut from the extracted OSS repo. Adds a patch-level changeset across all 8 `@buildinternet/releases*` packages so the Changesets publish pipeline has something to act on.

Merging this triggers the release workflow to open a "chore: version packages" PR bumping 0.13.0 → 0.13.1. Merging that version PR publishes npm packages, creates the GitHub Release with gzipped binaries, and regenerates `Formula/releases.rb` in [buildinternet/homebrew-tap](https://github.com/buildinternet/homebrew-tap) — enabling \`brew install buildinternet/tap/releases\`.

## Test plan

- [ ] Version PR opens automatically after merge
- [ ] After merging the version PR: npm packages @ 0.13.1 are live
- [ ] GitHub Release v0.13.1 on this repo has 9 assets (4 × .gz, 4 × .gz.sha256, checksums.txt)
- [ ] Formula/releases.rb updated in buildinternet/homebrew-tap
- [ ] \`brew install buildinternet/tap/releases\` works on a clean Mac
- [ ] \`releases --version\` prints 0.13.1