### PR TITLE
docs: post-split accuracy pass on README + AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ bun test                      # bun test
 ## Conventions
 
 - All logging to **stderr** via `@releases/lib/logger`. stdout is reserved for MCP JSON-RPC in `admin mcp serve` mode and for `--json` command output.
-- Reader commands (top-level `search`, `latest`, `list`, `show`, `stats`, `summary`, `compare`, `categories`) are unauthenticated GETs — safe to run without credentials.
+- Reader commands (top-level `search`, `latest`, `list`, `show`, `stats`, `categories`) are unauthenticated GETs — safe to run without credentials. `summary` and `compare` are intentionally not in this CLI; they require AI provider calls and live in the private monorepo.
 - Admin commands under `releases admin` are gated at CLI startup: missing `RELEASED_API_KEY` errors out before Commander dispatch.
 - IDs over slugs everywhere. Every `<identifier>` arg accepts `org_…`, `src_…`, `prod_…`, `rel_…`, or a slug.
 - `--json` supported on every reader command. Admin commands support it where it makes sense.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ The CLI talks to the hosted registry at `api.releases.sh`. Reader commands work 
 
 ## Install
 
+### Homebrew (macOS / Linux)
+
+```bash
+brew install buildinternet/tap/releases
+```
+
 ### npm
 
 ```bash
@@ -24,7 +30,7 @@ npx @buildinternet/releases search "react"
 curl -fsSL https://releases.sh/install | bash
 ```
 
-Installs a self-contained binary for your platform into `$HOME/.local/bin`.
+Downloads the matching platform binary from npm. Respects `RELEASED_INSTALL_DIR` (default: `/usr/local/bin`).
 
 ## Usage
 
@@ -80,7 +86,7 @@ bun run typecheck                         # tsc --noEmit
 bun test                                  # unit tests
 ```
 
-The project is a Bun workspace. The three shared packages (`@buildinternet/releases-core`, `-lib`, `-skills`) are published from this repo and consumed by the private ingest backend.
+The project is a Bun workspace. The three shared packages (`@buildinternet/releases-core`, `-lib`, `-skills`) are published from this repo alongside the CLI.
 
 ### Releasing
 


### PR DESCRIPTION
## Summary

Small accuracy pass on the public-facing docs after the repo split.

**README.md**
- Add a Homebrew install section — it's the recommended channel on [releases.sh/docs/installation](https://releases.sh/docs/installation) but was missing here.
- Fix the shell-installer path: the script installs to \`/usr/local/bin\` by default (not \`\$HOME/.local/bin\`), and it honors \`RELEASED_INSTALL_DIR\`. Updated the note.
- Soften the sentence about the shared packages — dropped the reference to a "private ingest backend" since the README shouldn't leak backend implementation detail. Now just says the shared packages are published alongside the CLI.

**AGENTS.md**
- Strip \`summary\` and \`compare\` from the reader command list. Those commands were intentionally not shipped in this OSS CLI (they require AI provider calls — see the help tests), but the agents guide still claimed they did. Added a one-line note so future contributors know why they're absent.

## Test plan

- [x] \`bun run typecheck\` clean
- [ ] README reads cleanly top-to-bottom
- [ ] Homebrew command works (\`brew install buildinternet/tap/releases\` — already verified in prior release work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)