### PR TITLE
chore: gitignore .bun-runtimes/ cross-compile cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist
 *.bun-build
 .*.bun-build
 npm/*/releases
+.bun-runtimes
 
 # logs
 *.log


### PR DESCRIPTION
## Summary

PR #9 added a step to download four canary bun runtimes into \`.bun-runtimes/\` for cross-compile. The changesets action then swept those ~240 MB of binaries into the auto-generated version PR (#10, now closed + branch deleted).

Same failure mode as the \`npm/*/releases\` sweep in PR #4 — fix is identical: add \`.bun-runtimes\` to \`.gitignore\`.

## Test plan

- [ ] Merging regenerates a clean version PR (0.13.1 → 0.13.2) with only version bumps + CHANGELOG updates, no bun binaries
- [ ] No large-file warnings on push