### PR TITLE
fix(release): supply canary bun runtimes via --compile-executable-path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,12 +34,29 @@ jobs:
       - name: Type-check
         run: npx tsc --noEmit
 
+      - name: Fetch canary bun runtimes for cross-compile
+        # When using canary bun for cross-compile, `bun build --compile`
+        # tries to fetch a target-platform runtime matching its own
+        # version (e.g. bun-darwin-aarch64-v1.3.13) which doesn't exist
+        # because canary builds aren't version-tagged. Pre-fetch the
+        # rolling canary assets and pass them via --compile-executable-path.
+        # Remove this step (and the flags below) once bun 1.3.13 stable
+        # ships and we switch bun-version to a real version.
+        run: |
+          mkdir -p .bun-runtimes
+          for target in darwin-aarch64 darwin-x64 linux-aarch64 linux-x64; do
+            curl -fsSL "https://github.com/oven-sh/bun/releases/download/canary/bun-${target}.zip" -o "/tmp/bun-${target}.zip"
+            unzip -q "/tmp/bun-${target}.zip" -d "/tmp/bun-${target}"
+            mv "/tmp/bun-${target}/bun-${target}/bun" ".bun-runtimes/bun-${target}"
+            chmod +x ".bun-runtimes/bun-${target}"
+          done
+
       - name: Build binaries
         run: |
-          bun build --compile src/index.ts --outfile npm/releases-darwin-arm64/releases --target=bun-darwin-arm64
-          bun build --compile src/index.ts --outfile npm/releases-darwin-x64/releases --target=bun-darwin-x64
-          bun build --compile src/index.ts --outfile npm/releases-linux-x64/releases --target=bun-linux-x64
-          bun build --compile src/index.ts --outfile npm/releases-linux-arm64/releases --target=bun-linux-arm64
+          bun build --compile src/index.ts --outfile npm/releases-darwin-arm64/releases --target=bun-darwin-arm64 --compile-executable-path=.bun-runtimes/bun-darwin-aarch64
+          bun build --compile src/index.ts --outfile npm/releases-darwin-x64/releases --target=bun-darwin-x64 --compile-executable-path=.bun-runtimes/bun-darwin-x64
+          bun build --compile src/index.ts --outfile npm/releases-linux-x64/releases --target=bun-linux-x64 --compile-executable-path=.bun-runtimes/bun-linux-x64
+          bun build --compile src/index.ts --outfile npm/releases-linux-arm64/releases --target=bun-linux-arm64 --compile-executable-path=.bun-runtimes/bun-linux-aarch64
 
       - name: Configure npm auth
         env:


### PR DESCRIPTION
## Context

PR #8 shipped the canary pin but the first CI run on main (\`24537289763\`) failed in the build step:

\`\`\`
Target platform 'bun-darwin-aarch64-v1.3.13' is not available for download.
Check if this version of Bun supports this target.
\`\`\`

When \`bun build --compile\` cross-compiles, it fetches a target-platform runtime matching its own reported version. Canary bun reports itself as \`1.3.13-canary.1\`, but canary builds live on a rolling \`canary\` tag rather than a version-tagged release, so the download 404s.

## Fix

Pre-fetch the four canary runtimes from \`https://github.com/oven-sh/bun/releases/download/canary/bun-<target>.zip\` and hand them to each \`bun build --compile\` via \`--compile-executable-path\`. That flag exists specifically for "use this pre-downloaded runtime instead of fetching."

### Verified locally

\`\`\`
$ curl -fsSL "https://github.com/oven-sh/bun/releases/download/canary/bun-darwin-aarch64.zip" -o /tmp/x.zip
$ unzip -q /tmp/x.zip -d /tmp/cp
$ bun build --compile src/index.ts --outfile /tmp/out \
    --target=bun-darwin-arm64 \
    --compile-executable-path=/tmp/cp/bun-darwin-aarch64/bun

$ codesign -dv /tmp/out
Signature=adhoc

$ /tmp/out --version
0.13.1
\`\`\`

## Teardown

Once bun 1.3.13 stable ships, delete the "Fetch canary bun runtimes" step and remove the \`--compile-executable-path\` flags. Switch \`bun-version: canary\` → \`bun-version: 1.3.13\` (or newer).

## Test plan

- [ ] CI build step succeeds with the four \`--compile-executable-path\` flags
- [ ] Merging triggers a version PR (0.13.1 → 0.13.2)
- [ ] Merging the version PR publishes 0.13.2, creates GitHub Release, regenerates tap formula
- [ ] \`brew upgrade buildinternet/tap/releases && "$(brew --prefix)/bin/releases" --version\` → \`0.13.2\` (no SIGKILL)

Tracked in [zachdunn/releases#267](https://github.com/zachdunn/releases/issues/267).