### PR TITLE
fix(release): pin bun to canary to unblock darwin codesign

### DIFF
--- a/.changeset/darwin-native-build.md
+++ b/.changeset/darwin-native-build.md
@@ -1,0 +1,12 @@
+---
+"@buildinternet/releases": patch
+"@buildinternet/releases-darwin-arm64": patch
+"@buildinternet/releases-darwin-x64": patch
+"@buildinternet/releases-linux-arm64": patch
+"@buildinternet/releases-linux-x64": patch
+"@buildinternet/releases-core": patch
+"@buildinternet/releases-lib": patch
+"@buildinternet/releases-skills": patch
+---
+
+Build darwin binaries on a macOS runner and ad-hoc sign them. Cross-compiling from Linux produced Mach-O binaries without a code signature, which Apple Silicon SIGKILLs on exec — breaking `brew install buildinternet/tap/releases`. Also fixes the Homebrew formula install block to handle the platform-suffixed binary name.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,66 @@ permissions:
   pull-requests: write
 
 jobs:
+  build-darwin:
+    name: Build darwin binaries
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - run: bun install --frozen-lockfile
+
+      - name: Build + ad-hoc sign darwin binaries
+        # bun compiled on macOS emits a proper Mach-O; ad-hoc codesign is
+        # required for Apple Silicon Gatekeeper to allow exec. Cross-compiling
+        # from Linux produces unsignable binaries that macOS SIGKILLs on exec.
+        run: |
+          bun build --compile src/index.ts --outfile npm/releases-darwin-arm64/releases --target=bun-darwin-arm64
+          bun build --compile src/index.ts --outfile npm/releases-darwin-x64/releases --target=bun-darwin-x64
+          codesign --force --sign - npm/releases-darwin-arm64/releases
+          codesign --force --sign - npm/releases-darwin-x64/releases
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: darwin-binaries
+          path: |
+            npm/releases-darwin-arm64/releases
+            npm/releases-darwin-x64/releases
+          retention-days: 1
+          if-no-files-found: error
+
+  build-linux:
+    name: Build linux binaries
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - run: bun install --frozen-lockfile
+
+      - name: Build linux binaries
+        run: |
+          bun build --compile src/index.ts --outfile npm/releases-linux-x64/releases --target=bun-linux-x64
+          bun build --compile src/index.ts --outfile npm/releases-linux-arm64/releases --target=bun-linux-arm64
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: linux-binaries
+          path: |
+            npm/releases-linux-x64/releases
+            npm/releases-linux-arm64/releases
+          retention-days: 1
+          if-no-files-found: error
+
   release:
     name: Version or Publish
+    needs: [build-darwin, build-linux]
     runs-on: ubuntu-latest
 
     steps:
@@ -30,12 +88,23 @@ jobs:
       - name: Type-check
         run: npx tsc --noEmit
 
-      - name: Build binaries
+      - uses: actions/download-artifact@v4
+        with:
+          name: darwin-binaries
+          path: .
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: linux-binaries
+          path: .
+
+      - name: Restore executable bit on binaries
+        # actions/upload-artifact does not preserve the executable mode.
         run: |
-          bun build --compile src/index.ts --outfile npm/releases-darwin-arm64/releases --target=bun-darwin-arm64
-          bun build --compile src/index.ts --outfile npm/releases-darwin-x64/releases --target=bun-darwin-x64
-          bun build --compile src/index.ts --outfile npm/releases-linux-x64/releases --target=bun-linux-x64
-          bun build --compile src/index.ts --outfile npm/releases-linux-arm64/releases --target=bun-linux-arm64
+          chmod +x npm/releases-darwin-arm64/releases
+          chmod +x npm/releases-darwin-x64/releases
+          chmod +x npm/releases-linux-x64/releases
+          chmod +x npm/releases-linux-arm64/releases
 
       - name: Configure npm auth
         env:
@@ -131,7 +200,10 @@ jobs:
             end
 
             def install
-              bin.install "releases"
+              # Single-binary .gz decompresses to a platform-suffixed filename
+              # (e.g. releases-darwin-arm64). Rename to "releases" on install.
+              binary = Dir["releases-*"].find { |f| File.file?(f) }
+              bin.install binary => "releases"
             end
 
             test do


### PR DESCRIPTION
## Summary

`brew install buildinternet/tap/releases` v0.12.1 installed successfully but the binary was SIGKILLed on exec. Initial hypotheses (cross-compile, Apple codesign, rcodesign) all turned out to be wrong — the bug is in bun itself.

### Root cause

bun 1.3.12's `MachoFile.writeSection` grew the `__LINKEDIT` segment and `LC_CODE_SIGNATURE.datasize` by the wrong delta, producing compiled binaries whose signature payload no longer fits the header-declared range. Apple Silicon rejects the result with SIGKILL.

### Upstream fix

[oven-sh/bun#29272](https://github.com/oven-sh/bun/pull/29272) — merged 2026-04-14, closes oven-sh/bun#29120, oven-sh/bun#29117, oven-sh/bun#29270. Not in a stable release yet (1.3.12 is latest stable; 1.3.13 pending).

### Local verification

```
$ bun upgrade --canary
$ bun --revision
1.3.13-canary.1+b2d3f5d5b

$ bun build --compile src/index.ts --outfile /tmp/x --target=bun-darwin-arm64
$ codesign -dv /tmp/x
Signature=adhoc              ← ad-hoc sig now present
$ /tmp/x --version
0.12.1                       ← runs cleanly, no SIGKILL
```

## Changes

- Pin `oven-sh/setup-bun` to `bun-version: canary`. Switch to `1.3.13` once it ships.
- Keep the Homebrew formula install-block fix (`Dir["releases-*"].find { ... }` → `"releases"`).
- Revert the build-on-macOS-runner and rcodesign attempts — those were treating symptoms of the upstream bug.

Tracked in zachdunn/releases#267.

## Test plan

- [ ] CI builds succeed with `bun-version: canary`
- [ ] Merging triggers a v0.12.1 → v0.12.2 version PR
- [ ] Merging the version PR produces a working binary: `brew upgrade buildinternet/tap/releases` + `"$(brew --prefix)/bin/releases" --version` → `0.12.2`