### PR TITLE
test: port more tests from monorepo

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,7 +15,8 @@
     "./dates": "./src/dates.ts",
     "./changelog-slice": "./src/changelog-slice.ts",
     "./id": "./src/id.ts",
-    "./slug": "./src/slug.ts"
+    "./slug": "./src/slug.ts",
+    "./tokens": "./src/tokens.ts"
   },
   "files": [
     "src",

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -404,6 +404,9 @@ export interface OverviewPageItem {
   updatedAt: string;
 }
 
+/** @deprecated Use OverviewPageItem */
+export type KnowledgePageItem = OverviewPageItem;
+
 // ── Activity ──
 
 export interface WeeklyBucket {

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -8,11 +8,22 @@
 import type {
   ReleaseDetail,
   SourceDetail,
+  SourceListItem,
   OrgDetail,
   OrgReleaseItem,
+  ReleaseItem,
+  ReleaseSummaryItem,
   UnifiedSearchResponse,
   OverviewPageItem,
 } from "../api/types.js";
+
+// Re-exports under legacy/monorepo-compatible names so ported test suites and
+// external callers can import either name.
+export type FormatRelease = ReleaseItem;
+export type FormatReleaseSummary = ReleaseSummaryItem;
+export type FormatSourceDetail = SourceDetail;
+export type FormatSourceListItem = SourceListItem;
+export type FormatOrgDetail = OrgDetail;
 
 export interface FormatOptions {
   /** Base URL for canonical links (e.g. "https://releases.sh") */
@@ -426,3 +437,6 @@ export function overviewToMarkdown(
 
   return lines.join("\n");
 }
+
+/** Legacy alias — `OverviewPageItem` was previously called `KnowledgePageItem`. */
+export const knowledgeToMarkdown = overviewToMarkdown;

--- a/tests/cli/errors.test.ts
+++ b/tests/cli/errors.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "bun:test";
+import { runCli } from "../utils.js";
+
+describe("CLI error handling", () => {
+  it("exits with error for unknown command", () => {
+    const { exitCode } = runCli(["nonexistent-command"]);
+    expect(exitCode).not.toBe(0);
+  });
+
+  it("shows error for fetch without required args in remote mode", () => {
+    // Remote mode requires a filter - bare fetch is blocked
+    const { exitCode } = runCli(["admin", "source", "fetch"], {
+      env: { RELEASED_API_URL: "https://example.com", RELEASED_API_KEY: "test" },
+    });
+    expect(exitCode).not.toBe(0);
+  });
+});

--- a/tests/cli/help.test.ts
+++ b/tests/cli/help.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "bun:test";
+import { runCli } from "../utils.js";
+
+describe("CLI help", () => {
+  it("shows help with --help", () => {
+    const { stdout, exitCode } = runCli(["--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Commands:");
+    expect(stdout).toContain("releases");
+  });
+
+  it("shows help with -h", () => {
+    const { stdout, exitCode } = runCli(["-h"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Commands:");
+  });
+
+  it("shows list subcommand help", () => {
+    const { stdout, exitCode } = runCli(["list", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("list");
+  });
+
+  it("shows search subcommand help", () => {
+    const { stdout, exitCode } = runCli(["search", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("search");
+  });
+});
+
+describe("CLI command gating (public mode)", () => {
+  // Clear both URL and KEY so the CLI falls back to the default public URL.
+  const publicEnv = { RELEASED_API_URL: "", RELEASED_API_KEY: "" };
+
+  it("shows public commands in help", () => {
+    const { stdout } = runCli(["--help"], { env: publicEnv });
+    expect(stdout).toContain("search");
+    expect(stdout).toContain("latest");
+    expect(stdout).toContain("list");
+    expect(stdout).toContain("stats");
+    expect(stdout).toContain("categories");
+    expect(stdout).toContain("admin");
+    // `summary` and `compare` are local-only AI tools — not shipped in OSS.
+  });
+
+  it("keeps admin workflows behind the admin entrypoint in public help", () => {
+    const { stdout } = runCli(["--help"], { env: publicEnv });
+    expect(stdout).not.toContain("Admin:");
+    expect(stdout).not.toContain("onboard");
+    expect(stdout).not.toContain("Manage organizations");
+  });
+
+  it("blocks admin commands with a clear error", () => {
+    for (const args of [
+      ["admin", "source", "fetch"],
+      ["admin", "discovery", "onboard", "Acme"],
+      ["admin", "org", "list"],
+      ["admin", "source", "poll"],
+    ]) {
+      const { stderr, exitCode } = runCli(args, { env: publicEnv });
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain(`"admin" requires an API key`);
+      expect(stderr).toContain("RELEASED_API_KEY");
+    }
+  });
+
+  it("allows browsing admin help without an API key", () => {
+    const { stdout, exitCode } = runCli(["admin", "--help"], { env: publicEnv });
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("source");
+    expect(stdout).toContain("discovery");
+  });
+
+  it("shows unknown command error for truly unknown commands", () => {
+    const { stderr, exitCode } = runCli(["help", "nonexistent"], { env: publicEnv });
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Unknown command");
+  });
+});
+
+describe("CLI command gating (admin mode)", () => {
+  const adminEnv = { RELEASED_API_KEY: "test-key" };
+
+  it("shows the admin entrypoint in root help", () => {
+    const { stdout } = runCli(["--help"], { env: adminEnv });
+    expect(stdout).toContain("admin");
+    expect(stdout).not.toContain("Admin:");
+  });
+
+  it("shows admin namespace help", () => {
+    const { stdout, exitCode } = runCli(["admin", "--help"], { env: adminEnv });
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("source");
+    expect(stdout).toContain("org");
+    expect(stdout).toContain("product");
+  });
+
+  it("allows admin source help", () => {
+    const { stdout, exitCode } = runCli(["admin", "source", "fetch", "--help"], { env: adminEnv });
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("fetch");
+  });
+
+  it("allows org subcommand help", () => {
+    const { stdout, exitCode } = runCli(["admin", "org", "--help"], { env: adminEnv });
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("org");
+  });
+
+  it("allows product subcommand help", () => {
+    const { stdout, exitCode } = runCli(["admin", "product", "--help"], { env: adminEnv });
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("product");
+  });
+});

--- a/tests/unit/categories.test.ts
+++ b/tests/unit/categories.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "bun:test";
+import { CATEGORIES, isValidCategory } from "@buildinternet/releases-core/categories";
+
+describe("CATEGORIES", () => {
+  it("is a non-empty array", () => {
+    expect(CATEGORIES.length).toBeGreaterThan(0);
+  });
+
+  it("contains known categories", () => {
+    expect(CATEGORIES).toContain("ai");
+    expect(CATEGORIES).toContain("developer-tools");
+    expect(CATEGORIES).toContain("cloud");
+  });
+
+  it("all entries are lowercase kebab-case", () => {
+    for (const cat of CATEGORIES) {
+      expect(cat).toMatch(/^[a-z][a-z0-9-]*$/);
+    }
+  });
+});
+
+describe("isValidCategory", () => {
+  it("returns true for valid categories", () => {
+    expect(isValidCategory("ai")).toBe(true);
+    expect(isValidCategory("cloud")).toBe(true);
+    expect(isValidCategory("developer-tools")).toBe(true);
+  });
+
+  it("returns false for invalid categories", () => {
+    expect(isValidCategory("not-a-category")).toBe(false);
+    expect(isValidCategory("")).toBe(false);
+    expect(isValidCategory("AI")).toBe(false); // case-sensitive
+  });
+});

--- a/tests/unit/dates.test.ts
+++ b/tests/unit/dates.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "bun:test";
+import { daysAgoIso, timeAgo } from "@buildinternet/releases-core/dates";
+
+describe("daysAgoIso", () => {
+  it("returns an ISO string", () => {
+    const result = daysAgoIso(7);
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("returns a date approximately N days ago", () => {
+    const result = new Date(daysAgoIso(1));
+    const now = Date.now();
+    const diff = now - result.getTime();
+    // Should be within ~1 second of exactly 1 day
+    expect(Math.abs(diff - 86_400_000)).toBeLessThan(1_000);
+  });
+
+  it("returns roughly now for 0 days", () => {
+    const result = new Date(daysAgoIso(0));
+    expect(Date.now() - result.getTime()).toBeLessThan(1_000);
+  });
+});
+
+describe("timeAgo", () => {
+  it("returns null for null input", () => {
+    expect(timeAgo(null)).toBeNull();
+  });
+
+  it("returns 'just now' for recent timestamps", () => {
+    expect(timeAgo(new Date().toISOString())).toBe("just now");
+  });
+
+  it("returns minutes for < 1 hour", () => {
+    const thirtyMinAgo = new Date(Date.now() - 30 * 60_000).toISOString();
+    expect(timeAgo(thirtyMinAgo)).toBe("30m ago");
+  });
+
+  it("returns hours for < 24 hours", () => {
+    const fiveHoursAgo = new Date(Date.now() - 5 * 3_600_000).toISOString();
+    expect(timeAgo(fiveHoursAgo)).toBe("5h ago");
+  });
+
+  it("returns days for < 30 days", () => {
+    const tenDaysAgo = new Date(Date.now() - 10 * 86_400_000).toISOString();
+    expect(timeAgo(tenDaysAgo)).toBe("10d ago");
+  });
+
+  it("returns months for >= 30 days", () => {
+    const ninetyDaysAgo = new Date(Date.now() - 90 * 86_400_000).toISOString();
+    expect(timeAgo(ninetyDaysAgo)).toBe("3mo ago");
+  });
+});

--- a/tests/unit/formatters-markdown.test.ts
+++ b/tests/unit/formatters-markdown.test.ts
@@ -1,0 +1,294 @@
+import { describe, it, expect } from "bun:test";
+import {
+  releaseToMarkdown,
+  orgReleaseFeedToMarkdown,
+  searchToMarkdown,
+} from "../../src/lib/formatters.js";
+import type { ReleaseDetail, OrgReleaseItem, UnifiedSearchResponse } from "../../src/api/types.js";
+
+// ── Fixtures ───────────────────────────────────────────────────────
+
+const fullRelease: ReleaseDetail = {
+  id: "rel_001",
+  sourceId: "src_001",
+  version: "15.0.0",
+  title: "Next.js 15",
+  content: "Full content here with **markdown**.",
+  contentSummary: "Major release with React 19 support",
+  url: "https://github.com/vercel/next.js/releases/tag/v15.0.0",
+  media: [],
+  publishedAt: "2024-06-15T00:00:00Z",
+  fetchedAt: "2024-06-16T12:00:00Z",
+  sourceName: "Next.js",
+  sourceSlug: "next-js",
+  sourceType: "github",
+  org: { slug: "vercel", name: "Vercel" },
+};
+
+const feedReleases: OrgReleaseItem[] = [
+  {
+    id: "rel_001",
+    version: "15.0.0",
+    title: "Next.js 15",
+    summary: "Major release",
+    content: "Full content for v15.",
+    publishedAt: "2024-06-15T00:00:00Z",
+    url: "https://example.com/v15",
+    source: { slug: "next-js", name: "Next.js", type: "github" },
+  },
+  {
+    id: "rel_002",
+    version: "2.0.0",
+    title: "Turborepo 2.0",
+    summary: "Turbo summary",
+    content: "",
+    publishedAt: "2024-06-10T00:00:00Z",
+    url: null,
+    source: { slug: "turbo", name: "Turborepo", type: "github" },
+  },
+];
+
+const searchResults: UnifiedSearchResponse = {
+  query: "react",
+  orgs: [
+    { slug: "meta", name: "Meta", domain: "meta.com", avatarUrl: null, category: "ai" },
+  ],
+  products: [
+    { slug: "react", name: "React", orgSlug: "meta", orgName: "Meta", category: "frontend" },
+    { slug: "react-native", name: "React Native", orgSlug: "meta", orgName: "Meta", category: null, kind: "source", sourceSlug: "react-native" },
+  ],
+  sources: [],
+  releases: [
+    {
+      id: "rel_react19",
+      sourceSlug: "react-releases",
+      sourceName: "React Releases",
+      orgSlug: "meta",
+      version: "19.0.0",
+      title: "React 19",
+      summary: "Major update with new features",
+      publishedAt: "2024-06-01T00:00:00Z",
+    },
+  ],
+};
+
+// ── releaseToMarkdown ─────────────────────────────────────────────
+
+describe("releaseToMarkdown", () => {
+  it("contains YAML frontmatter with correct fields", () => {
+    const md = releaseToMarkdown(fullRelease);
+    expect(md).toContain("---");
+    expect(md).toContain("title: Next.js 15");
+    expect(md).toContain("version: 15.0.0");
+    expect(md).toContain("source: Next.js");
+    expect(md).toContain("source_slug: next-js");
+    expect(md).toContain("source_type: github");
+    expect(md).toContain("published: 2024-06-15");
+  });
+
+  it("includes organization fields when org is present", () => {
+    const md = releaseToMarkdown(fullRelease);
+    expect(md).toContain("organization: Vercel");
+    expect(md).toContain("organization_slug: vercel");
+  });
+
+  it("omits organization fields when org is null", () => {
+    const md = releaseToMarkdown({ ...fullRelease, org: null });
+    expect(md).not.toContain("organization:");
+    expect(md).not.toContain("organization_slug:");
+  });
+
+  it("includes title as heading", () => {
+    const md = releaseToMarkdown(fullRelease);
+    expect(md).toContain("# Next.js 15");
+  });
+
+  it("includes full content body", () => {
+    const md = releaseToMarkdown(fullRelease);
+    expect(md).toContain("Full content here with **markdown**.");
+  });
+
+  it("includes url in frontmatter", () => {
+    const md = releaseToMarkdown(fullRelease);
+    expect(md).toContain("url: https://github.com/vercel/next.js/releases/tag/v15.0.0");
+  });
+
+  it("omits version when null", () => {
+    const md = releaseToMarkdown({ ...fullRelease, version: null });
+    expect(md).not.toContain("version:");
+  });
+
+  it("omits url when null", () => {
+    const md = releaseToMarkdown({ ...fullRelease, url: null });
+    expect(md).not.toContain("url:");
+  });
+
+  it("includes canonical_source when baseUrl is provided", () => {
+    const md = releaseToMarkdown(fullRelease, { baseUrl: "https://releases.sh" });
+    expect(md).toContain("canonical_source: https://releases.sh/vercel/next-js");
+  });
+
+  it("uses /source/ path when org is null", () => {
+    const md = releaseToMarkdown({ ...fullRelease, org: null }, { baseUrl: "https://releases.sh" });
+    expect(md).toContain("canonical_source: https://releases.sh/source/next-js");
+  });
+
+  it("handles empty content gracefully", () => {
+    const md = releaseToMarkdown({ ...fullRelease, content: "" });
+    expect(md).toContain("# Next.js 15");
+    expect(md).toContain("---");
+  });
+});
+
+// ── orgReleaseFeedToMarkdown ──────────────────────────────────────
+
+describe("orgReleaseFeedToMarkdown", () => {
+  it("contains YAML frontmatter with org slug and count", () => {
+    const md = orgReleaseFeedToMarkdown("vercel", feedReleases, { nextCursor: null, limit: 20 });
+    expect(md).toContain("organization: vercel");
+    expect(md).toContain("release_count: 2");
+  });
+
+  it("contains Release tags with source attribution", () => {
+    const md = orgReleaseFeedToMarkdown("vercel", feedReleases, { nextCursor: null, limit: 20 });
+    expect(md).toContain('source="next-js"');
+    expect(md).toContain('source="turbo"');
+    expect(md).toContain('version="15.0.0"');
+    expect(md).toContain('version="2.0.0"');
+  });
+
+  it("prefers content over summary", () => {
+    const md = orgReleaseFeedToMarkdown("vercel", feedReleases, { nextCursor: null, limit: 20 });
+    expect(md).toContain("Full content for v15.");
+  });
+
+  it("falls back to summary when content is empty", () => {
+    const md = orgReleaseFeedToMarkdown("vercel", feedReleases, { nextCursor: null, limit: 20 });
+    expect(md).toContain("Turbo summary");
+  });
+
+  it("shows title heading when title differs from version", () => {
+    const md = orgReleaseFeedToMarkdown("vercel", feedReleases, { nextCursor: null, limit: 20 });
+    expect(md).toContain("## Next.js 15");
+    expect(md).toContain("## Turborepo 2.0");
+  });
+
+  it("does NOT show Pagination when nextCursor is null", () => {
+    const md = orgReleaseFeedToMarkdown("vercel", feedReleases, { nextCursor: null, limit: 20 });
+    expect(md).not.toContain("<Pagination");
+  });
+
+  it("shows Pagination with cursor when nextCursor is present", () => {
+    const cursor = "2024-06-10T00:00:00Z|rel_002";
+    const md = orgReleaseFeedToMarkdown("vercel", feedReleases, { nextCursor: cursor, limit: 20 });
+    expect(md).toContain("<Pagination");
+    expect(md).toContain(`cursor="${cursor}"`);
+  });
+
+  it("includes has_more in frontmatter when cursor is present", () => {
+    const md = orgReleaseFeedToMarkdown("vercel", feedReleases, { nextCursor: "cursor", limit: 20 });
+    expect(md).toContain("has_more: true");
+  });
+
+  it("includes next URL in Pagination when baseUrl is provided", () => {
+    const cursor = "2024-06-10|rel_002";
+    const md = orgReleaseFeedToMarkdown("vercel", feedReleases, { nextCursor: cursor, limit: 20 }, { baseUrl: "https://releases.sh" });
+    expect(md).toContain("next=\"https://releases.sh/vercel/releases?cursor=");
+  });
+
+  it("handles empty releases array", () => {
+    const md = orgReleaseFeedToMarkdown("vercel", [], { nextCursor: null, limit: 20 });
+    expect(md).toContain("organization: vercel");
+    expect(md).toContain("release_count: 0");
+    expect(md).not.toContain("<Release");
+  });
+});
+
+// ── searchToMarkdown ──────────────────────────────────────────────
+
+describe("searchToMarkdown", () => {
+  it("contains query in frontmatter", () => {
+    const md = searchToMarkdown(searchResults);
+    expect(md).toContain("query: react");
+  });
+
+  it("has Organizations section with org details", () => {
+    const md = searchToMarkdown(searchResults);
+    expect(md).toContain("## Organizations");
+    expect(md).toContain("**Meta**");
+    expect(md).toContain("`meta`");
+    expect(md).toContain("[ai]");
+  });
+
+  it("has Products section with product and standalone source details", () => {
+    const md = searchToMarkdown(searchResults);
+    expect(md).toContain("## Products");
+    expect(md).toContain("**React**");
+    expect(md).toContain("`react`");
+    expect(md).toContain("(Meta)");
+    expect(md).toContain("**React Native**");
+    expect(md).not.toContain("## Sources");
+  });
+
+  it("has Releases section with release details", () => {
+    const md = searchToMarkdown(searchResults);
+    expect(md).toContain("## Releases");
+    expect(md).toContain("**React Releases 19.0.0**");
+    expect(md).toContain("React 19");
+    expect(md).toContain("2024-06-01");
+  });
+
+  it("includes release summary as blockquote", () => {
+    const md = searchToMarkdown(searchResults);
+    expect(md).toContain("> Major update with new features");
+  });
+
+  it("includes view links when baseUrl is provided", () => {
+    const md = searchToMarkdown(searchResults, { baseUrl: "https://releases.sh" });
+    expect(md).toContain("[view](https://releases.sh/meta)");
+    expect(md).toContain("[view](https://releases.sh/meta/product/react)");
+    expect(md).toContain("[view](https://releases.sh/meta/react-native)");
+  });
+
+  it("shows 'No results found' when all arrays are empty", () => {
+    const empty: UnifiedSearchResponse = {
+      query: "nothing",
+      orgs: [],
+      products: [],
+      sources: [],
+      releases: [],
+    };
+    const md = searchToMarkdown(empty);
+    expect(md).toContain("No results found.");
+    expect(md).not.toContain("## Organizations");
+    expect(md).not.toContain("## Products");
+    expect(md).not.toContain("## Sources");
+    expect(md).not.toContain("## Releases");
+  });
+
+  it("omits sections that have no results", () => {
+    const partial: UnifiedSearchResponse = {
+      query: "test",
+      orgs: [],
+      products: [],
+      sources: [],
+      releases: [
+        {
+          id: "rel_foo1",
+          sourceSlug: "foo",
+          sourceName: "Foo",
+          orgSlug: null,
+          version: "1.0.0",
+          title: "Foo 1.0",
+          summary: "First release",
+          publishedAt: "2024-01-01T00:00:00Z",
+        },
+      ],
+    };
+    const md = searchToMarkdown(partial);
+    expect(md).not.toContain("## Organizations");
+    expect(md).not.toContain("## Products");
+    expect(md).not.toContain("## Sources");
+    expect(md).toContain("## Releases");
+  });
+});

--- a/tests/unit/formatters.test.ts
+++ b/tests/unit/formatters.test.ts
@@ -1,0 +1,497 @@
+import { describe, it, expect } from "bun:test";
+import {
+  sourceToMarkdown,
+  orgToMarkdown,
+  knowledgeToMarkdown,
+  type FormatSourceDetail,
+  type FormatOrgDetail,
+} from "../../src/lib/formatters.js";
+import type { KnowledgePageItem } from "../../src/api/types.js";
+
+// ── Fixtures ───────────────────────────────────────────────────────
+
+const fullSource: FormatSourceDetail = {
+  slug: "next-js",
+  name: "Next.js",
+  type: "github",
+  url: "https://github.com/vercel/next.js",
+  changelogUrl: "https://nextjs.org/changelog",
+  org: { slug: "vercel", name: "Vercel" },
+  releaseCount: 150,
+  latestVersion: "15.0.0",
+  latestDate: "2024-06-15T00:00:00Z",
+  lastFetchedAt: "2024-06-16T12:00:00Z",
+  trackingSince: "2024-01-01T00:00:00Z",
+  releases: [
+    {
+      version: "15.0.0",
+      title: "Next.js 15",
+      summary: "Major release with React 19 support",
+      content: "Full content here with **markdown**.",
+      publishedAt: "2024-06-15T00:00:00Z",
+      url: "https://github.com/vercel/next.js/releases/tag/v15.0.0",
+    },
+    {
+      version: "14.2.0",
+      title: "14.2.0",
+      summary: "Bug fixes",
+      publishedAt: "2024-05-01T00:00:00Z",
+      url: null,
+    },
+  ],
+  pagination: { page: 1, pageSize: 20, totalPages: 1, totalItems: 2 },
+  summaries: {
+    rolling: {
+      windowDays: 90,
+      summary: "Focus on React 19 integration",
+      releaseCount: 10,
+      generatedAt: "2024-06-16T00:00:00Z",
+    },
+    monthly: [
+      {
+        year: 2024,
+        month: 6,
+        summary: "Major version bump",
+        releaseCount: 3,
+        generatedAt: "2024-06-16T00:00:00Z",
+      },
+    ],
+  },
+};
+
+const fullOrg: FormatOrgDetail = {
+  slug: "vercel",
+  name: "Vercel",
+  domain: "vercel.com",
+  avatarUrl: null,
+  description: "Frontend cloud platform",
+  category: "cloud",
+  tags: ["typescript", "edge"],
+  aliases: ["vercel.app", "nextjs.org"],
+  sourceCount: 5,
+  releaseCount: 300,
+  releasesLast30Days: 12,
+  avgReleasesPerWeek: 3.5,
+  lastFetchedAt: "2024-06-16T00:00:00Z",
+  trackingSince: "2024-01-01T00:00:00Z",
+  accounts: [
+    { platform: "github", handle: "vercel" },
+    { platform: "twitter", handle: "vercel" },
+  ],
+  products: [
+    {
+      id: "prod_1",
+      slug: "nextjs",
+      name: "Next.js",
+      url: "https://nextjs.org",
+      description: "React framework",
+      sourceCount: 2,
+    },
+  ],
+  sources: [
+    {
+      slug: "next-js",
+      name: "Next.js",
+      type: "github",
+      releaseCount: 150,
+      latestVersion: "15.0.0",
+      latestDate: "2024-06-15",
+      isPrimary: true,
+    },
+    {
+      slug: "turbo",
+      name: "Turborepo",
+      type: "github",
+      releaseCount: 50,
+      latestVersion: "2.0.0",
+      latestDate: "2024-06-01",
+    },
+  ],
+};
+
+// ── sourceToMarkdown ───────────────────────────────────────────────
+
+describe("sourceToMarkdown", () => {
+  it("contains YAML frontmatter with correct fields", () => {
+    const md = sourceToMarkdown(fullSource);
+    expect(md).toContain("---");
+    expect(md).toContain("name: Next.js");
+    expect(md).toContain("slug: next-js");
+    expect(md).toContain("type: github");
+    expect(md).toContain("source_url: https://github.com/vercel/next.js");
+    expect(md).toContain("total_releases: 150");
+    expect(md).toContain("tracking_since: 2024-01-01");
+  });
+
+  it("contains organization fields when org is present", () => {
+    const md = sourceToMarkdown(fullSource);
+    expect(md).toContain("organization: Vercel");
+    expect(md).toContain("organization_slug: vercel");
+  });
+
+  it("contains changelog_url when set", () => {
+    const md = sourceToMarkdown(fullSource);
+    expect(md).toContain("changelog_url: https://nextjs.org/changelog");
+  });
+
+  it("contains latest_version and latest_date when set", () => {
+    const md = sourceToMarkdown(fullSource);
+    expect(md).toContain("latest_version: 15.0.0");
+    expect(md).toContain("latest_date: 2024-06-15");
+  });
+
+  it("contains last_updated when lastFetchedAt is set", () => {
+    const md = sourceToMarkdown(fullSource);
+    expect(md).toContain("last_updated: 2024-06-16");
+  });
+
+  it("contains rolling Summary tag with correct attributes", () => {
+    const md = sourceToMarkdown(fullSource);
+    expect(md).toContain('<Summary type="rolling" window-days="90" release-count="10">');
+    expect(md).toContain("Focus on React 19 integration");
+    expect(md).toContain("</Summary>");
+  });
+
+  it("contains monthly Summary tags with period name", () => {
+    const md = sourceToMarkdown(fullSource);
+    expect(md).toContain('<Summary type="monthly" period="June 2024"');
+    expect(md).toContain('release-count="3"');
+    expect(md).toContain("Major version bump");
+  });
+
+  it("contains Release tags with version, date, url attributes", () => {
+    const md = sourceToMarkdown(fullSource);
+    expect(md).toContain('version="15.0.0"');
+    expect(md).toContain('date="June 15, 2024"');
+    expect(md).toContain('published="2024-06-15T00:00:00Z"');
+    expect(md).toContain('url="https://github.com/vercel/next.js/releases/tag/v15.0.0"');
+    expect(md).toContain("</Release>");
+  });
+
+  it("prefers content over summary in release body", () => {
+    const md = sourceToMarkdown(fullSource);
+    expect(md).toContain("Full content here with **markdown**.");
+    // The summary for the first release should NOT appear since content is present
+    const firstReleaseBlock = md.split("</Release>")[0];
+    expect(firstReleaseBlock).not.toContain("Major release with React 19 support");
+  });
+
+  it("falls back to summary when content is missing", () => {
+    const md = sourceToMarkdown(fullSource);
+    // The second release has no content, so summary should appear
+    const secondReleaseBlock = md.split("</Release>")[1];
+    expect(secondReleaseBlock).toContain("Bug fixes");
+  });
+
+  it("omits title heading when title equals version", () => {
+    const md = sourceToMarkdown(fullSource);
+    // "14.2.0" is both version and title — no ## heading
+    const secondReleaseBlock = md.split("</Release>")[1];
+    expect(secondReleaseBlock).not.toContain("## 14.2.0");
+  });
+
+  it("shows title heading when title differs from version", () => {
+    const md = sourceToMarkdown(fullSource);
+    expect(md).toContain("## Next.js 15");
+  });
+
+  it("does NOT show Pagination when totalPages is 1", () => {
+    const md = sourceToMarkdown(fullSource);
+    expect(md).not.toContain("<Pagination");
+  });
+
+  it("shows Pagination tag when totalPages > 1", () => {
+    const source: FormatSourceDetail = {
+      ...fullSource,
+      pagination: { page: 1, pageSize: 20, totalPages: 3, totalItems: 55 },
+    };
+    const md = sourceToMarkdown(source);
+    expect(md).toContain('<Pagination page="1" total-pages="3" total-items="55"');
+  });
+
+  it("includes canonical URL when baseUrl is provided", () => {
+    const md = sourceToMarkdown(fullSource, { baseUrl: "https://releases.sh" });
+    expect(md).toContain("canonical: https://releases.sh/vercel/next-js");
+    expect(md).toContain("organization_url: https://releases.sh/vercel");
+  });
+
+  it("includes next page URL in Pagination when baseUrl is provided", () => {
+    const source: FormatSourceDetail = {
+      ...fullSource,
+      pagination: { page: 1, pageSize: 20, totalPages: 3, totalItems: 55 },
+    };
+    const md = sourceToMarkdown(source, { baseUrl: "https://releases.sh" });
+    expect(md).toContain('next="https://releases.sh/vercel/next-js.md?page=2"');
+  });
+
+  it("omits canonical URL when baseUrl is not provided", () => {
+    const md = sourceToMarkdown(fullSource);
+    expect(md).not.toContain("canonical:");
+    expect(md).not.toContain("organization_url:");
+  });
+
+  it("handles null latestVersion, latestDate, lastFetchedAt gracefully", () => {
+    const source: FormatSourceDetail = {
+      ...fullSource,
+      latestVersion: null,
+      latestDate: null,
+      lastFetchedAt: null,
+    };
+    const md = sourceToMarkdown(source);
+    expect(md).not.toContain("latest_version:");
+    expect(md).not.toContain("latest_date:");
+    expect(md).not.toContain("last_updated:");
+    // Should still produce valid output
+    expect(md).toContain("name: Next.js");
+  });
+
+  it("handles null org (no organization fields in frontmatter)", () => {
+    const source: FormatSourceDetail = {
+      ...fullSource,
+      org: null,
+    };
+    const md = sourceToMarkdown(source);
+    expect(md).not.toContain("organization:");
+    expect(md).not.toContain("organization_slug:");
+    // Without org, canonical path uses /source/ prefix
+    const mdWithBase = sourceToMarkdown(source, { baseUrl: "https://releases.sh" });
+    expect(mdWithBase).toContain("canonical: https://releases.sh/source/next-js");
+    expect(mdWithBase).not.toContain("organization_url:");
+  });
+
+  it("handles empty releases array", () => {
+    const source: FormatSourceDetail = {
+      ...fullSource,
+      releases: [],
+    };
+    const md = sourceToMarkdown(source);
+    expect(md).not.toContain("<Release");
+    expect(md).toContain("name: Next.js");
+  });
+
+  it("handles null/empty summaries", () => {
+    const source: FormatSourceDetail = {
+      ...fullSource,
+      summaries: { rolling: null, monthly: [] },
+    };
+    const md = sourceToMarkdown(source);
+    expect(md).not.toContain("<Summary");
+    expect(md).toContain("name: Next.js");
+  });
+});
+
+// ── orgToMarkdown ──────────────────────────────────────────────────
+
+describe("orgToMarkdown", () => {
+  it("contains YAML frontmatter with correct fields", () => {
+    const md = orgToMarkdown(fullOrg);
+    expect(md).toContain("name: Vercel");
+    expect(md).toContain("slug: vercel");
+    expect(md).toContain("domain: vercel.com");
+    expect(md).toContain("sources: 5");
+    expect(md).toContain("total_releases: 300");
+    expect(md).toContain("releases_last_30d: 12");
+    expect(md).toContain("avg_releases_per_week: 3.5");
+    expect(md).toContain("last_updated: 2024-06-16");
+    expect(md).toContain("tracking_since: 2024-01-01");
+  });
+
+  it("contains accounts block with platform/handle", () => {
+    const md = orgToMarkdown(fullOrg);
+    expect(md).toContain("accounts:");
+    expect(md).toContain("  - platform: github");
+    expect(md).toContain("    handle: vercel");
+    expect(md).toContain("  - platform: twitter");
+  });
+
+  it("contains description when set", () => {
+    const md = orgToMarkdown(fullOrg);
+    expect(md).toContain("description: Frontend cloud platform");
+  });
+
+  it("omits description when null", () => {
+    const org: FormatOrgDetail = { ...fullOrg, description: null };
+    const md = orgToMarkdown(org);
+    expect(md).not.toContain("description:");
+  });
+
+  it("contains category when set", () => {
+    const md = orgToMarkdown(fullOrg);
+    expect(md).toContain("category: cloud");
+  });
+
+  it("omits category when null", () => {
+    const org: FormatOrgDetail = { ...fullOrg, category: null };
+    const md = orgToMarkdown(org);
+    expect(md).not.toContain("category:");
+  });
+
+  it("contains tags list when present", () => {
+    const md = orgToMarkdown(fullOrg);
+    expect(md).toContain("tags:");
+    expect(md).toContain("  - typescript");
+    expect(md).toContain("  - edge");
+  });
+
+  it("omits tags block when empty", () => {
+    const org: FormatOrgDetail = { ...fullOrg, tags: [] };
+    const md = orgToMarkdown(org);
+    expect(md).not.toContain("tags:");
+  });
+
+  it("contains aliases list when present", () => {
+    const md = orgToMarkdown(fullOrg);
+    expect(md).toContain("aliases:");
+    expect(md).toContain("  - vercel.app");
+    expect(md).toContain("  - nextjs.org");
+  });
+
+  it("omits aliases block when empty", () => {
+    const org: FormatOrgDetail = { ...fullOrg, aliases: [] };
+    const md = orgToMarkdown(org);
+    expect(md).not.toContain("aliases:");
+  });
+
+  it("contains Product tags when products are present", () => {
+    const md = orgToMarkdown(fullOrg);
+    expect(md).toContain('<Product name="Next.js"');
+    expect(md).toContain('slug="nextjs"');
+    expect(md).toContain('sources="2"');
+    expect(md).toContain('url="https://nextjs.org"');
+  });
+
+  it("omits Product section when products are empty", () => {
+    const org: FormatOrgDetail = { ...fullOrg, products: [] };
+    const md = orgToMarkdown(org);
+    expect(md).not.toContain("<Product");
+  });
+
+  it("omits accounts block when accounts array is empty", () => {
+    const org: FormatOrgDetail = { ...fullOrg, accounts: [] };
+    const md = orgToMarkdown(org);
+    expect(md).not.toContain("accounts:");
+  });
+
+  it("contains Source tags with correct attributes", () => {
+    const md = orgToMarkdown(fullOrg);
+    expect(md).toContain('name="Next.js"');
+    expect(md).toContain('slug="next-js"');
+    expect(md).toContain('type="github"');
+    expect(md).toContain('releases="150"');
+    expect(md).toContain('latest-version="15.0.0"');
+    expect(md).toContain('latest-date="2024-06-15"');
+  });
+
+  it("Source tags include primary=\"true\" for primary sources", () => {
+    const md = orgToMarkdown(fullOrg);
+    // Next.js is primary
+    expect(md).toContain('primary="true"');
+    // Turborepo line should NOT have primary
+    const turboLine = md.split("\n").find((l) => l.includes('slug="turbo"'));
+    expect(turboLine).toBeDefined();
+    expect(turboLine).not.toContain("primary");
+  });
+
+  it("includes canonical URL and source URLs when baseUrl is provided", () => {
+    const md = orgToMarkdown(fullOrg, { baseUrl: "https://releases.sh" });
+    expect(md).toContain("canonical: https://releases.sh/vercel");
+    expect(md).toContain('url="https://releases.sh/vercel/next-js"');
+    expect(md).toContain('url="https://releases.sh/vercel/turbo"');
+  });
+
+  it("omits canonical URL when baseUrl is not provided", () => {
+    const md = orgToMarkdown(fullOrg);
+    expect(md).not.toContain("canonical:");
+  });
+
+  it("handles null domain gracefully", () => {
+    const org: FormatOrgDetail = { ...fullOrg, domain: null };
+    const md = orgToMarkdown(org);
+    expect(md).not.toContain("domain:");
+    expect(md).toContain("name: Vercel");
+  });
+
+  it("handles null lastFetchedAt gracefully", () => {
+    const org: FormatOrgDetail = { ...fullOrg, lastFetchedAt: null };
+    const md = orgToMarkdown(org);
+    expect(md).not.toContain("last_updated:");
+    expect(md).toContain("name: Vercel");
+  });
+
+  it("handles empty sources array", () => {
+    const org: FormatOrgDetail = { ...fullOrg, sources: [] };
+    const md = orgToMarkdown(org);
+    expect(md).not.toContain("<Source");
+    expect(md).toContain("name: Vercel");
+  });
+
+  it("includes overview_url when overview exists and baseUrl is provided", () => {
+    const org: FormatOrgDetail = {
+      ...fullOrg,
+      overview: {
+        scope: "org",
+        content: "test",
+        releaseCount: 10,
+        lastContributingReleaseAt: "2024-06-15T00:00:00Z",
+        generatedAt: "2024-06-16T00:00:00Z",
+        updatedAt: "2024-06-16T00:00:00Z",
+      },
+    };
+    const md = orgToMarkdown(org, { baseUrl: "https://releases.sh" });
+    expect(md).toContain("overview_url: https://releases.sh/vercel/overview.md");
+  });
+
+  it("omits overview_url when overview is absent", () => {
+    const md = orgToMarkdown(fullOrg, { baseUrl: "https://releases.sh" });
+    expect(md).not.toContain("overview_url:");
+  });
+});
+
+// ── knowledgeToMarkdown ───────────────────────────────────────────
+
+describe("knowledgeToMarkdown", () => {
+  const fullKnowledge: KnowledgePageItem = {
+    scope: "org",
+    content: "# Overview\n\nThis org ships fast.",
+    releaseCount: 42,
+    lastContributingReleaseAt: "2024-06-15T00:00:00Z",
+    generatedAt: "2024-06-16T00:00:00Z",
+    updatedAt: "2024-06-16T00:00:00Z",
+  };
+
+  it("contains frontmatter with scope and stats", () => {
+    const md = knowledgeToMarkdown(fullKnowledge, { orgSlug: "vercel" });
+    expect(md).toContain("scope: org");
+    expect(md).toContain("organization: vercel");
+    expect(md).toContain("release_count: 42");
+    expect(md).toContain("last_release: 2024-06-15");
+    expect(md).toContain("generated: 2024-06-16");
+  });
+
+  it("includes the content body after frontmatter", () => {
+    const md = knowledgeToMarkdown(fullKnowledge);
+    expect(md).toContain("# Overview");
+    expect(md).toContain("This org ships fast.");
+  });
+
+  it("includes canonical URL when baseUrl and orgSlug are provided", () => {
+    const md = knowledgeToMarkdown(fullKnowledge, {
+      baseUrl: "https://releases.sh",
+      orgSlug: "vercel",
+    });
+    expect(md).toContain("canonical: https://releases.sh/vercel/overview.md");
+  });
+
+  it("includes product slug for product-scoped pages", () => {
+    const knowledge: KnowledgePageItem = { ...fullKnowledge, scope: "product" };
+    const md = knowledgeToMarkdown(knowledge, { productSlug: "nextjs" });
+    expect(md).toContain("scope: product");
+    expect(md).toContain("product: nextjs");
+  });
+
+  it("handles null lastContributingReleaseAt", () => {
+    const knowledge: KnowledgePageItem = { ...fullKnowledge, lastContributingReleaseAt: null };
+    const md = knowledgeToMarkdown(knowledge);
+    expect(md).not.toContain("last_release:");
+  });
+});

--- a/tests/unit/id.test.ts
+++ b/tests/unit/id.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "bun:test";
+import { newSourceId, newReleaseId, newOrgId, newProductId, newTagId } from "@buildinternet/releases-core/id";
+
+describe("ID generators", () => {
+  it("newSourceId has correct prefix", () => {
+    expect(newSourceId()).toMatch(/^src_/);
+  });
+
+  it("newReleaseId has correct prefix", () => {
+    expect(newReleaseId()).toMatch(/^rel_/);
+  });
+
+  it("newOrgId has correct prefix", () => {
+    expect(newOrgId()).toMatch(/^org_/);
+  });
+
+  it("newProductId has correct prefix", () => {
+    expect(newProductId()).toMatch(/^prod_/);
+  });
+
+  it("newTagId has correct prefix", () => {
+    expect(newTagId()).toMatch(/^tag_/);
+  });
+
+  it("generates unique IDs", () => {
+    const ids = new Set(Array.from({ length: 100 }, () => newSourceId()));
+    expect(ids.size).toBe(100);
+  });
+});

--- a/tests/unit/sanitize.test.ts
+++ b/tests/unit/sanitize.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "bun:test";
+import { stripAnsi } from "../../src/lib/sanitize.js";
+
+describe("stripAnsi", () => {
+  it("strips color codes", () => {
+    expect(stripAnsi("\x1b[31mred\x1b[0m")).toBe("red");
+  });
+
+  it("strips bold codes", () => {
+    expect(stripAnsi("\x1b[1mbold\x1b[0m")).toBe("bold");
+  });
+
+  it("leaves plain text unchanged", () => {
+    expect(stripAnsi("hello world")).toBe("hello world");
+  });
+
+  it("handles empty string", () => {
+    expect(stripAnsi("")).toBe("");
+  });
+
+  it("strips multiple escape sequences", () => {
+    expect(stripAnsi("\x1b[31m\x1b[1mred bold\x1b[0m normal")).toBe("red bold normal");
+  });
+});

--- a/tests/unit/slug.test.ts
+++ b/tests/unit/slug.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "bun:test";
+import { toSlug } from "@buildinternet/releases-core/slug";
+
+describe("toSlug", () => {
+  it("lowercases and replaces spaces with hyphens", () => {
+    expect(toSlug("Hello World")).toBe("hello-world");
+  });
+
+  it("strips non-alphanumeric characters", () => {
+    expect(toSlug("Foo's Bar! (v2)")).toBe("foo-s-bar-v2");
+  });
+
+  it("strips leading and trailing hyphens", () => {
+    expect(toSlug("---hello---")).toBe("hello");
+  });
+
+  it("collapses consecutive special chars into single hyphen", () => {
+    expect(toSlug("one   two---three")).toBe("one-two-three");
+  });
+
+  it("handles already-slugified input", () => {
+    expect(toSlug("already-a-slug")).toBe("already-a-slug");
+  });
+
+  it("handles empty string", () => {
+    expect(toSlug("")).toBe("");
+  });
+
+  it("handles numeric input", () => {
+    expect(toSlug("123 456")).toBe("123-456");
+  });
+});

--- a/tests/unit/tokens.test.ts
+++ b/tests/unit/tokens.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "bun:test";
+import { countTokens, countTokensSafe, estimateTokens } from "@buildinternet/releases-core/tokens";
+
+describe("countTokens", () => {
+  it("returns 0 for the empty string", () => {
+    expect(countTokens("")).toBe(0);
+  });
+
+  it("encodes short markdown to a plausible token count", () => {
+    const text = "# Hello\n\nThis is a short paragraph.";
+    const n = countTokens(text);
+    // ~10–12 tokens on cl100k; give the assertion headroom for encoder changes.
+    expect(n).toBeGreaterThan(5);
+    expect(n).toBeLessThan(30);
+  });
+
+  it("is deterministic across calls", () => {
+    const text = "## v1.0.0\n- first\n- second\n- third\n";
+    expect(countTokens(text)).toBe(countTokens(text));
+  });
+});
+
+describe("countTokensSafe", () => {
+  it("matches countTokens for small inputs", () => {
+    const text = "# CHANGELOG\n\n## v1\n- alpha\n- beta\n";
+    expect(countTokensSafe(text)).toBe(countTokens(text));
+  });
+
+  it("returns 0 for the empty string", () => {
+    expect(countTokensSafe("")).toBe(0);
+  });
+
+  it("falls back to the heuristic at and above the 256KB cap", () => {
+    // Pathological repeating-char input — without the cap the encoder
+    // hangs for minutes. Matching the heuristic exactly proves we took
+    // the fast path.
+    const body = "x".repeat(256 * 1024);
+    expect(countTokensSafe(body)).toBe(estimateTokens(body));
+  });
+});
+
+describe("estimateTokens", () => {
+  it("returns 0 for the empty string", () => {
+    expect(estimateTokens("")).toBe(0);
+  });
+
+  it("returns ceil(length/4)", () => {
+    expect(estimateTokens("a")).toBe(1);
+    expect(estimateTokens("abcd")).toBe(1);
+    expect(estimateTokens("abcde")).toBe(2);
+    expect(estimateTokens("x".repeat(100))).toBe(25);
+  });
+});

--- a/tests/unit/update-check.test.ts
+++ b/tests/unit/update-check.test.ts
@@ -1,0 +1,52 @@
+import { describe, test, expect } from "bun:test";
+
+// We can't import the module directly without side-effecting getDataDir,
+// so we test the pure logic by extracting it inline.
+
+function parseVersion(v: string): number[] {
+  return v.replace(/^v/, "").split(".").map(Number);
+}
+
+function isNewer(latest: string, current: string): boolean {
+  const l = parseVersion(latest);
+  const c = parseVersion(current);
+  for (let i = 0; i < Math.max(l.length, c.length); i++) {
+    const lv = l[i] ?? 0;
+    const cv = c[i] ?? 0;
+    if (lv > cv) return true;
+    if (lv < cv) return false;
+  }
+  return false;
+}
+
+describe("update-check", () => {
+  describe("isNewer", () => {
+    test("patch bump detected", () => {
+      expect(isNewer("0.11.2", "0.11.1")).toBe(true);
+    });
+
+    test("minor bump detected", () => {
+      expect(isNewer("0.12.0", "0.11.1")).toBe(true);
+    });
+
+    test("major bump detected", () => {
+      expect(isNewer("1.0.0", "0.11.1")).toBe(true);
+    });
+
+    test("same version is not newer", () => {
+      expect(isNewer("0.11.1", "0.11.1")).toBe(false);
+    });
+
+    test("older version is not newer", () => {
+      expect(isNewer("0.10.0", "0.11.1")).toBe(false);
+    });
+
+    test("handles v prefix", () => {
+      expect(isNewer("v1.0.0", "0.11.1")).toBe(true);
+    });
+
+    test("handles missing patch segment", () => {
+      expect(isNewer("1.0", "0.11.1")).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Addresses the bulk of the PORT-READY category in issue #14.

## New coverage

**Unit (140 tests)**
- \`sanitize\` (5) — ANSI/URL sanitizer
- \`formatters\` (48) — \`sourceToMarkdown\`, \`orgToMarkdown\`, \`knowledgeToMarkdown\`
- \`formatters-markdown\` (29) — \`releaseToMarkdown\`, \`orgReleaseFeedToMarkdown\`, \`searchToMarkdown\`
- \`slug\` (7), \`id\` (6), \`categories\` (5), \`dates\` (9), \`tokens\` (8), \`update-check\` (7)

**CLI (16 tests)**
- \`help\` (14) — public vs admin help gating, Commander wiring smoke tests. Public-mode clause clears both \`RELEASED_API_URL\` and \`RELEASED_API_KEY\` so the default public URL applies; dropped asserts for \`summary\` / \`compare\` (local-only AI tools not in OSS).
- \`errors\` (2) — unknown-command handling.

## Source additions (minimal, for test-import compatibility)

- \`src/lib/formatters.ts\` — re-export legacy type aliases (\`FormatRelease\`, \`FormatReleaseSummary\`, \`FormatSourceDetail\`, \`FormatSourceListItem\`, \`FormatOrgDetail\`) + \`knowledgeToMarkdown\` alias for \`overviewToMarkdown\`.
- \`src/api/types.ts\` — \`KnowledgePageItem\` alias for \`OverviewPageItem\`.
- \`packages/core/package.json\` — export \`./tokens\` subpath (file existed but wasn't in the \`exports\` map).

## Verified

\`bun test\`: **163 pass, 0 fail, 349 expect() calls, 1.86s.** (Up from 23 pre-port.)

## Remaining work

Tracked on the private monorepo at zachdunn/releases#284. Next wave is 7 PORT-WITH-ADAPTATION files (~124 tests) that need a fetch-mock harness — separate PR.