### PR TITLE
fix(release): pin bun to canary + leapfrog npm past orphan v0.13.0

### DIFF
--- a/.changeset/darwin-native-build.md
+++ b/.changeset/darwin-native-build.md
@@ -9,4 +9,4 @@
 "@buildinternet/releases-skills": patch
 ---
 
-Build darwin binaries on a macOS runner and ad-hoc sign them. Cross-compiling from Linux produced Mach-O binaries without a code signature, which Apple Silicon SIGKILLs on exec — breaking `brew install buildinternet/tap/releases`. Also fixes the Homebrew formula install block to handle the platform-suffixed binary name.
+Pin CI to bun canary to pick up oven-sh/bun#29272 — fixes `bun build --compile` producing Mach-O binaries that Apple Silicon SIGKILLs on exec due to a broken LC_CODE_SIGNATURE size in bun 1.3.12. Also leapfrogs the npm version timeline past the orphaned `@buildinternet/releases@0.13.0` left behind during the monorepo → OSS repo extraction.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,66 +12,8 @@ permissions:
   pull-requests: write
 
 jobs:
-  build-darwin:
-    name: Build darwin binaries
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - run: bun install --frozen-lockfile
-
-      - name: Build + ad-hoc sign darwin binaries
-        # bun compiled on macOS emits a proper Mach-O; ad-hoc codesign is
-        # required for Apple Silicon Gatekeeper to allow exec. Cross-compiling
-        # from Linux produces unsignable binaries that macOS SIGKILLs on exec.
-        run: |
-          bun build --compile src/index.ts --outfile npm/releases-darwin-arm64/releases --target=bun-darwin-arm64
-          bun build --compile src/index.ts --outfile npm/releases-darwin-x64/releases --target=bun-darwin-x64
-          codesign --force --sign - npm/releases-darwin-arm64/releases
-          codesign --force --sign - npm/releases-darwin-x64/releases
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: darwin-binaries
-          path: |
-            npm/releases-darwin-arm64/releases
-            npm/releases-darwin-x64/releases
-          retention-days: 1
-          if-no-files-found: error
-
-  build-linux:
-    name: Build linux binaries
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - run: bun install --frozen-lockfile
-
-      - name: Build linux binaries
-        run: |
-          bun build --compile src/index.ts --outfile npm/releases-linux-x64/releases --target=bun-linux-x64
-          bun build --compile src/index.ts --outfile npm/releases-linux-arm64/releases --target=bun-linux-arm64
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: linux-binaries
-          path: |
-            npm/releases-linux-x64/releases
-            npm/releases-linux-arm64/releases
-          retention-days: 1
-          if-no-files-found: error
-
   release:
     name: Version or Publish
-    needs: [build-darwin, build-linux]
     runs-on: ubuntu-latest
 
     steps:
@@ -81,30 +23,23 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          # Pinned to canary to pick up oven-sh/bun#29272, which fixes
+          # `bun build --compile` producing Mach-O binaries that macOS
+          # SIGKILLs on Apple Silicon due to a broken LC_CODE_SIGNATURE
+          # size in bun 1.3.12. Swap to `1.3.13` (or newer) once released.
+          bun-version: canary
 
       - run: bun install --frozen-lockfile
 
       - name: Type-check
         run: npx tsc --noEmit
 
-      - uses: actions/download-artifact@v4
-        with:
-          name: darwin-binaries
-          path: .
-
-      - uses: actions/download-artifact@v4
-        with:
-          name: linux-binaries
-          path: .
-
-      - name: Restore executable bit on binaries
-        # actions/upload-artifact does not preserve the executable mode.
+      - name: Build binaries
         run: |
-          chmod +x npm/releases-darwin-arm64/releases
-          chmod +x npm/releases-darwin-x64/releases
-          chmod +x npm/releases-linux-x64/releases
-          chmod +x npm/releases-linux-arm64/releases
+          bun build --compile src/index.ts --outfile npm/releases-darwin-arm64/releases --target=bun-darwin-arm64
+          bun build --compile src/index.ts --outfile npm/releases-darwin-x64/releases --target=bun-darwin-x64
+          bun build --compile src/index.ts --outfile npm/releases-linux-x64/releases --target=bun-linux-x64
+          bun build --compile src/index.ts --outfile npm/releases-linux-arm64/releases --target=bun-linux-arm64
 
       - name: Configure npm auth
         env:

--- a/npm/releases-darwin-arm64/package.json
+++ b/npm/releases-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@buildinternet/releases-darwin-arm64",
-  "version": "0.12.1",
+  "version": "0.13.1",
   "description": "releases binary for macOS ARM64",
   "os": [
     "darwin"

--- a/npm/releases-darwin-x64/package.json
+++ b/npm/releases-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@buildinternet/releases-darwin-x64",
-  "version": "0.12.1",
+  "version": "0.13.1",
   "description": "releases binary for macOS x64",
   "os": [
     "darwin"

--- a/npm/releases-linux-arm64/package.json
+++ b/npm/releases-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@buildinternet/releases-linux-arm64",
-  "version": "0.12.1",
+  "version": "0.13.1",
   "description": "releases binary for Linux ARM64",
   "os": [
     "linux"

--- a/npm/releases-linux-x64/package.json
+++ b/npm/releases-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@buildinternet/releases-linux-x64",
-  "version": "0.12.1",
+  "version": "0.13.1",
   "description": "releases binary for Linux x64",
   "os": [
     "linux"

--- a/npm/releases/package.json
+++ b/npm/releases/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@buildinternet/releases",
-  "version": "0.12.1",
+  "version": "0.13.1",
   "description": "Changelog indexer and registry for AI agents and developers",
   "bin": {
     "releases": "bin/releases"
@@ -9,10 +9,10 @@
     "bin/releases"
   ],
   "optionalDependencies": {
-    "@buildinternet/releases-darwin-arm64": "0.12.1",
-    "@buildinternet/releases-darwin-x64": "0.12.1",
-    "@buildinternet/releases-linux-x64": "0.12.1",
-    "@buildinternet/releases-linux-arm64": "0.12.1"
+    "@buildinternet/releases-darwin-arm64": "0.13.1",
+    "@buildinternet/releases-darwin-x64": "0.13.1",
+    "@buildinternet/releases-linux-x64": "0.13.1",
+    "@buildinternet/releases-linux-arm64": "0.13.1"
   },
   "keywords": [
     "changelog",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "releases-cli",
-  "version": "0.12.1",
+  "version": "0.13.1",
   "private": true,
   "description": "CLI and shared packages for Releases — the changelog registry for AI agents and developers.",
   "type": "module",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@buildinternet/releases-core",
-  "version": "0.12.1",
+  "version": "0.13.1",
   "description": "Pure helpers shared by the Releases CLI — schema, categories, slicing, IDs, slugs, tokens.",
   "type": "module",
   "license": "MIT",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@buildinternet/releases-lib",
-  "version": "0.12.1",
+  "version": "0.13.1",
   "description": "Runtime-neutral helpers for the Releases CLI — logger, errors, config.",
   "type": "module",
   "license": "MIT",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@buildinternet/releases-skills",
-  "version": "0.12.1",
+  "version": "0.13.1",
   "description": "Agent skills bundled with the Releases CLI. Markdown playbooks for changelog ingest, discovery, and analysis.",
   "type": "module",
   "license": "MIT",

--- a/src/cli/version.ts
+++ b/src/cli/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "0.12.1";
+export const VERSION = "0.13.1";


### PR DESCRIPTION
## Context

PR #7 merged a pre-canary workflow (macOS-runner + codesign) that failed in CI on main (run \`24536277586\`) — Apple's codesign and rcodesign both reject bun 1.3.12's compiled binary layout. My follow-up commits pushed to that branch never landed because the PR was already merged. This PR supersedes them with the actually-working fix.

Also takes the opportunity to address the versioning gap with the orphaned \`@buildinternet/releases@0.13.0\` on npm.

## Two fixes

### 1. Pin bun to canary

Root cause of the brew-install SIGKILLs is upstream: bun 1.3.12 regressed \`MachoFile.writeSection\`'s \`LC_CODE_SIGNATURE.datasize\` calculation, producing Mach-O binaries whose signature payload is truncated at the end — Apple Silicon refuses to exec them.

Upstream fix: [oven-sh/bun#29272](https://github.com/oven-sh/bun/pull/29272) — merged 2026-04-14, not yet in a stable release.

Verified locally:

\`\`\`
$ bun upgrade --canary
$ bun --revision
1.3.13-canary.1+b2d3f5d5b

$ bun build --compile src/index.ts --outfile /tmp/x --target=bun-darwin-arm64
$ codesign -dv /tmp/x
Signature=adhoc               ← ad-hoc signature now valid
$ /tmp/x --version
0.13.1                        ← runs cleanly, no SIGKILL
\`\`\`

Workflow change: \`bun-version: latest\` → \`bun-version: canary\`. Swap to \`1.3.13\` once stable lands.

Revert the earlier macOS-runner split — not needed once bun is fixed.

### 2. Leapfrog past the orphan

Hand-bump workspace baseline from \`0.12.1\` → \`0.13.1\`. This skips past \`@buildinternet/releases@0.13.0\` on npm, an orphan publish from the monorepo era that has a higher semver than our current 0.12.x line.

After this PR + the resulting version PR merge, the published version will be \`0.13.2\` (changesets patch-bumps on top of the pre-bumped 0.13.1). Anyone pinned to \`^0.13.0\` picks up the fix automatically.

Separately, I'll deprecate the 0.13.0 orphan on npm via \`npm deprecate\` once 0.13.2 is confirmed working.

## Also includes

- Homebrew formula install block fix (\`Dir["releases-*"].find\` → rename to \`releases\`) — the tap was patched directly earlier; this locks it into the generator so it doesn't regress on next publish.

## Test plan

- [ ] CI runs successfully with \`bun-version: canary\` (builds all 4 platform binaries, no codesign errors)
- [ ] Merging triggers a version PR (0.13.1 → 0.13.2)
- [ ] Merging the version PR publishes 8 npm packages at 0.13.2, creates GitHub Release v0.13.2, regenerates the tap formula
- [ ] \`brew upgrade buildinternet/tap/releases && "$(brew --prefix)/bin/releases" --version\` → \`0.13.2\` (no SIGKILL)
- [ ] Follow-up: \`npm deprecate @buildinternet/releases@0.13.0 "Superseded — use 0.13.2+"\`

Tracked in [zachdunn/releases#267](https://github.com/zachdunn/releases/issues/267).