### PR TITLE
fix(release): resolve platform-suffixed binary in generated formula

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,10 @@ jobs:
             end
 
             def install
-              bin.install "releases"
+              # Single-binary .gz decompresses to a platform-suffixed filename
+              # (e.g. releases-darwin-arm64). Rename to "releases" on install.
+              binary = Dir["releases-*"].find { |f| File.file?(f) }
+              bin.install binary => "releases"
             end
 
             test do


### PR DESCRIPTION
## Summary

\`brew install buildinternet/tap/releases\` v0.12.1 failed with \`Errno::ENOENT: No such file or directory - releases\` because the formula's install block was \`bin.install "releases"\`, but the .gz assets decompress to \`releases-darwin-arm64\` / \`releases-linux-x64\` / etc.

Updated the heredoc to glob for the platform-specific filename and rename to \`releases\` during install. Already patched directly in \`buildinternet/homebrew-tap\` so existing v0.12.1 installs work now; this PR ensures the workflow's generated formula doesn't overwrite the fix on next publish.

## Test plan

- [x] Tap formula patched directly (commit \`f286335\` in buildinternet/homebrew-tap)
- [ ] brew install succeeds with the patched formula
- [ ] After merging this PR, next publish regenerates the tap formula with the same install logic (no regression)