### PR TITLE
ci: drop test step until tests are ported

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,9 +30,6 @@ jobs:
       - name: Type-check
         run: npx tsc --noEmit
 
-      - name: Run tests
-        run: bun run test
-
       - name: Build binaries
         run: |
           bun build --compile src/index.ts --outfile npm/releases-darwin-arm64/releases --target=bun-darwin-arm64


### PR DESCRIPTION
## Summary

The release workflow fails at \`Run tests\` because \`bun test\` exits 1 when no test files exist. The OSS repo hasn't had tests ported from the monorepo yet, so the step is unreachable-green and blocking every push to \`main\`.

Drop the step for now. Add back (or wrap with a pass-with-no-tests guard) once tests land.

## Test plan

- [ ] CI turns green on this PR
- [ ] After merge, the release workflow reaches the changesets action and opens the version PR for the pending bootstrap changeset