### PR TITLE
chore: gitignore compiled binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist
 *.tgz
 *.bun-build
 .*.bun-build
+npm/*/releases
 
 # logs
 *.log


### PR DESCRIPTION
## Summary

\`npm/*/releases\` are build artifacts (the compiled \`bun build --compile\` output), not source. They only need to exist on disk at \`npm publish\` time — npm reads from the filesystem, not git.

The changesets action was sweeping them into the auto-generated "chore: version packages" PR, adding ~317 MB of binaries across four platforms and triggering GitHub's >50 MB file warnings on push.

Ignoring them fixes the version PR going forward.

## Follow-up

After merging this, close PR #3 and delete the \`changeset-release/main\` branch so the orphaned binary commit becomes unreachable. The next push to \`main\` will regenerate a clean version PR.

## Test plan

- [ ] After merge + branch cleanup, the regenerated version PR contains only version bumps + CHANGELOG updates, no binaries
- [ ] No large-file warnings on push