### PR TITLE
fix(cli): shared JSON output contract for `list` (#24)

### DIFF
--- a/.changeset/fix-list-json-contract.md
+++ b/.changeset/fix-list-json-contract.md
@@ -1,0 +1,23 @@
+---
+"@buildinternet/releases": minor
+"@buildinternet/releases-darwin-arm64": minor
+"@buildinternet/releases-darwin-x64": minor
+"@buildinternet/releases-linux-arm64": minor
+"@buildinternet/releases-linux-x64": minor
+"@buildinternet/releases-core": minor
+"@buildinternet/releases-lib": minor
+"@buildinternet/releases-skills": minor
+---
+
+**CLI JSON contract: shared envelope, parsed metadata, truncation warnings**
+
+`releases list --json` now returns a consistent `{ items, pagination }` envelope whether or not `--limit` is passed, parses `metadata` into a nested object (no more `.metadata | fromjson?` in jq), and emits a stderr warning when results may be truncated.
+
+- **New shared types** in `@buildinternet/releases-core/cli-contracts`: `ListResponse<T>`, `Pagination`, `DEFAULT_PAGE_SIZE`, `computePagination()`, `parseMetadataField()`, `formatTruncationWarning()`. Single source of truth for the CLI's `--json` output shape.
+- **Default page size is now 500** (previously 100, the API's silent default) so a default `releases list --json` call returns 5× more rows before any risk of truncation. Explicit `--limit` still wins.
+- **Metadata fields are parsed** into nested objects in `--json` output for both the list view and single-source detail view.
+- **Stderr truncation warning** when no `--limit` was passed and `hasMore` is true — no more silent loss of rows.
+- **`--flat` flag** returns the legacy bare-array shape for scripts still tied to it. Not recommended; use the envelope.
+- **Server-side pagination** — `--limit` and `--page` are now passed through to the API instead of applied client-side to an already-truncated result set.
+
+Fixes buildinternet/releases-cli#24 (CLI side). An API-side follow-up will add an opt-in envelope response so `totalItems` can be populated for every page; until then `totalItems` is only set when the tail of the list is reached.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ bun test                      # bun test
 - Admin commands under `releases admin` are gated at CLI startup: missing `RELEASED_API_KEY` errors out before Commander dispatch.
 - IDs over slugs everywhere. Every `<identifier>` arg accepts `org_…`, `src_…`, `prod_…`, `rel_…`, or a slug.
 - `--json` supported on every reader command. Admin commands support it where it makes sense.
+- `--json` list responses return `{ items, pagination }` via the shared `ListResponse<T>` contract in `@buildinternet/releases-core/cli-contracts`. Pagination carries `{ page, pageSize, returned, hasMore }` plus `totalItems`/`totalPages` once the tail has been seen. When a default call returns a full page and more exists, the CLI also emits a stderr truncation warning so scripts don't silently miss rows. `metadata` fields are parsed into nested objects — don't call `JSON.parse` again. Use `parseMetadataField()` from the same module when adding new commands that surface metadata.
 - `daysAgoIso()` from `@releases/core/dates` for cutoff math. Don't roll your own.
 - Org overviews: `releases org show <slug>` includes a short overview preview; `releases org overview <slug>` is the unauthenticated public reader for the full body. Both surfaces add a `⚠ older than 30 days` warning past `OVERVIEW_STALE_DAYS` (from `@buildinternet/releases-core/overview`).
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ releases org overview vercel    # full AI-generated overview for an org
 releases stats
 ```
 
-Every reader command supports `--json` for machine-readable output. `org show` includes a short overview preview (with a stale warning when more than 30 days old); `org overview <slug>` prints the full body.
+Every reader command supports `--json` for machine-readable output. List commands emit a `{ items, pagination }` envelope — parse with `jq '.items[]'`, and check `.pagination.hasMore` before assuming you've seen every row. Nested `metadata` fields are returned as parsed objects (no `fromjson` needed). `org show` includes a short overview preview (with a stale warning when more than 30 days old); `org overview <slug>` prints the full body.
 
 ### MCP
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,7 +17,8 @@
     "./overview": "./src/overview.ts",
     "./id": "./src/id.ts",
     "./slug": "./src/slug.ts",
-    "./tokens": "./src/tokens.ts"
+    "./tokens": "./src/tokens.ts",
+    "./cli-contracts": "./src/cli-contracts.ts"
   },
   "files": [
     "src",

--- a/packages/core/src/cli-contracts.ts
+++ b/packages/core/src/cli-contracts.ts
@@ -56,20 +56,30 @@ export function computePagination(opts: ComputePaginationOpts): Pagination {
   return { page, pageSize, returned, hasMore: returned === pageSize };
 }
 
-export type MetadataValue = string | Record<string, unknown> | null | undefined;
+type MetadataInput = string | Record<string, unknown> | null | undefined;
 
 /**
  * Parse a metadata field that may be a JSON-encoded string into its nested
  * object form. No-ops for objects, null, or invalid JSON (preserves the
  * original value so we never lose data on a malformed row).
  */
-export function parseMetadataField(value: MetadataValue): MetadataValue {
+export function parseMetadataField(value: MetadataInput): MetadataInput {
   if (typeof value !== "string") return value;
   try {
     return JSON.parse(value);
   } catch {
     return value;
   }
+}
+
+/**
+ * Narrow variant of `parseMetadataField` for callers that only care about the
+ * object shape (e.g. checking whether a key exists). Returns null for strings
+ * that fail to parse, for primitives, and for null/undefined inputs.
+ */
+export function parseMetadataObject(value: MetadataInput): Record<string, unknown> | null {
+  const parsed = parseMetadataField(value);
+  return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : null;
 }
 
 /**

--- a/packages/core/src/cli-contracts.ts
+++ b/packages/core/src/cli-contracts.ts
@@ -1,0 +1,90 @@
+/**
+ * Shared output-contract types for the `--json` surface of the `releases` CLI.
+ *
+ * The CLI is an implicit public API for scripts and AI agents. This module is
+ * the single source of truth for the shape of paginated list responses, so the
+ * OSS CLI (buildinternet/releases-cli) and the monorepo dev CLI
+ * (buildinternet/releases) cannot drift on pagination semantics or envelope
+ * fields.
+ *
+ * See buildinternet/releases-cli#24 for the motivating incident.
+ */
+
+/** Matches the API worker's hard cap so a single default request returns the
+ *  broadest safe window. */
+export const DEFAULT_PAGE_SIZE = 500;
+
+export interface Pagination {
+  page: number;
+  pageSize: number;
+  /** Number of items on THIS page. Always present. */
+  returned: number;
+  /** Total items across all pages. Optional — only populated when the backing
+   *  API reports totals. Absent means "total unknown; use hasMore instead." */
+  totalItems?: number;
+  /** Total page count. Optional; absent when `totalItems` is. */
+  totalPages?: number;
+  /** True when more results may exist beyond this page. Conservative: when
+   *  totals are unknown, derived from `returned === pageSize`. */
+  hasMore: boolean;
+}
+
+export interface ListResponse<T> {
+  items: T[];
+  pagination: Pagination;
+}
+
+export interface ComputePaginationOpts {
+  page: number;
+  pageSize: number;
+  returned: number;
+  totalItems?: number;
+}
+
+export function computePagination(opts: ComputePaginationOpts): Pagination {
+  const { page, pageSize, returned, totalItems } = opts;
+  if (totalItems != null) {
+    return {
+      page,
+      pageSize,
+      returned,
+      totalItems,
+      totalPages: Math.max(1, Math.ceil(totalItems / pageSize)),
+      hasMore: page * pageSize < totalItems,
+    };
+  }
+  return { page, pageSize, returned, hasMore: returned === pageSize };
+}
+
+export type MetadataValue = string | Record<string, unknown> | null | undefined;
+
+/**
+ * Parse a metadata field that may be a JSON-encoded string into its nested
+ * object form. No-ops for objects, null, or invalid JSON (preserves the
+ * original value so we never lose data on a malformed row).
+ */
+export function parseMetadataField(value: MetadataValue): MetadataValue {
+  if (typeof value !== "string") return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+/**
+ * Format a stderr warning explaining why a large JSON list response may be
+ * truncated, with the exact flags a caller should pass to paginate.
+ *
+ * Returns the line to print; the caller decides where (stderr, log, etc).
+ */
+export function formatTruncationWarning(opts: {
+  returned: number;
+  pageSize: number;
+  commandExample: string;
+}): string {
+  return (
+    `warning: results may be truncated (${opts.returned} items returned, page size ${opts.pageSize}). ` +
+    `Paginate explicitly: ${opts.commandExample}`
+  );
+}

--- a/plugins/claude/releases/skills/releases-cli/references/reader.md
+++ b/plugins/claude/releases/skills/releases-cli/references/reader.md
@@ -48,7 +48,16 @@ releases list --category ai            # filter by category
 releases list --json                   # machine-readable output
 releases list --json --compact         # lightweight JSON (id, slug, name, type, org, date)
 releases list --json --limit 20 --page 2  # pagination (server-side)
+releases list --json --flat            # legacy bare-array shape (discouraged)
 ```
+
+`--json` always emits `{ items, pagination }`. The `pagination` object carries
+`{ page, pageSize, returned, hasMore }` and includes `totalItems`/`totalPages`
+once the last page has been seen. When a default (no-`--limit`) call returns a
+page worth of items and `hasMore: true`, the CLI also emits a stderr warning so
+scripts don't silently miss rows. `metadata` is a parsed object on every row
+(no `fromjson` required). Pass `--flat` to revert to the legacy bare-array
+shape when you have existing scripts that expect it.
 
 Aliased as `releases admin source list` for discoverability within admin workflows.
 

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -219,6 +219,8 @@ export async function listSourcesWithOrg(opts?: {
   query?: string;
   includeHidden?: boolean;
   category?: string;
+  limit?: number;
+  page?: number;
 }): Promise<SourceWithOrg[]> {
   const params = new URLSearchParams();
   if (opts?.orgSlug) params.set("orgSlug", opts.orgSlug);
@@ -227,6 +229,8 @@ export async function listSourcesWithOrg(opts?: {
   if (opts?.query) params.set("query", opts.query);
   if (opts?.includeHidden) params.set("include_hidden", "true");
   if (opts?.category) params.set("category", opts.category);
+  if (opts?.limit != null) params.set("limit", String(opts.limit));
+  if (opts?.page != null) params.set("page", String(opts.page));
   const qs = params.toString();
 
   return apiFetch<SourceWithOrg[]>(`/v1/sources${qs ? `?${qs}` : ""}`);

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -4,18 +4,28 @@ import Table from "cli-table3";
 import { listSourcesWithOrg, findSource } from "../../api/client.js";
 import { sourceNotFound } from "../suggest.js";
 import { stripAnsi } from "../../lib/sanitize.js";
+import {
+  DEFAULT_PAGE_SIZE,
+  computePagination,
+  parseMetadataField,
+  formatTruncationWarning,
+  type ListResponse,
+} from "@buildinternet/releases-core/cli-contracts";
 
 function getFetchMethod(type: string, metadata: string | null): string {
   if (type === "github") return "github";
   if (type === "feed") return "feed";
-  if (metadata) {
-    try {
-      const meta = JSON.parse(metadata);
-      if (meta.feedUrl) return "feed";
-      if (meta.noFeedFound) return "ai";
-    } catch { /* malformed */ }
+  const meta = parseMetadataField(metadata);
+  if (meta && typeof meta === "object") {
+    const m = meta as Record<string, unknown>;
+    if (m.feedUrl) return "feed";
+    if (m.noFeedFound) return "ai";
   }
   return "-";
+}
+
+function paginateExample(json: boolean): string {
+  return `releases list${json ? " --json" : ""} --limit <n> --page <p>`;
 }
 
 export function registerListCommand(program: Command) {
@@ -31,18 +41,16 @@ export function registerListCommand(program: Command) {
     .option("--category <category>", "Filter by organization or product category")
     .option("--include-disabled", "Include disabled sources in the list")
     .option("--compact", "Return lightweight fields only")
-    .option("--limit <n>", "Limit the number of results")
+    .option("--limit <n>", `Limit the number of results (default ${DEFAULT_PAGE_SIZE})`)
     .option("--page <n>", "Page number for paginated results")
-    .action(async (slug: string | undefined, opts: { json?: boolean; org?: string; product?: string; category?: string; hasFeed?: boolean; query?: string; includeDisabled?: boolean; compact?: boolean; limit?: string; page?: string }) => {
+    .option("--flat", "Legacy: return a bare array instead of the paginated envelope (--json only)")
+    .action(async (slug: string | undefined, opts: { json?: boolean; org?: string; product?: string; category?: string; hasFeed?: boolean; query?: string; includeDisabled?: boolean; compact?: boolean; limit?: string; page?: string; flat?: boolean }) => {
       if (slug) {
         const source = await findSource(slug);
         if (!source) return sourceNotFound(slug);
         if (opts.json) {
           const method = getFetchMethod(source.type, source.metadata ?? null);
-          const parsed: Record<string, unknown> = { ...source, method };
-          if (typeof parsed.metadata === "string") {
-            try { parsed.metadata = JSON.parse(parsed.metadata as string); } catch {}
-          }
+          const parsed: Record<string, unknown> = { ...source, method, metadata: parseMetadataField(source.metadata) };
           console.log(JSON.stringify(parsed, null, 2));
           return;
         }
@@ -63,54 +71,78 @@ export function registerListCommand(program: Command) {
         return;
       }
 
-      const allSources = await listSourcesWithOrg({
+      const limitOpt = opts.limit ? parseInt(opts.limit, 10) : undefined;
+      const explicitLimit = limitOpt != null && limitOpt > 0;
+      const pageSize = explicitLimit ? limitOpt : DEFAULT_PAGE_SIZE;
+      const page = opts.page ? Math.max(1, parseInt(opts.page, 10)) : 1;
+
+      const pageItems = await listSourcesWithOrg({
         orgSlug: opts.org,
         productSlug: opts.product,
         category: opts.category,
         hasFeed: opts.hasFeed,
         query: opts.query,
         includeHidden: opts.includeDisabled,
+        limit: pageSize,
+        page,
       });
 
-      if (allSources.length === 0) {
-        if (opts.json) console.log(JSON.stringify([], null, 2));
-        else console.log("No sources configured.");
+      // Total is only knowable when the returned count falls short of a full
+      // page. Drop once the API returns pagination envelopes.
+      const knownTotalOnTail = pageItems.length < pageSize
+        ? (page - 1) * pageSize + pageItems.length
+        : undefined;
+
+      if (pageItems.length === 0 && page === 1 && !opts.json) {
+        console.log("No sources configured.");
         return;
       }
 
       if (opts.json) {
-        let items: Record<string, unknown>[];
-        if (opts.compact) {
-          items = allSources.map((row) => ({
-            id: row.id,
-            slug: row.slug,
-            name: row.name,
-            type: row.type,
-            method: getFetchMethod(row.type, row.metadata),
-            orgName: row.orgName ?? null,
-            productName: row.productName ?? null,
-            releaseCount: row.releaseCount,
-            latestDate: row.latestDate ?? null,
-            lastFetchedAt: row.lastFetchedAt ?? null,
-          }));
-        } else {
-          items = allSources.map((row) => ({
+        const items: Record<string, unknown>[] = pageItems.map((row) => {
+          if (opts.compact) {
+            return {
+              id: row.id,
+              slug: row.slug,
+              name: row.name,
+              type: row.type,
+              method: getFetchMethod(row.type, row.metadata),
+              orgName: row.orgName ?? null,
+              productName: row.productName ?? null,
+              releaseCount: row.releaseCount,
+              latestDate: row.latestDate ?? null,
+              lastFetchedAt: row.lastFetchedAt ?? null,
+            };
+          }
+          return {
             ...row,
             method: getFetchMethod(row.type, row.metadata),
-          }));
-        }
-        const limit = opts.limit ? parseInt(opts.limit, 10) : undefined;
-        if (limit && limit > 0) {
-          const page = opts.page ? parseInt(opts.page, 10) : 1;
-          const start = (page - 1) * limit;
-          const slice = items.slice(start, start + limit);
-          const totalPages = Math.ceil(items.length / limit);
-          console.log(JSON.stringify({
-            items: slice,
-            pagination: { page, pageSize: limit, totalPages, totalItems: items.length },
-          }, null, 2));
-        } else {
+            metadata: parseMetadataField(row.metadata),
+          };
+        });
+
+        const pagination = computePagination({
+          page,
+          pageSize,
+          returned: items.length,
+          totalItems: knownTotalOnTail,
+        });
+
+        const warnTruncated = !explicitLimit && pagination.hasMore;
+
+        if (opts.flat) {
           console.log(JSON.stringify(items, null, 2));
+        } else {
+          const response: ListResponse<Record<string, unknown>> = { items, pagination };
+          console.log(JSON.stringify(response, null, 2));
+        }
+
+        if (warnTruncated) {
+          console.error(formatTruncationWarning({
+            returned: items.length,
+            pageSize,
+            commandExample: paginateExample(true),
+          }));
         }
         return;
       }
@@ -119,7 +151,7 @@ export function registerListCommand(program: Command) {
         head: ["Name", "Slug", "Type", "Method", "URL", "Org", "Product", "Last Fetched"],
       });
 
-      for (const row of allSources) {
+      for (const row of pageItems) {
         const method = getFetchMethod(row.type, row.metadata);
         const name = stripAnsi(row.name);
         table.push([
@@ -135,5 +167,12 @@ export function registerListCommand(program: Command) {
       }
 
       console.log(table.toString());
+      if (!explicitLimit && pageItems.length === pageSize) {
+        console.error(formatTruncationWarning({
+          returned: pageItems.length,
+          pageSize,
+          commandExample: paginateExample(false),
+        }));
+      }
     });
 }

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -7,20 +7,16 @@ import { stripAnsi } from "../../lib/sanitize.js";
 import {
   DEFAULT_PAGE_SIZE,
   computePagination,
-  parseMetadataField,
+  parseMetadataObject,
   formatTruncationWarning,
   type ListResponse,
 } from "@buildinternet/releases-core/cli-contracts";
 
-function getFetchMethod(type: string, metadata: string | null): string {
+function getFetchMethod(type: string, meta: Record<string, unknown> | null): string {
   if (type === "github") return "github";
   if (type === "feed") return "feed";
-  const meta = parseMetadataField(metadata);
-  if (meta && typeof meta === "object") {
-    const m = meta as Record<string, unknown>;
-    if (m.feedUrl) return "feed";
-    if (m.noFeedFound) return "ai";
-  }
+  if (meta?.feedUrl) return "feed";
+  if (meta?.noFeedFound) return "ai";
   return "-";
 }
 
@@ -48,15 +44,15 @@ export function registerListCommand(program: Command) {
       if (slug) {
         const source = await findSource(slug);
         if (!source) return sourceNotFound(slug);
+        const parsedMeta = parseMetadataObject(source.metadata);
+        const method = getFetchMethod(source.type, parsedMeta);
         if (opts.json) {
-          const method = getFetchMethod(source.type, source.metadata ?? null);
-          const parsed: Record<string, unknown> = { ...source, method, metadata: parseMetadataField(source.metadata) };
+          const parsed: Record<string, unknown> = { ...source, method, metadata: parsedMeta ?? source.metadata };
           console.log(JSON.stringify(parsed, null, 2));
           return;
         }
         const label = (key: string, val: string | null | undefined) =>
           `  ${chalk.bold(key.padEnd(16))} ${val ?? chalk.dim("—")}`;
-        const method = getFetchMethod(source.type, source.metadata ?? null);
         console.log(chalk.bold(`\n${stripAnsi(source.name)}\n`));
         console.log(label("Slug", source.slug));
         console.log(label("Type", source.type));
@@ -87,8 +83,7 @@ export function registerListCommand(program: Command) {
         page,
       });
 
-      // Total is only knowable when the returned count falls short of a full
-      // page. Drop once the API returns pagination envelopes.
+      // Drop once the API returns pagination envelopes with totals.
       const knownTotalOnTail = pageItems.length < pageSize
         ? (page - 1) * pageSize + pageItems.length
         : undefined;
@@ -100,13 +95,15 @@ export function registerListCommand(program: Command) {
 
       if (opts.json) {
         const items: Record<string, unknown>[] = pageItems.map((row) => {
+          const parsedMeta = parseMetadataObject(row.metadata);
+          const method = getFetchMethod(row.type, parsedMeta);
           if (opts.compact) {
             return {
               id: row.id,
               slug: row.slug,
               name: row.name,
               type: row.type,
-              method: getFetchMethod(row.type, row.metadata),
+              method,
               orgName: row.orgName ?? null,
               productName: row.productName ?? null,
               releaseCount: row.releaseCount,
@@ -116,8 +113,8 @@ export function registerListCommand(program: Command) {
           }
           return {
             ...row,
-            method: getFetchMethod(row.type, row.metadata),
-            metadata: parseMetadataField(row.metadata),
+            method,
+            metadata: parsedMeta ?? row.metadata,
           };
         });
 
@@ -152,7 +149,7 @@ export function registerListCommand(program: Command) {
       });
 
       for (const row of pageItems) {
-        const method = getFetchMethod(row.type, row.metadata);
+        const method = getFetchMethod(row.type, parseMetadataObject(row.metadata));
         const name = stripAnsi(row.name);
         table.push([
           row.isPrimary ? `${name} ${chalk.yellow("\u2605")}` : name,

--- a/tests/unit/cli-contracts.test.ts
+++ b/tests/unit/cli-contracts.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "bun:test";
+import {
+  DEFAULT_PAGE_SIZE,
+  computePagination,
+  parseMetadataField,
+  formatTruncationWarning,
+} from "@buildinternet/releases-core/cli-contracts";
+
+describe("cli-contracts: computePagination", () => {
+  it("populates totals when totalItems is provided", () => {
+    const p = computePagination({ page: 2, pageSize: 50, returned: 50, totalItems: 233 });
+    expect(p.page).toBe(2);
+    expect(p.pageSize).toBe(50);
+    expect(p.returned).toBe(50);
+    expect(p.totalItems).toBe(233);
+    expect(p.totalPages).toBe(5);
+    expect(p.hasMore).toBe(true);
+  });
+
+  it("derives hasMore from returned === pageSize when totals unknown", () => {
+    const p = computePagination({ page: 1, pageSize: 100, returned: 100 });
+    expect(p.hasMore).toBe(true);
+    expect(p.totalItems).toBeUndefined();
+    expect(p.totalPages).toBeUndefined();
+  });
+
+  it("hasMore is false when returned < pageSize (unknown totals)", () => {
+    const p = computePagination({ page: 1, pageSize: 100, returned: 17 });
+    expect(p.hasMore).toBe(false);
+  });
+
+  it("hasMore is false on the exact last page when totals known", () => {
+    const p = computePagination({ page: 5, pageSize: 50, returned: 33, totalItems: 233 });
+    expect(p.hasMore).toBe(false);
+    expect(p.totalPages).toBe(5);
+  });
+
+  it("empty result with known zero total has totalPages 1 (not 0)", () => {
+    const p = computePagination({ page: 1, pageSize: 100, returned: 0, totalItems: 0 });
+    expect(p.totalPages).toBe(1);
+    expect(p.hasMore).toBe(false);
+  });
+});
+
+describe("cli-contracts: parseMetadataField", () => {
+  it("parses a JSON string into an object", () => {
+    const result = parseMetadataField('{"fetchUrl":"https://example.com","feedEtag":"abc"}');
+    expect(result).toEqual({ fetchUrl: "https://example.com", feedEtag: "abc" });
+  });
+
+  it("returns the original string if not valid JSON", () => {
+    const result = parseMetadataField("not json");
+    expect(result).toBe("not json");
+  });
+
+  it("passes through non-string values unchanged", () => {
+    expect(parseMetadataField({ foo: "bar" })).toEqual({ foo: "bar" });
+    expect(parseMetadataField(null)).toBeNull();
+    expect(parseMetadataField(undefined)).toBeUndefined();
+  });
+});
+
+describe("cli-contracts: formatTruncationWarning", () => {
+  it("includes the returned count, page size, and example", () => {
+    const msg = formatTruncationWarning({
+      returned: 500,
+      pageSize: 500,
+      commandExample: "releases list --json --limit <n> --page <p>",
+    });
+    expect(msg).toContain("500 items returned");
+    expect(msg).toContain("page size 500");
+    expect(msg).toContain("releases list --json --limit <n> --page <p>");
+  });
+});
+
+describe("cli-contracts: DEFAULT_PAGE_SIZE", () => {
+  it("matches the API hard cap so a single default call maximizes the window", () => {
+    expect(DEFAULT_PAGE_SIZE).toBe(500);
+  });
+});

--- a/tests/unit/cli-contracts.test.ts
+++ b/tests/unit/cli-contracts.test.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_PAGE_SIZE,
   computePagination,
   parseMetadataField,
+  parseMetadataObject,
   formatTruncationWarning,
 } from "@buildinternet/releases-core/cli-contracts";
 
@@ -57,6 +58,32 @@ describe("cli-contracts: parseMetadataField", () => {
     expect(parseMetadataField({ foo: "bar" })).toEqual({ foo: "bar" });
     expect(parseMetadataField(null)).toBeNull();
     expect(parseMetadataField(undefined)).toBeUndefined();
+  });
+});
+
+describe("cli-contracts: parseMetadataObject", () => {
+  it("returns the parsed object for a valid JSON string", () => {
+    const result = parseMetadataObject('{"fetchUrl":"https://example.com"}');
+    expect(result).toEqual({ fetchUrl: "https://example.com" });
+  });
+
+  it("returns null for malformed JSON", () => {
+    expect(parseMetadataObject("not json")).toBeNull();
+  });
+
+  it("returns null for a JSON string that parses to a non-object", () => {
+    expect(parseMetadataObject('"a string"')).toBeNull();
+    expect(parseMetadataObject("42")).toBeNull();
+  });
+
+  it("returns null for null/undefined input", () => {
+    expect(parseMetadataObject(null)).toBeNull();
+    expect(parseMetadataObject(undefined)).toBeNull();
+  });
+
+  it("returns the same object for already-parsed input", () => {
+    const obj = { fetchUrl: "x" };
+    expect(parseMetadataObject(obj)).toBe(obj);
   });
 });
 


### PR DESCRIPTION
Closes #24 (CLI side — an API-side follow-up completes #24).

## Summary

`releases list --json` was silently capping results at 100 rows with no indication, returning two different shapes (bare array vs envelope) depending on whether `--limit` was passed, and returning `metadata` as a JSON-encoded string nested inside JSON output. Together these caused an agent session to confidently report a wrong count to the user (see #24 for the trigger incident).

This PR collapses the `--json` list surface onto a single `{ items, pagination }` envelope, parses nested `metadata` into objects, warns on stderr when results may be silently truncated, and anchors it all in a shared contract module so the OSS CLI and the monorepo dev CLI can't drift again.

## Changes

- **New** `packages/core/src/cli-contracts.ts` — `ListResponse<T>`, `Pagination`, `DEFAULT_PAGE_SIZE` (500), `computePagination`, `parseMetadataField`, `formatTruncationWarning`. Exported as `@buildinternet/releases-core/cli-contracts`.
- **`releases list --json`** always emits `{ items, pagination }`. `--flat` preserves the legacy bare-array shape for scripts that need it.
- **Default page size** is now 500 (API hard cap) instead of the API's silent default of 100 — single default call returns 5× more rows before any risk of truncation.
- **`metadata` is parsed** into a nested object on every row and in the single-source detail view. No more `.metadata | fromjson?` in jq.
- **Stderr truncation warning** fires when a default call hits `hasMore: true`. No more silent data loss.
- **`listSourcesWithOrg`** plumbs `limit`/`page` through to the server so pagination works beyond page 1.
- Docs updated: README, AGENTS.md, and the `releases-cli` skill reader reference.
- Changeset added (minor bump, all packages).

## Sample output

```json
{
  "items": [...],
  "pagination": {
    "page": 1,
    "pageSize": 500,
    "returned": 233,
    "totalItems": 233,
    "totalPages": 1,
    "hasMore": false
  }
}
```

When the tail hasn't been reached, `totalItems` and `totalPages` are omitted — `hasMore` is derived from `returned === pageSize`. An API-side follow-up will enable `totalItems` on every page.

## Trade-offs

- Changing the default `--json` shape from bare array to envelope is a breaking change for scripts that expect `[...]`. Pre-1.0 semver allows it, but `--flat` is available for callers that can't migrate immediately. The help text labels it "legacy."
- Default page size 500 means a bare `releases list --json` returns ~5× more data than before. In practice the API hard-caps at 500, so callers of the prior behavior were being silently cut off — this is strictly more correct.

## Test plan

- [x] `bun test` — 182 pass (+10 new for the contract helpers)
- [x] `bunx tsc --noEmit` — clean
- [x] Smoke: default `releases list --json` now returns all 233 remote sources (was 100)
- [x] Smoke: the original failing jq query `.items[] | select(.type == "agent")` finds `posthog-changelog` with parsed `metadata.fetchUrl`
- [x] Smoke: small `--limit` reports `hasMore: true` correctly; default call past the tail emits no warning
- [x] Smoke: `--flat` still returns a bare array; empty-result case emits a clean envelope
- [x] Smoke: non-JSON table view unchanged, emits truncation warning only when appropriate

## Follow-ups (in sequence)

1. **API envelope** (monorepo): add opt-in `?envelope=1` on `/v1/sources` so `totalItems` is populated on every page.
2. **`releases whoami`** — diagnostic command (issue #24 fix #4).
3. **Parity sweep**: update the monorepo dev CLI to consume `@buildinternet/releases-core/cli-contracts` too, so both CLIs share the contract.
4. Other items from #24 (`--count-by`, `--fields`) are quality-of-life and can wait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
