### PR TITLE
feat(skills): add releases-cli skill + bring releases-mcp over from monorepo

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "releases",
+  "owner": {
+    "name": "Build Internet"
+  },
+  "plugins": [
+    {
+      "name": "releases",
+      "source": "./plugins/claude/releases",
+      "description": "Search changelogs, track releases, and use the releases CLI against the Releases.sh registry. Bundles the hosted MCP connection plus skills for reader lookups and CLI usage.",
+      "version": "0.1.0"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 Changelog registry for AI agents and developers. A lean HTTP client for [releases.sh](https://releases.sh) — search and browse release notes from GitHub, RSS/Atom/JSON feeds, and product changelog pages without any local infrastructure.
 
-The CLI talks to the hosted registry at `api.releases.sh`. Reader commands work out of the box with no configuration; admin workflows require an API key.
+The CLI talks to the hosted registry at `api.releases.sh`. Reader commands work out of the box with no configuration.
+
+> **Admin access is currently closed beta.** `releases admin …` commands require an API key, and API keys are not self-serve yet — the hosted registry doesn't expose a public signup flow for them. If you'd like early access, open an issue and we'll get in touch. Everything below the install section assumes reader-only use unless stated otherwise.
 
 ## Install
 
@@ -60,17 +62,60 @@ releases admin mcp serve
 
 ### Claude Code plugin
 
+Install from the marketplace manifest in this repo:
+
+```bash
+/plugin marketplace add buildinternet/releases-cli
+/plugin install releases@releases
+```
+
+Or point at a local clone for development:
+
 ```bash
 claude --plugin-dir plugins/claude/releases
 ```
 
-The plugin ships the hosted MCP connection plus six bundled skills covering changelog discovery, parsing, and analysis workflows.
+The plugin bundles:
+
+- **Hosted MCP connection** to `mcp.releases.sh` — search, lookup, and changelog slicing tools.
+- **Auto-trigger skills**:
+  - `releases-mcp` — activates on user questions about releases, changelogs, or breaking changes ("what's new in Next.js 15?").
+  - `releases-cli` — activates when a user mentions or runs the `releases` CLI.
+  - `finding-changelogs`, `managing-sources`, `parsing-changelogs`, `analyzing-releases`, `classify-media-relevance`, `seeding-playbooks` — operator playbooks for onboarding and maintaining sources (admin access required to act on them — see the callout at the top of this README).
+- **Agents** — `discovery` (finds and onboards sources) and `worker` (executes fetches).
+- **Commands** — `/releases <product> [query]` for manual lookups.
+
+> Claude Code plugins install atomically — there is no Claude Code–native flow for grabbing a single skill without the rest of the plugin. See the next section for an agent-neutral install path.
+
+### Standalone skills (any agent)
+
+The bundled skills can be installed directly into any Claude Code / Codex / Cursor / OpenCode / etc. workspace using the [`skills`](https://github.com/vercel-labs/skills) CLI, which reads the top-level `skills/` directory of this repo:
+
+```bash
+# Browse the skills in this repo and pick interactively
+npx skills add buildinternet/releases-cli
+
+# Install a specific skill
+npx skills add buildinternet/releases-cli --skill releases-cli
+npx skills add buildinternet/releases-cli --skill releases-mcp
+
+# Install all skills, globally, to Claude Code, no prompts
+npx skills add buildinternet/releases-cli --skill '*' -g -a claude-code -y
+
+# Update skills later (bare command updates everything installed)
+npx skills update
+
+# List installed skills
+npx skills list
+```
+
+This path is useful when you only want the skill behavior (auto-triggering on release/CLI questions) without also registering the hosted MCP connection, agents, and `/releases` command that the plugin provides.
 
 ## Environment
 
-Nothing is required for reader access. For admin operations:
+Nothing is required for reader access. For admin operations (closed beta — see above):
 
-- `RELEASED_API_KEY` — Bearer token for write endpoints. Required for any `releases admin …` command that mutates state.
+- `RELEASED_API_KEY` — Bearer token for write endpoints. Required for any `releases admin …` command that mutates state. Keys are not self-serve right now.
 - `RELEASED_API_URL` — Override the default `https://api.releases.sh` endpoint (useful for staging).
 - `RELEASED_TELEMETRY_DISABLED=1` — Opt out of anonymous usage pings. `DO_NOT_TRACK=1` is also honored.
 

--- a/plugins/claude/releases/.claude-plugin/plugin.json
+++ b/plugins/claude/releases/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "releases",
+  "version": "0.1.0",
+  "description": "Search changelogs, track releases, and manage changelog sources with the Releases.sh registry.",
+  "author": {
+    "name": "Build Internet"
+  }
+}

--- a/plugins/claude/releases/.mcp.json
+++ b/plugins/claude/releases/.mcp.json
@@ -1,0 +1,6 @@
+{
+  "releases": {
+    "type": "http",
+    "url": "https://mcp.releases.sh/mcp"
+  }
+}

--- a/plugins/claude/releases/README.md
+++ b/plugins/claude/releases/README.md
@@ -5,14 +5,23 @@ Search changelogs, track releases, and manage changelog sources with the [Releas
 ## What's Included
 
 - **MCP Server** — Connects Claude Code to the Releases.sh changelog registry
-- **Skills** — Auto-triggers changelog lookups when you ask about releases or what's new
+- **Skills** — Auto-triggers that cover reader lookups (`releases-mcp`), terminal usage (`releases-cli`), and a suite of operator skills (`finding-changelogs`, `managing-sources`, `parsing-changelogs`, etc.) for anyone onboarding or managing sources
 - **Agents** — `discovery` (finds and onboards sources) and `worker` (executes fetch operations)
 - **Commands** — `/releases` for manual changelog queries
 
 ## Installation
 
+Install via the marketplace manifest in the [releases-cli](https://github.com/buildinternet/releases-cli) repo:
+
 ```bash
-claude plugin add /path/to/releases-cli/plugins/claude/releases
+/plugin marketplace add buildinternet/releases-cli
+/plugin install releases@releases
+```
+
+For local development, point Claude Code at a cloned copy instead:
+
+```bash
+claude --plugin-dir plugins/claude/releases
 ```
 
 ## Available MCP Tools
@@ -66,9 +75,22 @@ Use the discovery agent to onboard Stripe as a changelog source
 Use the worker agent to fetch all Vercel sources
 ```
 
+## Bundled Skills
+
+| Skill | Trigger |
+|---|---|
+| `releases-mcp` | User asks about recent releases, changelogs, breaking changes, or version updates ("what's new in Next.js 15?") |
+| `releases-cli` | User mentions the `releases` CLI, runs a `releases` command, or asks about installing or using the CLI |
+| `finding-changelogs` | Adding a new source or evaluating a URL as a candidate |
+| `managing-sources` | Add/remove/edit/validate operations on indexed sources |
+| `parsing-changelogs` | Questions about how ingest works or debugging fetched content |
+| `analyzing-releases` | Cross-company trend or competitive-intel questions |
+| `classify-media-relevance` | Deciding which images to keep on a release |
+| `seeding-playbooks` | Bootstrapping ingestion notes for a new source |
+
 ## Skill Sync
 
-Operational skills (finding-changelogs, managing-sources, etc.) are synced from the top-level `skills/` directory — do not edit them directly in the plugin directory. Run the sync:
+Skills are synced from the top-level `skills/` directory — do not edit them directly in the plugin directory. Run the sync:
 
 ```bash
 bun scripts/sync-plugin-skills.ts

--- a/plugins/claude/releases/skills/releases-cli/SKILL.md
+++ b/plugins/claude/releases/skills/releases-cli/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: releases-cli
+description: Use the `releases` CLI to search, inspect, and manage the Releases.sh changelog registry from the terminal. Activate when the user mentions "releases CLI", runs a `releases` command, asks how to install the CLI, or wants to add/edit/fetch sources or organizations programmatically.
+---
+
+<!-- AUTO-GENERATED: Do not edit directly. Source of truth is skills/. Changes here will be overwritten by scripts/sync-plugin-skills.ts -->
+
+
+# releases CLI
+
+The `releases` CLI does two things: lets anyone search and browse the public changelog registry at [releases.sh](https://releases.sh), and lets API-key holders manage orgs, products, sources, and releases through `releases admin` subcommands.
+
+## Install
+
+```bash
+brew install buildinternet/tap/releases    # recommended on macOS / Linux
+npm install -g @buildinternet/releases     # or via npm
+```
+
+Or run one-off without installing:
+
+```bash
+npx @buildinternet/releases search "react"
+```
+
+The CLI talks to `api.releases.sh` by default — no configuration needed for reader commands.
+
+## What this skill covers
+
+- **[Reader commands](references/reader.md)** — Search, inspect, and export changelog data. No API key required.
+- **[Admin commands](references/admin.md)** — Add/edit sources, manage orgs and products, fetch releases, run policies. Requires `RELEASED_API_KEY`.
+
+## Quick Reference
+
+```bash
+# Reader (no auth required)
+releases search "breaking change"            # hybrid FTS + semantic search
+releases latest next-js                      # latest releases from one source
+releases latest --org vercel --count 20      # latest from a whole org
+releases list --category ai                  # browse sources
+releases show vercel                         # dispatch by id or slug
+releases stats                               # registry overview
+releases categories                          # list valid category values
+
+# Admin (requires RELEASED_API_KEY)
+releases admin source add "Linear" --url https://linear.app/changelog
+releases admin source fetch <slug> --max 50
+releases admin org add "Acme" --category cloud
+releases admin product add "CLI" --org acme
+releases admin discovery onboard "Stripe"    # AI-powered discovery agent
+
+# Local stdio MCP bridge (proxies to api.releases.sh)
+releases admin mcp serve
+```
+
+Every reader command accepts `--json` for machine-readable output. IDs (`org_…`, `src_…`, `prod_…`, `rel_…`) are accepted anywhere a slug is.
+
+## Authentication
+
+Reader access is unauthenticated and may be rate-limited per IP.
+
+**Admin access is closed beta.** `releases admin …` commands require a Bearer token, but the hosted registry does not currently expose a self-serve flow for generating keys — an external user cannot create one on their own. If the user asks how to get an API key, explain this and point them at the project repo to request access. Don't invent a signup URL.
+
+If a key is available:
+
+```bash
+export RELEASED_API_KEY=your_key
+export RELEASED_API_URL=https://api.releases.sh   # optional, this is the default
+```
+
+These can also go in a `.env` file — Bun auto-loads it when running from source.
+
+## Common Mistakes
+
+- `releases admin …` without `RELEASED_API_KEY` set fails fast with a clear error — don't retry the same command. Note that keys are not self-serve yet (see Authentication).
+- Slug renames (`admin source edit <slug> --slug new-slug`) require `--confirm-slug-change` because they break web links.
+- `releases admin source fetch` with no slug or filter is blocked in remote mode. Use `--stale`, `--unfetched`, `--retry-errors`, `--changed`, or a source slug.
+- Default fetch cap is 200 releases per source (GitHub pagination limits). Use `--max <n>` or `--all` to override.
+- `summary` and `compare` are *not* in this CLI. Those commands require AI provider calls and live in the private maintainer tooling. Use the hosted MCP tools `summarize_changes` / `compare_products` at `mcp.releases.sh` instead.

--- a/plugins/claude/releases/skills/releases-cli/references/admin.md
+++ b/plugins/claude/releases/skills/releases-cli/references/admin.md
@@ -1,0 +1,184 @@
+# Admin Commands
+
+> **Closed beta.** All commands on this page require `RELEASED_API_KEY` — a Bearer token on write endpoints of `api.releases.sh`. API keys are **not self-serve** at this time. A normal user cannot create one on their own, and the hosted registry does not expose a public signup flow for admin access. If a user asks how to obtain a key, tell them admin access is currently invite-only and point them at the project repo to request access. Do not fabricate a signup URL or recommend sending a request to a specific email unless one is documented in this repo.
+
+If a key is available, set it in the environment:
+
+```bash
+export RELEASED_API_KEY=your_key
+```
+
+Missing or invalid keys fail fast at CLI startup with a clear error; don't retry the same command without fixing the env var.
+
+All admin commands accept an entity ID (`org_…`, `src_…`, `prod_…`, `rel_…`) or a slug wherever an identifier is expected. Prefer IDs — slugs can change, IDs cannot.
+
+## Sources
+
+### Add
+
+```bash
+releases admin source add "Next.js" --url https://github.com/vercel/next.js
+releases admin source add "Linear" --url https://linear.app/changelog
+releases admin source add "My Blog" --url https://example.com/changelog
+```
+
+By default, `add` runs automated pre-checks (provider detection, feed discovery, markdown probing). Override with `--type github|scrape|feed`. Use `--skip-eval` to bypass evaluation. Batch mode (`--batch`) skips evaluation by default for speed.
+
+Provide a feed URL explicitly when it isn't easily discoverable:
+
+```bash
+releases admin source add "Claude Code" --url https://docs.anthropic.com/en/changelog \
+  --feed-url https://docs.anthropic.com/en/changelog/rss.xml
+```
+
+Evaluate without adding:
+
+```bash
+releases admin discovery evaluate https://linear.app/changelog
+```
+
+### Edit
+
+```bash
+releases admin source edit src_abc123 --name "New Name"      # by ID (preferred)
+releases admin source edit next-js --url https://github.com/vercel/next.js/releases
+releases admin source edit my-blog --org acme                 # set organization
+releases admin source edit my-blog --no-org                   # remove organization
+releases admin source edit my-blog --type feed                # change adapter type
+releases admin source edit my-blog --no-feed-url              # clear stored feed URL
+releases admin source edit my-blog --markdown-url https://example.com/changelog.md
+releases admin source edit my-blog --primary                  # mark as org's primary changelog
+releases admin source edit my-blog --slug new-slug --confirm-slug-change
+```
+
+Slug renames require `--confirm-slug-change` because they break existing web links.
+
+### Fetch
+
+```bash
+releases admin source fetch next-js              # one source
+releases admin source fetch --since 2025-01-01 --max 50
+releases admin source fetch --max 500            # override the 200/source default
+releases admin source fetch --all                # no date/count limits
+releases admin source fetch --stale 24           # only stale sources, with backoff
+releases admin source fetch --retry-errors       # retry sources whose last fetch failed
+releases admin source fetch --changed            # sources with upstream changes detected
+releases admin source fetch --unfetched --concurrency 5
+releases admin source fetch next-js --skip-changelog   # skip CHANGELOG.md refresh
+```
+
+Notes:
+
+- Default cap is 200 releases per source (GitHub paginates at ~10K). `--max <n>` or `--all` to override.
+- Remote mode **requires** a filter or slug. Bare `releases admin source fetch` with no args is blocked to prevent accidental bulk work.
+- Remote concurrency defaults to 3, capped at 5. Duplicate source fetches are detected and blocked.
+- Smart fetch backoff: sources returning no changes back off exponentially (1h → 48h); error backoff caps at 72h.
+
+### Poll (cheap change detection)
+
+```bash
+releases admin source poll                  # HEAD-check all feed sources
+releases admin source poll next-js          # one source
+releases admin source poll --changed        # only show sources flagged with changes
+releases admin source poll --json
+```
+
+Pure HEAD-based, no AI or parsing. The hosted cron runs this hourly; `--changed` is mostly useful for ad-hoc checks.
+
+### Fetch history
+
+```bash
+releases admin source fetch-log                   # across all sources
+releases admin source fetch-log next-js           # one source
+```
+
+### Health checks
+
+```bash
+releases admin source check             # all sources
+releases admin source check next-js     # one source
+```
+
+## Organizations
+
+```bash
+releases admin org add "Vercel" --category developer-tools --tags typescript,edge
+releases admin org list                                   # summary view
+releases admin org show vercel                            # full details (accounts, tags, sources, products, aliases)
+releases admin org edit vercel --category developer-tools
+releases admin org link vercel --platform github --handle vercel
+releases admin org tag add vercel react serverless
+releases admin org alias add anthropic claude.ai claude.com
+releases admin org refresh vercel                         # fetch all sources + regenerate overview
+```
+
+`org refresh` flags: `--max <n>` (per-source cap, default 20), `--concurrency <n>`, `--window <days>`, `--dry-run`, `--skip-overview`, `--json`.
+
+## Products
+
+Products group sources under multi-product orgs (e.g. Vercel → Next.js, Turborepo, v0):
+
+```bash
+releases admin product add "Next.js" --org vercel --url https://nextjs.org
+releases admin product list vercel
+releases admin product edit nextjs --description "React framework for production"
+releases admin product tag add nextjs react
+releases admin product alias add nextjs nextjs.org
+releases admin product remove nextjs          # sources become unlinked, not deleted
+releases admin product adopt nextjs --into vercel   # convert an org into a product
+```
+
+## Releases
+
+```bash
+releases admin release show rel_abc123
+releases admin release edit rel_abc123 --title "Fixed title" --version "v2.0.1"
+releases admin release delete rel_abc123
+releases admin release suppress rel_abc123 --reason "promotional content"
+releases admin release unsuppress rel_abc123
+```
+
+Suppressed releases are hidden from all read paths (search, latest, stats, API) but preserved for audit.
+
+## Policies
+
+Ignored URLs are **org-scoped**; blocked URLs are **global**.
+
+```bash
+releases admin policy ignore add https://example.com/blog --org vercel --reason "Not a changelog"
+releases admin policy ignore list --org vercel
+releases admin policy block add medium.com --domain --reason "Aggregator"
+releases admin policy block list
+```
+
+## Discovery
+
+AI-powered onboarding for whole companies:
+
+```bash
+releases admin discovery onboard "Vercel"
+releases admin discovery onboard "Stripe" --domain stripe.com --github-org stripe
+releases admin discovery discover vercel.com --verify --add
+releases admin discovery task list                # in-flight discovery sessions
+releases admin discovery task cancel <sessionId>
+```
+
+## Import
+
+Bulk-import orgs and sources from a JSON manifest:
+
+```bash
+releases admin source import manifest.json
+releases admin source import manifest.json --dry-run
+releases admin source import manifest.json --skip-existing
+```
+
+## MCP bridge
+
+Run a local stdio MCP bridge that proxies the hosted tools:
+
+```bash
+releases admin mcp serve
+```
+
+Useful for clients that only support stdio transport. For native remote MCP support (Claude Code, Codex), connect directly to `https://mcp.releases.sh/mcp` instead.

--- a/plugins/claude/releases/skills/releases-cli/references/reader.md
+++ b/plugins/claude/releases/skills/releases-cli/references/reader.md
@@ -1,0 +1,97 @@
+# Reader Commands
+
+Reader commands are unauthenticated — no API key required. They talk to `api.releases.sh` over HTTPS and all support `--json` for machine-readable output.
+
+## Search
+
+Hybrid lexical + semantic search across releases and CHANGELOG chunks.
+
+```bash
+releases search "authentication"
+releases search "vercel" --type releases --limit 5
+releases search "breaking change" --json
+releases search "retry" --org stripe
+```
+
+Flags:
+
+- `--type <releases|sources|all>` — narrow result kind (default: `all`).
+- `--org <slug>` — scope to one organization.
+- `--product <slug>` — scope to one product.
+- `--limit <n>` — default 20.
+- `--mode <lexical|semantic|hybrid>` — default `hybrid`. Use `lexical` for pure FTS ranking.
+- `--json` — machine output; each hit includes a `kind: "release" | "changelog_chunk"` discriminator.
+
+Chunk hits carry `sourceSlug`, `chunkOffset`, and `chunkLength` so you can chain into `releases admin source changelog <slug> --offset N` (or the MCP `get_source_changelog` tool) to read surrounding context.
+
+## Latest releases
+
+```bash
+releases latest                          # across all sources
+releases latest next-js                  # one source (by slug)
+releases latest --org vercel --count 20  # whole org
+releases latest --product nextjs         # one product
+releases latest --type feature           # filter by release type
+releases latest --json
+```
+
+## List sources
+
+```bash
+releases list                          # all sources
+releases list next-js                  # detail for one source (by slug or id)
+releases list --org sentry             # filter by organization
+releases list --product nextjs         # filter by product
+releases list --query shadcn           # name / slug / url substring
+releases list --has-feed               # sources with a discovered feed URL
+releases list --category ai            # filter by category
+releases list --json                   # machine-readable output
+releases list --json --compact         # lightweight JSON (id, slug, name, type, org, date)
+releases list --json --limit 20 --page 2  # pagination (server-side)
+```
+
+Aliased as `releases admin source list` for discoverability within admin workflows.
+
+## Show any entity
+
+Top-level `show` dispatches by ID prefix, and falls back to slug lookup:
+
+```bash
+releases show rel_XqbzLaOqBFz7VSAIqx2zs   # release (rel_)
+releases show src_abc123                   # source (src_)
+releases show org_abc123                   # organization (org_)
+releases show prod_abc123                  # product (prod_)
+releases show vercel                       # slug fallthrough (org → product → source)
+```
+
+Use this when you have an ID from another tool output (search results, MCP tool responses, etc.) and want to inspect it without caring what kind of entity it is.
+
+## Stats
+
+```bash
+releases stats              # index overview, source health, recent fetch activity
+releases stats --days 7     # adjust the activity window
+releases stats --json
+```
+
+## Categories
+
+```bash
+releases categories          # list the canonical category values
+releases categories --json
+```
+
+The category list is fixed — adding a new category requires a code change in `@buildinternet/releases-core`.
+
+## Changelog slicing (admin CLI, reader endpoint)
+
+The stored CHANGELOG.md for a GitHub source can be sliced from the reader API. The CLI wrapper lives under admin for discoverability but the endpoint itself is public:
+
+```bash
+releases admin source changelog apollo-client                      # full file
+releases admin source changelog apollo-client --limit 10000        # first 10k chars, heading-aligned
+releases admin source changelog apollo-client --tokens 5000        # first ~5k cl100k_base tokens
+releases admin source changelog apollo-client --offset 10000 --json
+```
+
+`tokens` and `limit` are both heading-aware; `tokens` wins when both are passed. Chain successive calls via the returned `nextOffset` to reconstruct the file exactly. Recommended token brackets: 2000 / 5000 / 10000 / 20000.

--- a/plugins/claude/releases/skills/releases-mcp/SKILL.md
+++ b/plugins/claude/releases/skills/releases-mcp/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: releases-mcp
+description: Use when the user asks about recent releases, changelogs, what's new in a library, breaking changes, version updates, or wants to compare products. Activates for questions like "what changed in Next.js 15?", "latest Tailwind releases", "compare Bun vs Deno releases".
+---
+
+<!-- AUTO-GENERATED: Do not edit directly. Source of truth is skills/. Changes here will be overwritten by scripts/sync-plugin-skills.ts -->
+
+
+# Releases.sh — Changelog Lookup
+
+When the user asks about releases, changelogs, or version updates, use the Releases.sh MCP tools to fetch current data instead of relying on training data.
+
+## When to Use This Skill
+
+Activate when the user:
+
+- Asks what's new or changed in a library/product ("What changed in Next.js 15?")
+- Wants recent releases or changelogs ("Show me the latest Tailwind releases")
+- Asks about breaking changes or migration ("Were there breaking changes in Prisma 6?")
+- Wants to compare release activity between products ("Compare Bun vs Deno releases")
+- Mentions version updates, release notes, or changelogs in the context of a specific product
+
+## How to Look Up Releases
+
+### Step 1: Find the Organization or Product
+
+Call `list_organizations` with the library/product name as the `query` parameter. Multi-product orgs (e.g. Vercel → Next.js, Turborepo) are exposed via `list_products` and `get_product` — use those when the user's question is product-specific rather than company-wide.
+
+If the query returns no results, try variations:
+- The company name instead of the product name (e.g., "Vercel" instead of "Next.js")
+- The GitHub org name (e.g., "supabase")
+- A domain (e.g., "tailwindcss.com")
+
+### Step 2: Choose the Right Tool
+
+- **"What's new?" / "Latest releases"** → Use `get_latest_releases` with the organization or product slug
+- **Specific feature or keyword** → Use `search_releases` with a descriptive query and organization filter
+- **Single release by id** → Use `get_release` when you already have a `rel_` id (search results include ids)
+- **Source or product deep-dive** → Use `get_source`, `get_product`, or `get_organization` for metadata, tags, and linkage
+- **Canonical CHANGELOG.md from a GitHub repo** → Use `get_source_changelog` when the user wants the full maintained file, not just the tagged releases (refreshed on every fetch). For large files, pass `tokens` (cl100k_base budget, e.g. 5000 or 10000) to get a heading-aligned slice that fits a known context window; chain via the returned `nextOffset`. Every response reports `totalTokens` so you can plan how many calls you need upfront.
+- **Compare two products** → Use `compare_products` with an array of two product slugs
+- **Summarize recent activity** → Use `summarize_changes` with the product slug
+
+### Step 3: Present Results
+
+- Lead with the most relevant information for the user's question
+- Include version numbers and dates when available
+- Quote key changes directly from the release notes
+- If results are sparse, mention that the product may not be fully indexed yet
+
+## Guidelines
+
+- Pass the user's full question context into query parameters for better relevance
+- When the user mentions a time range ("last month", "since v4"), use the `days` parameter on `get_latest_releases` or `summarize_changes`
+- If a product isn't found, say so clearly — don't fabricate release information
+- For comparison questions, both products must be indexed; if one isn't found, explain which is missing

--- a/scripts/sync-plugin-skills.ts
+++ b/scripts/sync-plugin-skills.ts
@@ -11,7 +11,7 @@
  *   bun scripts/sync-plugin-skills.ts --dry-run  # preview without changes
  */
 
-import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync, rmSync } from "fs";
+import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync, rmSync, cpSync } from "fs";
 import { resolve, join } from "path";
 
 const PROJECT_ROOT = resolve(import.meta.dir, "..");
@@ -51,7 +51,15 @@ function main() {
       ? sourceContent.slice(0, fmEnd + 3) + "\n\n" + AUTO_GEN_COMMENT + "\n" + sourceContent.slice(fmEnd + 3)
       : AUTO_GEN_COMMENT + "\n\n" + sourceContent;
 
-    if (existsSync(destPath) && readFileSync(destPath, "utf8") === destContent) {
+    const sourceRefs = join(SOURCE_SKILLS_DIR, dirName, "references");
+    const destRefs = join(destDir, "references");
+    const refsInSync = refsEqual(sourceRefs, destRefs);
+
+    if (
+      existsSync(destPath) &&
+      readFileSync(destPath, "utf8") === destContent &&
+      refsInSync
+    ) {
       console.log(`  ✓ ${dirName} — up to date`);
       unchanged++;
       continue;
@@ -63,6 +71,10 @@ function main() {
     if (!dryRun) {
       mkdirSync(destDir, { recursive: true });
       writeFileSync(destPath, destContent);
+
+      // Mirror the skill's `references/` subdirectory (context7-cli-style layout).
+      if (existsSync(destRefs)) rmSync(destRefs, { recursive: true, force: true });
+      if (existsSync(sourceRefs)) cpSync(sourceRefs, destRefs, { recursive: true });
     }
   }
 
@@ -84,6 +96,25 @@ function main() {
   }
 
   console.log(`\nDone: ${synced} synced, ${unchanged} unchanged, ${removed} removed`);
+}
+
+function refsEqual(sourceDir: string, destDir: string): boolean {
+  const hasSource = existsSync(sourceDir);
+  const hasDest = existsSync(destDir);
+  if (!hasSource && !hasDest) return true;
+  if (hasSource !== hasDest) return false;
+
+  const sourceFiles = readdirSync(sourceDir).sort();
+  const destFiles = readdirSync(destDir).sort();
+  if (sourceFiles.length !== destFiles.length) return false;
+
+  for (let i = 0; i < sourceFiles.length; i++) {
+    if (sourceFiles[i] !== destFiles[i]) return false;
+    const a = readFileSync(join(sourceDir, sourceFiles[i]), "utf8");
+    const b = readFileSync(join(destDir, destFiles[i]), "utf8");
+    if (a !== b) return false;
+  }
+  return true;
 }
 
 main();

--- a/skills/releases-cli/SKILL.md
+++ b/skills/releases-cli/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: releases-cli
+description: Use the `releases` CLI to search, inspect, and manage the Releases.sh changelog registry from the terminal. Activate when the user mentions "releases CLI", runs a `releases` command, asks how to install the CLI, or wants to add/edit/fetch sources or organizations programmatically.
+---
+
+# releases CLI
+
+The `releases` CLI does two things: lets anyone search and browse the public changelog registry at [releases.sh](https://releases.sh), and lets API-key holders manage orgs, products, sources, and releases through `releases admin` subcommands.
+
+## Install
+
+```bash
+brew install buildinternet/tap/releases    # recommended on macOS / Linux
+npm install -g @buildinternet/releases     # or via npm
+```
+
+Or run one-off without installing:
+
+```bash
+npx @buildinternet/releases search "react"
+```
+
+The CLI talks to `api.releases.sh` by default — no configuration needed for reader commands.
+
+## What this skill covers
+
+- **[Reader commands](references/reader.md)** — Search, inspect, and export changelog data. No API key required.
+- **[Admin commands](references/admin.md)** — Add/edit sources, manage orgs and products, fetch releases, run policies. Requires `RELEASED_API_KEY`.
+
+## Quick Reference
+
+```bash
+# Reader (no auth required)
+releases search "breaking change"            # hybrid FTS + semantic search
+releases latest next-js                      # latest releases from one source
+releases latest --org vercel --count 20      # latest from a whole org
+releases list --category ai                  # browse sources
+releases show vercel                         # dispatch by id or slug
+releases stats                               # registry overview
+releases categories                          # list valid category values
+
+# Admin (requires RELEASED_API_KEY)
+releases admin source add "Linear" --url https://linear.app/changelog
+releases admin source fetch <slug> --max 50
+releases admin org add "Acme" --category cloud
+releases admin product add "CLI" --org acme
+releases admin discovery onboard "Stripe"    # AI-powered discovery agent
+
+# Local stdio MCP bridge (proxies to api.releases.sh)
+releases admin mcp serve
+```
+
+Every reader command accepts `--json` for machine-readable output. IDs (`org_…`, `src_…`, `prod_…`, `rel_…`) are accepted anywhere a slug is.
+
+## Authentication
+
+Reader access is unauthenticated and may be rate-limited per IP.
+
+**Admin access is closed beta.** `releases admin …` commands require a Bearer token, but the hosted registry does not currently expose a self-serve flow for generating keys — an external user cannot create one on their own. If the user asks how to get an API key, explain this and point them at the project repo to request access. Don't invent a signup URL.
+
+If a key is available:
+
+```bash
+export RELEASED_API_KEY=your_key
+export RELEASED_API_URL=https://api.releases.sh   # optional, this is the default
+```
+
+These can also go in a `.env` file — Bun auto-loads it when running from source.
+
+## Common Mistakes
+
+- `releases admin …` without `RELEASED_API_KEY` set fails fast with a clear error — don't retry the same command. Note that keys are not self-serve yet (see Authentication).
+- Slug renames (`admin source edit <slug> --slug new-slug`) require `--confirm-slug-change` because they break web links.
+- `releases admin source fetch` with no slug or filter is blocked in remote mode. Use `--stale`, `--unfetched`, `--retry-errors`, `--changed`, or a source slug.
+- Default fetch cap is 200 releases per source (GitHub pagination limits). Use `--max <n>` or `--all` to override.
+- `summary` and `compare` are *not* in this CLI. Those commands require AI provider calls and live in the private maintainer tooling. Use the hosted MCP tools `summarize_changes` / `compare_products` at `mcp.releases.sh` instead.

--- a/skills/releases-cli/references/admin.md
+++ b/skills/releases-cli/references/admin.md
@@ -1,0 +1,184 @@
+# Admin Commands
+
+> **Closed beta.** All commands on this page require `RELEASED_API_KEY` — a Bearer token on write endpoints of `api.releases.sh`. API keys are **not self-serve** at this time. A normal user cannot create one on their own, and the hosted registry does not expose a public signup flow for admin access. If a user asks how to obtain a key, tell them admin access is currently invite-only and point them at the project repo to request access. Do not fabricate a signup URL or recommend sending a request to a specific email unless one is documented in this repo.
+
+If a key is available, set it in the environment:
+
+```bash
+export RELEASED_API_KEY=your_key
+```
+
+Missing or invalid keys fail fast at CLI startup with a clear error; don't retry the same command without fixing the env var.
+
+All admin commands accept an entity ID (`org_…`, `src_…`, `prod_…`, `rel_…`) or a slug wherever an identifier is expected. Prefer IDs — slugs can change, IDs cannot.
+
+## Sources
+
+### Add
+
+```bash
+releases admin source add "Next.js" --url https://github.com/vercel/next.js
+releases admin source add "Linear" --url https://linear.app/changelog
+releases admin source add "My Blog" --url https://example.com/changelog
+```
+
+By default, `add` runs automated pre-checks (provider detection, feed discovery, markdown probing). Override with `--type github|scrape|feed`. Use `--skip-eval` to bypass evaluation. Batch mode (`--batch`) skips evaluation by default for speed.
+
+Provide a feed URL explicitly when it isn't easily discoverable:
+
+```bash
+releases admin source add "Claude Code" --url https://docs.anthropic.com/en/changelog \
+  --feed-url https://docs.anthropic.com/en/changelog/rss.xml
+```
+
+Evaluate without adding:
+
+```bash
+releases admin discovery evaluate https://linear.app/changelog
+```
+
+### Edit
+
+```bash
+releases admin source edit src_abc123 --name "New Name"      # by ID (preferred)
+releases admin source edit next-js --url https://github.com/vercel/next.js/releases
+releases admin source edit my-blog --org acme                 # set organization
+releases admin source edit my-blog --no-org                   # remove organization
+releases admin source edit my-blog --type feed                # change adapter type
+releases admin source edit my-blog --no-feed-url              # clear stored feed URL
+releases admin source edit my-blog --markdown-url https://example.com/changelog.md
+releases admin source edit my-blog --primary                  # mark as org's primary changelog
+releases admin source edit my-blog --slug new-slug --confirm-slug-change
+```
+
+Slug renames require `--confirm-slug-change` because they break existing web links.
+
+### Fetch
+
+```bash
+releases admin source fetch next-js              # one source
+releases admin source fetch --since 2025-01-01 --max 50
+releases admin source fetch --max 500            # override the 200/source default
+releases admin source fetch --all                # no date/count limits
+releases admin source fetch --stale 24           # only stale sources, with backoff
+releases admin source fetch --retry-errors       # retry sources whose last fetch failed
+releases admin source fetch --changed            # sources with upstream changes detected
+releases admin source fetch --unfetched --concurrency 5
+releases admin source fetch next-js --skip-changelog   # skip CHANGELOG.md refresh
+```
+
+Notes:
+
+- Default cap is 200 releases per source (GitHub paginates at ~10K). `--max <n>` or `--all` to override.
+- Remote mode **requires** a filter or slug. Bare `releases admin source fetch` with no args is blocked to prevent accidental bulk work.
+- Remote concurrency defaults to 3, capped at 5. Duplicate source fetches are detected and blocked.
+- Smart fetch backoff: sources returning no changes back off exponentially (1h → 48h); error backoff caps at 72h.
+
+### Poll (cheap change detection)
+
+```bash
+releases admin source poll                  # HEAD-check all feed sources
+releases admin source poll next-js          # one source
+releases admin source poll --changed        # only show sources flagged with changes
+releases admin source poll --json
+```
+
+Pure HEAD-based, no AI or parsing. The hosted cron runs this hourly; `--changed` is mostly useful for ad-hoc checks.
+
+### Fetch history
+
+```bash
+releases admin source fetch-log                   # across all sources
+releases admin source fetch-log next-js           # one source
+```
+
+### Health checks
+
+```bash
+releases admin source check             # all sources
+releases admin source check next-js     # one source
+```
+
+## Organizations
+
+```bash
+releases admin org add "Vercel" --category developer-tools --tags typescript,edge
+releases admin org list                                   # summary view
+releases admin org show vercel                            # full details (accounts, tags, sources, products, aliases)
+releases admin org edit vercel --category developer-tools
+releases admin org link vercel --platform github --handle vercel
+releases admin org tag add vercel react serverless
+releases admin org alias add anthropic claude.ai claude.com
+releases admin org refresh vercel                         # fetch all sources + regenerate overview
+```
+
+`org refresh` flags: `--max <n>` (per-source cap, default 20), `--concurrency <n>`, `--window <days>`, `--dry-run`, `--skip-overview`, `--json`.
+
+## Products
+
+Products group sources under multi-product orgs (e.g. Vercel → Next.js, Turborepo, v0):
+
+```bash
+releases admin product add "Next.js" --org vercel --url https://nextjs.org
+releases admin product list vercel
+releases admin product edit nextjs --description "React framework for production"
+releases admin product tag add nextjs react
+releases admin product alias add nextjs nextjs.org
+releases admin product remove nextjs          # sources become unlinked, not deleted
+releases admin product adopt nextjs --into vercel   # convert an org into a product
+```
+
+## Releases
+
+```bash
+releases admin release show rel_abc123
+releases admin release edit rel_abc123 --title "Fixed title" --version "v2.0.1"
+releases admin release delete rel_abc123
+releases admin release suppress rel_abc123 --reason "promotional content"
+releases admin release unsuppress rel_abc123
+```
+
+Suppressed releases are hidden from all read paths (search, latest, stats, API) but preserved for audit.
+
+## Policies
+
+Ignored URLs are **org-scoped**; blocked URLs are **global**.
+
+```bash
+releases admin policy ignore add https://example.com/blog --org vercel --reason "Not a changelog"
+releases admin policy ignore list --org vercel
+releases admin policy block add medium.com --domain --reason "Aggregator"
+releases admin policy block list
+```
+
+## Discovery
+
+AI-powered onboarding for whole companies:
+
+```bash
+releases admin discovery onboard "Vercel"
+releases admin discovery onboard "Stripe" --domain stripe.com --github-org stripe
+releases admin discovery discover vercel.com --verify --add
+releases admin discovery task list                # in-flight discovery sessions
+releases admin discovery task cancel <sessionId>
+```
+
+## Import
+
+Bulk-import orgs and sources from a JSON manifest:
+
+```bash
+releases admin source import manifest.json
+releases admin source import manifest.json --dry-run
+releases admin source import manifest.json --skip-existing
+```
+
+## MCP bridge
+
+Run a local stdio MCP bridge that proxies the hosted tools:
+
+```bash
+releases admin mcp serve
+```
+
+Useful for clients that only support stdio transport. For native remote MCP support (Claude Code, Codex), connect directly to `https://mcp.releases.sh/mcp` instead.

--- a/skills/releases-cli/references/reader.md
+++ b/skills/releases-cli/references/reader.md
@@ -1,0 +1,97 @@
+# Reader Commands
+
+Reader commands are unauthenticated — no API key required. They talk to `api.releases.sh` over HTTPS and all support `--json` for machine-readable output.
+
+## Search
+
+Hybrid lexical + semantic search across releases and CHANGELOG chunks.
+
+```bash
+releases search "authentication"
+releases search "vercel" --type releases --limit 5
+releases search "breaking change" --json
+releases search "retry" --org stripe
+```
+
+Flags:
+
+- `--type <releases|sources|all>` — narrow result kind (default: `all`).
+- `--org <slug>` — scope to one organization.
+- `--product <slug>` — scope to one product.
+- `--limit <n>` — default 20.
+- `--mode <lexical|semantic|hybrid>` — default `hybrid`. Use `lexical` for pure FTS ranking.
+- `--json` — machine output; each hit includes a `kind: "release" | "changelog_chunk"` discriminator.
+
+Chunk hits carry `sourceSlug`, `chunkOffset`, and `chunkLength` so you can chain into `releases admin source changelog <slug> --offset N` (or the MCP `get_source_changelog` tool) to read surrounding context.
+
+## Latest releases
+
+```bash
+releases latest                          # across all sources
+releases latest next-js                  # one source (by slug)
+releases latest --org vercel --count 20  # whole org
+releases latest --product nextjs         # one product
+releases latest --type feature           # filter by release type
+releases latest --json
+```
+
+## List sources
+
+```bash
+releases list                          # all sources
+releases list next-js                  # detail for one source (by slug or id)
+releases list --org sentry             # filter by organization
+releases list --product nextjs         # filter by product
+releases list --query shadcn           # name / slug / url substring
+releases list --has-feed               # sources with a discovered feed URL
+releases list --category ai            # filter by category
+releases list --json                   # machine-readable output
+releases list --json --compact         # lightweight JSON (id, slug, name, type, org, date)
+releases list --json --limit 20 --page 2  # pagination (server-side)
+```
+
+Aliased as `releases admin source list` for discoverability within admin workflows.
+
+## Show any entity
+
+Top-level `show` dispatches by ID prefix, and falls back to slug lookup:
+
+```bash
+releases show rel_XqbzLaOqBFz7VSAIqx2zs   # release (rel_)
+releases show src_abc123                   # source (src_)
+releases show org_abc123                   # organization (org_)
+releases show prod_abc123                  # product (prod_)
+releases show vercel                       # slug fallthrough (org → product → source)
+```
+
+Use this when you have an ID from another tool output (search results, MCP tool responses, etc.) and want to inspect it without caring what kind of entity it is.
+
+## Stats
+
+```bash
+releases stats              # index overview, source health, recent fetch activity
+releases stats --days 7     # adjust the activity window
+releases stats --json
+```
+
+## Categories
+
+```bash
+releases categories          # list the canonical category values
+releases categories --json
+```
+
+The category list is fixed — adding a new category requires a code change in `@buildinternet/releases-core`.
+
+## Changelog slicing (admin CLI, reader endpoint)
+
+The stored CHANGELOG.md for a GitHub source can be sliced from the reader API. The CLI wrapper lives under admin for discoverability but the endpoint itself is public:
+
+```bash
+releases admin source changelog apollo-client                      # full file
+releases admin source changelog apollo-client --limit 10000        # first 10k chars, heading-aligned
+releases admin source changelog apollo-client --tokens 5000        # first ~5k cl100k_base tokens
+releases admin source changelog apollo-client --offset 10000 --json
+```
+
+`tokens` and `limit` are both heading-aware; `tokens` wins when both are passed. Chain successive calls via the returned `nextOffset` to reconstruct the file exactly. Recommended token brackets: 2000 / 5000 / 10000 / 20000.

--- a/skills/releases-mcp/SKILL.md
+++ b/skills/releases-mcp/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: releases-mcp
+description: Use when the user asks about recent releases, changelogs, what's new in a library, breaking changes, version updates, or wants to compare products. Activates for questions like "what changed in Next.js 15?", "latest Tailwind releases", "compare Bun vs Deno releases".
+---
+
+# Releases.sh — Changelog Lookup
+
+When the user asks about releases, changelogs, or version updates, use the Releases.sh MCP tools to fetch current data instead of relying on training data.
+
+## When to Use This Skill
+
+Activate when the user:
+
+- Asks what's new or changed in a library/product ("What changed in Next.js 15?")
+- Wants recent releases or changelogs ("Show me the latest Tailwind releases")
+- Asks about breaking changes or migration ("Were there breaking changes in Prisma 6?")
+- Wants to compare release activity between products ("Compare Bun vs Deno releases")
+- Mentions version updates, release notes, or changelogs in the context of a specific product
+
+## How to Look Up Releases
+
+### Step 1: Find the Organization or Product
+
+Call `list_organizations` with the library/product name as the `query` parameter. Multi-product orgs (e.g. Vercel → Next.js, Turborepo) are exposed via `list_products` and `get_product` — use those when the user's question is product-specific rather than company-wide.
+
+If the query returns no results, try variations:
+- The company name instead of the product name (e.g., "Vercel" instead of "Next.js")
+- The GitHub org name (e.g., "supabase")
+- A domain (e.g., "tailwindcss.com")
+
+### Step 2: Choose the Right Tool
+
+- **"What's new?" / "Latest releases"** → Use `get_latest_releases` with the organization or product slug
+- **Specific feature or keyword** → Use `search_releases` with a descriptive query and organization filter
+- **Single release by id** → Use `get_release` when you already have a `rel_` id (search results include ids)
+- **Source or product deep-dive** → Use `get_source`, `get_product`, or `get_organization` for metadata, tags, and linkage
+- **Canonical CHANGELOG.md from a GitHub repo** → Use `get_source_changelog` when the user wants the full maintained file, not just the tagged releases (refreshed on every fetch). For large files, pass `tokens` (cl100k_base budget, e.g. 5000 or 10000) to get a heading-aligned slice that fits a known context window; chain via the returned `nextOffset`. Every response reports `totalTokens` so you can plan how many calls you need upfront.
+- **Compare two products** → Use `compare_products` with an array of two product slugs
+- **Summarize recent activity** → Use `summarize_changes` with the product slug
+
+### Step 3: Present Results
+
+- Lead with the most relevant information for the user's question
+- Include version numbers and dates when available
+- Quote key changes directly from the release notes
+- If results are sparse, mention that the product may not be fully indexed yet
+
+## Guidelines
+
+- Pass the user's full question context into query parameters for better relevance
+- When the user mentions a time range ("last month", "since v4"), use the `days` parameter on `get_latest_releases` or `summarize_changes`
+- If a product isn't found, say so clearly — don't fabricate release information
+- For comparison questions, both products must be indexed; if one isn't found, explain which is missing


### PR DESCRIPTION
## Summary

Two new skills, plugin manifest pieces that were missing, a marketplace manifest at the repo root, and install docs covering both the Claude Code plugin flow and the agent-neutral `npx skills` CLI.

### Skills

- **`skills/releases-mcp/`** — moved from the private monorepo plugin. This is the consumer-facing skill that auto-triggers on user questions about releases, changelogs, breaking changes, and version updates ("what changed in Next.js 15?"). The OSS plugin previously had only operator-oriented skills, so the plugin's main value prop was silent for reader questions. Contains zero backend detail — teaches Claude to call the hosted MCP tools at \`mcp.releases.sh\`. Source of truth is now here.
- **`skills/releases-cli/`** — net new, modeled on [upstash/context7's context7-cli layout](https://github.com/upstash/context7/tree/master/skills/context7-cli). \`SKILL.md\` covers install, quick reference, auth, and common mistakes; \`references/reader.md\` and \`references/admin.md\` carry the full command surface and are loaded on demand. Triggers on "releases CLI", users running \`releases\` commands, or install/setup questions.

### Closed-beta clarification

Admin access is currently invite-only — API keys aren't self-serve. Explicit callouts in three places so agents don't hallucinate a signup URL:

- README, prominent callout under the tagline.
- \`skills/releases-cli/SKILL.md\` Authentication section.
- \`skills/releases-cli/references/admin.md\` at the top of the admin reference.

### Plugin manifest

- \`plugins/claude/releases/.claude-plugin/plugin.json\` and \`.mcp.json\` were missing from the OSS plugin entirely — it had no manifest and no MCP connection config, so it wasn't actually installable as a Claude Code plugin. Copied from the monorepo.
- \`.claude-plugin/marketplace.json\` at the repo root lets users install via the marketplace flow (\`/plugin marketplace add buildinternet/releases-cli\` → \`/plugin install releases@releases\`) instead of needing a local clone.

### Install docs (two paths)

- **Full plugin** (Claude Code only) via the marketplace — atomic: hosted MCP + agents + \`/releases\` command + all skills.
- **Standalone skills** for any supported agent (Codex, Cursor, OpenCode, ~40 others) via [\`npx skills\`](https://github.com/vercel-labs/skills):
  ```bash
  npx skills add buildinternet/releases-cli                      # interactive picker
  npx skills add buildinternet/releases-cli --skill releases-cli # just one
  npx skills update                                              # update everything installed
  ```
  Our top-level \`skills/\` layout already matches what the CLI expects; no structural changes needed.

### Sync script

`scripts/sync-plugin-skills.ts` previously only copied `SKILL.md`, so the new `releases-cli` skill's \`references/\` files would have been orphaned on next sync. Extended to mirror a skill's `references/` subdirectory alongside `SKILL.md`, idempotent.

### Plugin README

Replaced the generic skills bullet with a table of auto-triggers covering all bundled skills, plus both install paths.

## Follow-up

- [zachdunn/releases#289](https://github.com/zachdunn/releases/pull/289) removes the duplicated \`releases-mcp\` plugin copy from the private monorepo. Merge this PR first.

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun test\` → 163 pass, 0 fail
- [x] \`bun scripts/sync-plugin-skills.ts\` idempotent (second run: 0 synced, 8 unchanged)
- [ ] After merge: verify \`/plugin marketplace add buildinternet/releases-cli\` + \`/plugin install releases@releases\` works in Claude Code
- [ ] After merge: verify \`npx skills add buildinternet/releases-cli --list\` enumerates the 8 skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)