### PR TITLE
test: scaffold test harness and port starter suite

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,9 +34,6 @@ jobs:
       - name: Type-check
         run: npx tsc --noEmit
 
-      - name: Test
-        run: bun test
-
       - name: Fetch canary bun runtimes for cross-compile
         # When using canary bun for cross-compile, `bun build --compile`
         # tries to fetch a target-platform runtime matching its own

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Type-check
         run: npx tsc --noEmit
 
+      - name: Test
+        run: bun test
+
       - name: Fetch canary bun runtimes for cross-compile
         # When using canary bun for cross-compile, `bun build --compile`
         # tries to fetch a target-platform runtime matching its own

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Type-check and test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          # Matches the release workflow pin; see release.yml for context.
+          bun-version: canary
+
+      - run: bun install --frozen-lockfile
+
+      - name: Type-check
+        run: npx tsc --noEmit
+
+      - name: Test
+        run: bun test

--- a/tests/cli/categories.test.ts
+++ b/tests/cli/categories.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "bun:test";
+import { runCli } from "../utils.js";
+
+describe("categories command", () => {
+  it("lists categories", () => {
+    const { stdout, exitCode } = runCli(["categories"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("ai");
+    expect(stdout).toContain("cloud");
+    expect(stdout).toContain("developer-tools");
+  });
+
+  it("supports --json flag", () => {
+    const { stdout, exitCode } = runCli(["categories", "--json"]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed).toContain("ai");
+  });
+});

--- a/tests/unit/api-client.test.ts
+++ b/tests/unit/api-client.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import type { SourceWithOrg } from "../../src/api/types.js";
+
+// Mock mode.ts before importing the client — apiFetch calls getApiUrl/getApiKey.
+mock.module("../../src/lib/mode.js", () => ({
+  getApiUrl: () => "https://test.example.com",
+  getApiKey: () => "test-key",
+  isAdminMode: () => true,
+}));
+
+const client = await import("../../src/api/client.js");
+
+// ---------------------------------------------------------------------------
+// apiFetch 404 behavior — GET vs mutating methods
+// ---------------------------------------------------------------------------
+
+describe("apiFetch 404 handling", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  function mockFetch(status: number, body: unknown = null) {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { "Content-Type": "application/json" },
+      })) as any;
+  }
+
+  it("returns null for GET 404 (findSource)", async () => {
+    mockFetch(404);
+    const result = await client.findSource("nonexistent");
+    expect(result).toBeNull();
+  });
+
+  it("returns null for GET 404 (findOrg)", async () => {
+    mockFetch(404);
+    const result = await client.findOrg("nonexistent");
+    expect(result).toBeNull();
+  });
+
+  it("throws on POST 404 (addIgnoredUrl)", async () => {
+    mockFetch(404, { message: "Not Found" });
+    await expect(
+      client.addIgnoredUrl("https://example.com", "org_123"),
+    ).rejects.toThrow(/API error \(404\) on POST/);
+  });
+
+  it("throws on DELETE 404 (deleteRelease)", async () => {
+    mockFetch(404, { message: "Not Found" });
+    await expect(client.deleteRelease("rel_123")).rejects.toThrow(
+      /API error \(404\) on DELETE/,
+    );
+  });
+
+  it("throws on non-404 errors for GET", async () => {
+    mockFetch(500, { message: "Internal Server Error" });
+    await expect(client.findSource("test")).rejects.toThrow(
+      /API error \(500\)/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listSourcesWithOrg — response shape conforms to shared SourceWithOrg type
+// ---------------------------------------------------------------------------
+
+describe("listSourcesWithOrg", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const apiRow: SourceWithOrg = {
+    id: "src_abc123",
+    name: "Next.js",
+    slug: "nextjs",
+    type: "github",
+    url: "https://github.com/vercel/next.js",
+    orgName: "Vercel",
+    orgSlug: "vercel",
+    productName: null,
+    productSlug: null,
+    isPrimary: true,
+    isHidden: false,
+    metadata: '{"feedUrl":"https://nextjs.org/feed.xml"}',
+    releaseCount: 42,
+    latestVersion: "15.3.0",
+    latestDate: "2026-04-10T00:00:00Z",
+    lastFetchedAt: "2026-04-15T12:00:00Z",
+    fetchPriority: "normal",
+    changeDetectedAt: null,
+    consecutiveNoChange: 3,
+    consecutiveErrors: 0,
+    nextFetchAfter: null,
+  };
+
+  it("returns response preserving all SourceWithOrg fields", async () => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify([apiRow]), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })) as any;
+
+    const rows = await client.listSourcesWithOrg();
+    expect(rows).toHaveLength(1);
+
+    const row = rows[0];
+    expect(row.id).toBe("src_abc123");
+    expect(row.orgSlug).toBe("vercel");
+    expect(row.orgName).toBe("Vercel");
+    expect(row.latestVersion).toBe("15.3.0");
+    expect(row.productName).toBeNull();
+    expect(row.productSlug).toBeNull();
+    expect(row.isPrimary).toBe(true);
+    expect(row.isHidden).toBe(false);
+    expect(row.consecutiveNoChange).toBe(3);
+    expect(row.consecutiveErrors).toBe(0);
+  });
+
+  it("passes filter params as query string", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = (async (url: string) => {
+      capturedUrl = url;
+      return new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as any;
+
+    await client.listSourcesWithOrg({ orgSlug: "vercel", hasFeed: true, category: "ai" });
+    expect(capturedUrl).toContain("orgSlug=vercel");
+    expect(capturedUrl).toContain("has_feed=true");
+    expect(capturedUrl).toContain("category=ai");
+  });
+});

--- a/tests/unit/changelog-slice.test.ts
+++ b/tests/unit/changelog-slice.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from "bun:test";
+import {
+  sliceChangelog,
+  hasRangeParams,
+  parseRangeParam,
+  DEFAULT_CHANGELOG_SLICE_LIMIT,
+  buildChangelogResponse,
+} from "@buildinternet/releases-core/changelog-slice";
+
+const sample = [
+  "# CHANGELOG",
+  "",
+  "Some preamble describing the project.",
+  "",
+  "## v1.0.0",
+  "",
+  "- first release",
+  "- another bullet",
+  "",
+  "## v0.9.0",
+  "",
+  "- beta",
+  "- notes that go on for a while to make the section bigger",
+  "",
+  "### Sub-section",
+  "",
+  "- nested item",
+  "",
+  "## v0.8.0",
+  "",
+  "- older stuff",
+  "",
+].join("\n");
+
+describe("sliceChangelog", () => {
+  it("returns the full file when offset=0 and limit exceeds totalChars", () => {
+    const result = sliceChangelog(sample, { offset: 0, limit: 10_000 });
+    expect(result.content).toBe(sample);
+    expect(result.offset).toBe(0);
+    expect(result.nextOffset).toBeNull();
+    expect(result.totalChars).toBe(sample.length);
+  });
+
+  it("snaps the end to the next heading boundary", () => {
+    const result = sliceChangelog(sample, { offset: 0, limit: 50 });
+    expect(result.content.endsWith("\n")).toBe(true);
+    expect(sample.slice(result.nextOffset ?? 0).startsWith("## ")).toBe(true);
+  });
+
+  it("preserves offset=0 so preamble is returned", () => {
+    const result = sliceChangelog(sample, { offset: 0, limit: 80 });
+    expect(result.content.startsWith("# CHANGELOG")).toBe(true);
+  });
+
+  it("snaps a non-zero offset forward to the next heading", () => {
+    const result = sliceChangelog(sample, { offset: 3, limit: 50 });
+    expect(result.content.startsWith("## ")).toBe(true);
+    expect(result.offset).toBeGreaterThan(3);
+  });
+
+  it("round-trips: concatenating successive slices reconstructs the file", () => {
+    const slices: string[] = [];
+    let offset = 0;
+    let iterations = 0;
+    while (offset < sample.length && iterations < 20) {
+      const r = sliceChangelog(sample, { offset, limit: 30 });
+      slices.push(r.content);
+      if (r.nextOffset == null) break;
+      offset = r.nextOffset;
+      iterations++;
+    }
+    expect(slices.join("")).toBe(sample);
+  });
+
+  it("returns an empty-ish tail when offset >= totalChars", () => {
+    const r = sliceChangelog(sample, { offset: sample.length + 10, limit: 50 });
+    expect(r.content).toBe("");
+    expect(r.nextOffset).toBeNull();
+  });
+
+  it("defaults offset to 0 and applies default limit", () => {
+    const r = sliceChangelog(sample, {});
+    expect(r.offset).toBe(0);
+    expect(r.limit).toBe(DEFAULT_CHANGELOG_SLICE_LIMIT);
+  });
+
+  it("makes forward progress even when there are no headings", () => {
+    const flat = "plain text with no markdown headings at all ".repeat(200);
+    const r = sliceChangelog(flat, { offset: 0, limit: 100 });
+    expect(r.content.length).toBeGreaterThan(0);
+    expect(r.nextOffset).not.toBeNull();
+    expect(r.nextOffset).toBeGreaterThan(0);
+  });
+});
+
+describe("hasRangeParams", () => {
+  it("is false when neither offset nor limit is present", () => {
+    expect(hasRangeParams({ offset: null, limit: null })).toBe(false);
+    expect(hasRangeParams({})).toBe(false);
+  });
+  it("is true when either is present", () => {
+    expect(hasRangeParams({ offset: "0", limit: null })).toBe(true);
+    expect(hasRangeParams({ offset: null, limit: "100" })).toBe(true);
+  });
+});
+
+describe("parseRangeParam", () => {
+  it("returns undefined for null/empty/non-numeric", () => {
+    expect(parseRangeParam(null)).toBeUndefined();
+    expect(parseRangeParam("")).toBeUndefined();
+    expect(parseRangeParam("abc")).toBeUndefined();
+  });
+  it("parses valid numbers", () => {
+    expect(parseRangeParam("42")).toBe(42);
+    expect(parseRangeParam("0")).toBe(0);
+  });
+});
+
+describe("buildChangelogResponse truncation + files", () => {
+  const row = {
+    path: "CHANGELOG.md",
+    filename: "CHANGELOG.md",
+    url: "https://github.com/acme/repo/blob/HEAD/CHANGELOG.md",
+    rawUrl: "https://raw/CHANGELOG.md",
+    content: "# CHANGELOG\n\nhello",
+    bytes: 18,
+    fetchedAt: "2026-04-14T00:00:00.000Z",
+  };
+
+  it("flags truncated=false by default and includes files index", () => {
+    const res = buildChangelogResponse(row, { offset: null, limit: null }, [
+      { path: "CHANGELOG.md", filename: "CHANGELOG.md", url: row.url, bytes: 18, fetchedAt: row.fetchedAt },
+      { path: "packages/a/CHANGELOG.md", filename: "CHANGELOG.md", url: row.url, bytes: 9, fetchedAt: row.fetchedAt },
+    ]);
+    expect(res.truncated).toBe(false);
+    expect(res.truncatedAt).toBeNull();
+    expect(res.files).toHaveLength(2);
+  });
+
+  it("flags truncated=true when bytes >= 1MB and carries truncatedAt", () => {
+    const res = buildChangelogResponse(
+      { ...row, bytes: 1024 * 1024 },
+      { offset: null, limit: null },
+      [],
+    );
+    expect(res.truncated).toBe(true);
+    expect(res.truncatedAt).toBe(1024 * 1024);
+  });
+});

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,0 +1,30 @@
+import { spawnSync } from "child_process";
+import { join } from "path";
+import { stripAnsi } from "../src/lib/sanitize.js";
+
+const CLI_PATH = join(import.meta.dirname, "..", "src", "index.ts");
+
+export function runCli(
+  args: string[],
+  options?: { env?: Record<string, string>; timeout?: number },
+): { stdout: string; stderr: string; exitCode: number } {
+  // OSS CLI is remote-only — a real-looking URL must be set so the CLI starts.
+  // Commands that don't hit the API (e.g. `categories`) succeed without it.
+  const safeEnv: Record<string, string> = {
+    ...process.env as Record<string, string>,
+    RELEASED_API_URL: "https://test.example.com",
+    RELEASED_API_KEY: "test",
+    ...options?.env,
+  };
+  const result = spawnSync("bun", [CLI_PATH, ...args], {
+    encoding: "utf-8",
+    stdio: ["pipe", "pipe", "pipe"],
+    env: safeEnv,
+    timeout: options?.timeout ?? 30_000,
+  });
+  return {
+    stdout: stripAnsi(result.stdout ?? ""),
+    stderr: stripAnsi(result.stderr ?? ""),
+    exitCode: result.status ?? 1,
+  };
+}


### PR DESCRIPTION
Closes a slice of #14 — this bootstraps the test tree and re-enables \`bun test\` in CI. The remaining monorepo test files are still to port; the full checklist stays in #14.

## What ships

### Harness

- \`tests/utils.ts\` — \`runCli()\` helper that spawns the CLI via \`bun src/index.ts\` with a dummy \`RELEASED_API_URL\` / \`RELEASED_API_KEY\` so remote-mode startup passes. Commands that don't hit the API (e.g. \`categories\`) succeed without real infra.

### Ported tests

- **\`tests/unit/api-client.test.ts\`** (5 tests)
  - \`apiFetch\` 404 handling: GET returns null (\`findSource\`, \`findOrg\`), POST throws (\`addIgnoredUrl\`), DELETE throws (\`deleteRelease\`), non-404 errors bubble as thrown \`API error (status)\`.
  - \`listSourcesWithOrg\`: response shape preserves all \`SourceWithOrg\` fields; filter params (\`orgSlug\`, \`hasFeed\`, \`category\`) are sent as query string.
  - Substitutes OSS-available methods for the monorepo-only \`knowledgePage\` helpers in the original.
- **\`tests/unit/changelog-slice.test.ts\`** (16 tests) — pure-function coverage of \`sliceChangelog\`, \`hasRangeParams\`, \`parseRangeParam\`, and \`buildChangelogResponse\` from \`@buildinternet/releases-core\`. Dropped the monorepo's \`js-tiktoken\` token-bracket tests because this package doesn't ship the token encoder locally.
- **\`tests/cli/categories.test.ts\`** (2 tests) — end-to-end smoke of \`releases categories\` (text + \`--json\`).

### CI

\`.github/workflows/release.yml\` now runs \`bun test\` after the type-check step. The step was removed during the OSS bootstrap when no tests existed.

## Verified

\`bun test\` locally: **23 pass, 0 fail, 57 expect() calls, 431ms.**

## Still to port (tracked in #14)

From the monorepo's \`tests/cli/\`: \`search-edge-cases\`, \`search-unified\`, \`help\`, \`errors\`, \`source-lifecycle\`, \`product-lifecycle\`, \`org-lifecycle\`, \`tags\`, \`ignore-block\`.

From \`tests/unit/\`: \`formatters-markdown\`, \`formatters\`, \`sanitize\`, \`dates\`, \`categories\`, \`slug\`, \`id\`, \`tokens\`.

From \`tests/mcp/\`: \`tools.test.ts\` (validates local stdio bridge's proxied tool schemas).