### PR TITLE
feat(cli): preview AI overview in org show + add full reader

### DIFF
--- a/.changeset/overview-tighten.md
+++ b/.changeset/overview-tighten.md
@@ -1,0 +1,10 @@
+---
+"@buildinternet/releases": minor
+"@buildinternet/releases-core": minor
+---
+
+Surface AI-generated org overviews more readily in the CLI:
+
+- `releases org show <slug>` now prints a short preview (first ~80 words) of the AI overview with a generated-at hint and a "⚠ older than 30 days" stale warning where appropriate.
+- New `releases org overview <slug>` command (public read, no auth) prints the full overview body with the same staleness signal.
+- `@buildinternet/releases-core/overview` exports shared helpers — `OVERVIEW_STALE_DAYS`, `overviewAgeDays`, `isOverviewStale`, `overviewPreview` — used by both the CLI and the upstream MCP server.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ bun test                      # bun test
 - IDs over slugs everywhere. Every `<identifier>` arg accepts `org_…`, `src_…`, `prod_…`, `rel_…`, or a slug.
 - `--json` supported on every reader command. Admin commands support it where it makes sense.
 - `daysAgoIso()` from `@releases/core/dates` for cutoff math. Don't roll your own.
+- Org overviews: `releases org show <slug>` includes a short overview preview; `releases org overview <slug>` is the unauthenticated public reader for the full body. Both surfaces add a `⚠ older than 30 days` warning past `OVERVIEW_STALE_DAYS` (from `@buildinternet/releases-core/overview`).
 
 ## Telemetry
 

--- a/README.md
+++ b/README.md
@@ -46,10 +46,11 @@ releases search "authentication"
 releases latest next-js
 releases list --category ai
 releases show vercel            # org, product, or source
+releases org overview vercel    # full AI-generated overview for an org
 releases stats
 ```
 
-Every reader command supports `--json` for machine-readable output.
+Every reader command supports `--json` for machine-readable output. `org show` includes a short overview preview (with a stale warning when more than 30 days old); `org overview <slug>` prints the full body.
 
 ### MCP
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,6 +14,7 @@
     "./categories": "./src/categories.ts",
     "./dates": "./src/dates.ts",
     "./changelog-slice": "./src/changelog-slice.ts",
+    "./overview": "./src/overview.ts",
     "./id": "./src/id.ts",
     "./slug": "./src/slug.ts",
     "./tokens": "./src/tokens.ts"

--- a/packages/core/src/overview.ts
+++ b/packages/core/src/overview.ts
@@ -1,0 +1,47 @@
+/**
+ * Overview is considered stale beyond this many days. CLI and MCP both warn
+ * (but still show) when an overview's `generatedAt` is older than this.
+ */
+export const OVERVIEW_STALE_DAYS = 30;
+
+/** Default preview length when truncating overview content for inline display. */
+export const OVERVIEW_PREVIEW_WORDS = 80;
+
+export interface OverviewMeta {
+  generatedAt: string;
+  updatedAt?: string | null;
+  lastContributingReleaseAt?: string | null;
+}
+
+export function overviewAgeDays(generatedAt: string, now: number = Date.now()): number {
+  const ms = now - new Date(generatedAt).getTime();
+  return Math.floor(ms / (24 * 60 * 60 * 1000));
+}
+
+export function isOverviewStale(generatedAt: string, now: number = Date.now()): boolean {
+  return overviewAgeDays(generatedAt, now) > OVERVIEW_STALE_DAYS;
+}
+
+/**
+ * Strip a stray leading markdown heading. The overview prompt forbids
+ * headings, but the model occasionally emits one anyway and it ruins
+ * previews.
+ */
+function stripLeadingHeading(content: string): string {
+  return content.replace(/^\s*#{1,6}\s+[^\n]+\n+/, "");
+}
+
+export function overviewPreview(content: string, maxWords: number = OVERVIEW_PREVIEW_WORDS): string {
+  const trimmed = stripLeadingHeading(content.trim());
+  if (!trimmed) return "";
+
+  const firstParaEnd = trimmed.indexOf("\n\n");
+  const firstPara = firstParaEnd === -1 ? trimmed : trimmed.slice(0, firstParaEnd);
+  const firstParaWords = firstPara.split(/\s+/).length;
+
+  if (firstParaWords <= maxWords) return firstPara;
+
+  const words = trimmed.split(/\s+/);
+  if (words.length <= maxWords) return trimmed;
+  return words.slice(0, maxWords).join(" ") + "…";
+}

--- a/plugins/claude/releases/README.md
+++ b/plugins/claude/releases/README.md
@@ -45,7 +45,10 @@ Return the canonical `CHANGELOG.md` (or `CHANGES`/`HISTORY`/`RELEASES`/`NEWS`) s
 List all indexed organizations, with optional search.
 
 ### get_organization
-Get detailed information about a single organization.
+Get detailed information about a single organization. Includes a short preview of the AI-generated overview when one exists, with a stale warning if it's older than 30 days.
+
+### get_organization_overview
+Read the full AI-generated overview for an organization — a short briefing that distills recent changelog activity into themed sections.
 
 ### list_products
 List products, optionally scoped to one organization.

--- a/plugins/claude/releases/skills/releases-cli/references/admin.md
+++ b/plugins/claude/releases/skills/releases-cli/references/admin.md
@@ -104,7 +104,8 @@ releases admin source check next-js     # one source
 ```bash
 releases admin org add "Vercel" --category developer-tools --tags typescript,edge
 releases admin org list                                   # summary view
-releases admin org show vercel                            # full details (accounts, tags, sources, products, aliases)
+releases admin org show vercel                            # full details (overview shown as ~80-word preview)
+releases org overview vercel                              # full AI-generated overview (public read)
 releases admin org edit vercel --category developer-tools
 releases admin org link vercel --platform github --handle vercel
 releases admin org tag add vercel react serverless

--- a/src/cli/commands/org.ts
+++ b/src/cli/commands/org.ts
@@ -13,6 +13,13 @@ import { logger } from "@releases/lib/logger";
 import { orgNotFound } from "../suggest.js";
 import { toSlug } from "@releases/core/slug";
 import { isValidCategory, CATEGORIES } from "@releases/core/categories";
+import { timeAgo } from "@releases/core/dates";
+import {
+  OVERVIEW_STALE_DAYS,
+  overviewAgeDays,
+  isOverviewStale,
+  overviewPreview,
+} from "@releases/core/overview";
 
 export function registerOrgCommand(program: Command) {
   const org = program
@@ -166,10 +173,74 @@ export function registerOrgCommand(program: Command) {
       }
 
       if (overview?.content) {
+        const preview = overviewPreview(stripAnsi(overview.content));
+        const stale = overview.generatedAt ? isOverviewStale(overview.generatedAt) : false;
+        const generatedHint = overview.generatedAt
+          ? chalk.dim(`generated ${timeAgo(overview.generatedAt) ?? "?"}`)
+          : "";
+
         console.log();
-        console.log(chalk.bold("Overview:"));
-        console.log(stripAnsi(overview.content));
+        console.log(`${chalk.bold("Overview")}  ${generatedHint}`);
+        if (stale) {
+          console.log(chalk.yellow(`  ⚠ Overview is older than ${OVERVIEW_STALE_DAYS} days — may not reflect recent releases.`));
+        }
+        console.log(preview);
+        console.log(chalk.dim(`\n  Full overview: releases org overview ${found.slug}`));
       }
+    });
+
+  // ── org overview ──
+  org
+    .command("overview")
+    .description("Print the full AI-generated overview for an organization")
+    .argument("<identifier>", "Org slug, domain, name, or account handle")
+    .option("--json", "Output as JSON")
+    .addHelpText("after", `
+Examples:
+  releases org overview acme
+  releases org overview acme --json`)
+    .action(async (identifier: string, opts: { json?: boolean }) => {
+      const found = await findOrg(identifier);
+      if (!found) return orgNotFound(identifier);
+
+      const overview = await getOverview("org", found.slug).catch(() => null);
+
+      if (!overview?.content) {
+        if (opts.json) {
+          console.log(JSON.stringify({ org: found.slug, overview: null }, null, 2));
+        } else {
+          console.log(chalk.yellow(`No overview available for ${found.name}.`));
+        }
+        return;
+      }
+
+      const stale = overview.generatedAt ? isOverviewStale(overview.generatedAt) : false;
+      const ageDays = overview.generatedAt ? overviewAgeDays(overview.generatedAt) : null;
+
+      if (opts.json) {
+        console.log(JSON.stringify({
+          org: found.slug,
+          name: found.name,
+          generatedAt: overview.generatedAt,
+          updatedAt: overview.updatedAt,
+          lastContributingReleaseAt: overview.lastContributingReleaseAt,
+          releaseCount: overview.releaseCount,
+          stale,
+          ageDays,
+          content: overview.content,
+        }, null, 2));
+        return;
+      }
+
+      console.log(chalk.bold(`${found.name} — overview`));
+      if (overview.generatedAt) {
+        console.log(chalk.dim(`  generated ${timeAgo(overview.generatedAt) ?? "?"} · ${overview.releaseCount} releases`));
+      }
+      if (stale) {
+        console.log(chalk.yellow(`  ⚠ Overview is older than ${OVERVIEW_STALE_DAYS} days — may not reflect recent releases.`));
+      }
+      console.log();
+      console.log(stripAnsi(overview.content));
     });
 
   // ── org edit ──

--- a/tests/unit/overview.test.ts
+++ b/tests/unit/overview.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "bun:test";
+import {
+  OVERVIEW_STALE_DAYS,
+  isOverviewStale,
+  overviewAgeDays,
+  overviewPreview,
+} from "@buildinternet/releases-core/overview";
+
+const DAY = 24 * 60 * 60 * 1000;
+
+describe("overviewAgeDays", () => {
+  it("returns 0 when generatedAt is now", () => {
+    const now = Date.now();
+    expect(overviewAgeDays(new Date(now).toISOString(), now)).toBe(0);
+  });
+
+  it("rounds down to whole days", () => {
+    const now = Date.now();
+    const generated = new Date(now - 5 * DAY - 60_000).toISOString();
+    expect(overviewAgeDays(generated, now)).toBe(5);
+  });
+});
+
+describe("isOverviewStale", () => {
+  it("returns false at exactly the threshold", () => {
+    const now = Date.now();
+    const generated = new Date(now - OVERVIEW_STALE_DAYS * DAY).toISOString();
+    expect(isOverviewStale(generated, now)).toBe(false);
+  });
+
+  it("returns true beyond the threshold", () => {
+    const now = Date.now();
+    const generated = new Date(now - (OVERVIEW_STALE_DAYS + 1) * DAY - 60_000).toISOString();
+    expect(isOverviewStale(generated, now)).toBe(true);
+  });
+});
+
+describe("overviewPreview", () => {
+  it("returns the input untouched when shorter than maxWords", () => {
+    expect(overviewPreview("Short single paragraph.", 80)).toBe("Short single paragraph.");
+  });
+
+  it("returns the first paragraph when it fits", () => {
+    const content = "First paragraph here.\n\nSecond paragraph follows.";
+    expect(overviewPreview(content, 80)).toBe("First paragraph here.");
+  });
+
+  it("truncates with ellipsis when first paragraph exceeds maxWords", () => {
+    const long = "word ".repeat(120).trim();
+    const result = overviewPreview(long, 10);
+    expect(result.endsWith("…")).toBe(true);
+    expect(result.split(/\s+/)).toHaveLength(10);
+  });
+
+  it("returns empty string for blank content", () => {
+    expect(overviewPreview("   ")).toBe("");
+  });
+
+  it("strips a leading markdown heading before previewing", () => {
+    const content = "# Some Heading\n\nFirst real paragraph.\n\nSecond paragraph.";
+    expect(overviewPreview(content, 80)).toBe("First real paragraph.");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a short overview preview (first ~80 words) inline in `releases org show <slug>` with a generated-at hint and a staleness warning past 30 days.
- New `releases org overview <slug>` (public read, no auth) prints the full AI-generated overview body with the same staleness signal.
- Introduces `@buildinternet/releases-core/overview` with shared helpers (`OVERVIEW_STALE_DAYS`, `overviewAgeDays`, `isOverviewStale`, `overviewPreview`) so the CLI and the upstream MCP server stay in sync.

Companion change in the monorepo (tightens the generation prompt + mirrors the same surfacing in MCP and the web): _link to follow_.

## Test plan

- [ ] `bun test tests/unit/overview.test.ts`
- [ ] `bun test` (full suite)
- [ ] `releases org show vercel` — preview, generated date, hint visible
- [ ] `releases org overview vercel` — full body
- [ ] `releases org overview <slug-without-overview>` — graceful "no overview" message
- [ ] `releases org show <very-stale-slug>` — `⚠ older than 30 days` warning shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)