### PR TITLE
docs: add badges + ship README to npm

### DIFF
--- a/.changeset/include-readme-in-published-package.md
+++ b/.changeset/include-readme-in-published-package.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": patch
+---
+
+Include README in the published npm tarball so the package page on npmjs.com renders install + usage docs. A `prepack` script copies the repo-root README into the package directory at publish time.

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist
 *.bun-build
 .*.bun-build
 npm/*/releases
+npm/releases/README.md
 .bun-runtimes
 
 # logs

--- a/README.md
+++ b/README.md
@@ -94,27 +94,13 @@ The plugin bundles:
 
 ### Standalone skills (any agent)
 
-The bundled skills can be installed directly into any Claude Code / Codex / Cursor / OpenCode / etc. workspace using the [`skills`](https://github.com/vercel-labs/skills) CLI, which reads the top-level `skills/` directory of this repo:
+The bundled skills are also available as a standalone package. Install them into any Claude Code / Codex / Cursor / OpenCode workspace using the [`skills`](https://github.com/vercel-labs/skills) CLI, which reads the top-level `skills/` directory of this repo:
 
 ```bash
-# Browse the skills in this repo and pick interactively
 npx skills add buildinternet/releases-cli
-
-# Install a specific skill
-npx skills add buildinternet/releases-cli --skill releases-cli
-npx skills add buildinternet/releases-cli --skill releases-mcp
-
-# Install all skills, globally, to Claude Code, no prompts
-npx skills add buildinternet/releases-cli --skill '*' -g -a claude-code -y
-
-# Update skills later (bare command updates everything installed)
-npx skills update
-
-# List installed skills
-npx skills list
 ```
 
-This path is useful when you only want the skill behavior (auto-triggering on release/CLI questions) without also registering the hosted MCP connection, agents, and `/releases` command that the plugin provides.
+Use this when you only want the skill behavior (auto-triggering on release/CLI questions) without also registering the hosted MCP connection, agents, and `/releases` command that the plugin provides.
 
 ## Environment
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Releases CLI
 
+[![npm](https://img.shields.io/npm/v/@buildinternet/releases?color=cb3837&label=npm&logo=npm)](https://www.npmjs.com/package/@buildinternet/releases)
+[![Release](https://github.com/buildinternet/releases-cli/actions/workflows/release.yml/badge.svg)](https://github.com/buildinternet/releases-cli/actions/workflows/release.yml)
+[![Test](https://github.com/buildinternet/releases-cli/actions/workflows/test.yml/badge.svg)](https://github.com/buildinternet/releases-cli/actions/workflows/test.yml)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
+
 Changelog registry for AI agents and developers. A lean HTTP client for [releases.sh](https://releases.sh) — search and browse release notes from GitHub, RSS/Atom/JSON feeds, and product changelog pages without any local infrastructure.
 
 The CLI talks to the hosted registry at `api.releases.sh`. Reader commands work out of the box with no configuration.

--- a/npm/releases/package.json
+++ b/npm/releases/package.json
@@ -5,8 +5,12 @@
   "bin": {
     "releases": "bin/releases"
   },
+  "scripts": {
+    "prepack": "cp ../../README.md ./README.md"
+  },
   "files": [
-    "bin/releases"
+    "bin/releases",
+    "README.md"
   ],
   "optionalDependencies": {
     "@buildinternet/releases-darwin-arm64": "0.13.2",


### PR DESCRIPTION
## Summary
- Adds npm version, CI workflow, and license badges to the README
- Adds a `prepack` script in `npm/releases/` that copies the repo README into the package, so npmjs.com renders install + usage docs (currently shows "no README")
- Includes a patch changeset so the README ships with the next publish

## Test plan
- [x] `npm pack --dry-run` from `npm/releases/` includes `README.md` in the tarball
- [x] Badges render on the GitHub PR view
- [ ] After merge + publish, https://npmjs.com/package/@buildinternet/releases shows the README