### PR TITLE
fix(cli): consume ?envelope=true for accurate pagination totals

### DIFF
--- a/.changeset/consume-api-envelope.md
+++ b/.changeset/consume-api-envelope.md
@@ -1,0 +1,14 @@
+---
+"@buildinternet/releases": patch
+"@buildinternet/releases-darwin-arm64": patch
+"@buildinternet/releases-darwin-x64": patch
+"@buildinternet/releases-linux-arm64": patch
+"@buildinternet/releases-linux-x64": patch
+---
+
+**`releases list --json` now surfaces accurate `totalItems` on every page**
+
+The API's `?envelope=true` response is now consumed end-to-end: `totalItems`, `totalPages`, and `hasMore` are populated on the first page as well as the tail, instead of only when the final page is reached. The stderr truncation warning on the table view now uses the API-returned `hasMore` instead of inferring from `returned === pageSize` (which flagged spuriously when totalItems was an exact multiple of pageSize).
+
+- `listSourcesWithOrg({ envelope: true })` returns `ListResponse<SourceWithOrg>` via a typed overload; existing bare-array callers (`check`, MCP) are untouched.
+- Closes the loop opened by the API's envelope support (buildinternet/releases#356).

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -12,6 +12,7 @@ import type {
   UsageStatsResponse, Session,
   EmbedBackfillResponse, EmbedStatusResponse, MediaItem,
 } from "./types.js";
+import type { ListResponse } from "@releases/core/cli-contracts";
 export type {
   SourceWithOrg, SourcePatchInput, ReleaseWithSource, StatsSummary,
   FetchLogEntry, LatestRelease, UsageBreakdownRow, UsageStatsResponse,
@@ -212,7 +213,7 @@ export async function unifiedSearch(
 
 // ── List sources with org ──
 
-export async function listSourcesWithOrg(opts?: {
+type ListSourcesOpts = {
   orgSlug?: string;
   productSlug?: string;
   hasFeed?: boolean;
@@ -221,7 +222,15 @@ export async function listSourcesWithOrg(opts?: {
   category?: string;
   limit?: number;
   page?: number;
-}): Promise<SourceWithOrg[]> {
+};
+
+export async function listSourcesWithOrg(opts?: ListSourcesOpts): Promise<SourceWithOrg[]>;
+export async function listSourcesWithOrg(
+  opts: ListSourcesOpts & { envelope: true },
+): Promise<ListResponse<SourceWithOrg>>;
+export async function listSourcesWithOrg(
+  opts?: ListSourcesOpts & { envelope?: boolean },
+): Promise<SourceWithOrg[] | ListResponse<SourceWithOrg>> {
   const params = new URLSearchParams();
   if (opts?.orgSlug) params.set("orgSlug", opts.orgSlug);
   if (opts?.productSlug) params.set("productSlug", opts.productSlug);
@@ -231,9 +240,10 @@ export async function listSourcesWithOrg(opts?: {
   if (opts?.category) params.set("category", opts.category);
   if (opts?.limit != null) params.set("limit", String(opts.limit));
   if (opts?.page != null) params.set("page", String(opts.page));
+  if (opts?.envelope) params.set("envelope", "true");
   const qs = params.toString();
 
-  return apiFetch<SourceWithOrg[]>(`/v1/sources${qs ? `?${qs}` : ""}`);
+  return apiFetch<SourceWithOrg[] | ListResponse<SourceWithOrg>>(`/v1/sources${qs ? `?${qs}` : ""}`);
 }
 
 // ── Stats ──

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -6,7 +6,6 @@ import { sourceNotFound } from "../suggest.js";
 import { stripAnsi } from "../../lib/sanitize.js";
 import {
   DEFAULT_PAGE_SIZE,
-  computePagination,
   parseMetadataObject,
   formatTruncationWarning,
   type ListResponse,
@@ -72,7 +71,7 @@ export function registerListCommand(program: Command) {
       const pageSize = explicitLimit ? limitOpt : DEFAULT_PAGE_SIZE;
       const page = opts.page ? Math.max(1, parseInt(opts.page, 10)) : 1;
 
-      const pageItems = await listSourcesWithOrg({
+      const { items: pageItems, pagination: apiPagination } = await listSourcesWithOrg({
         orgSlug: opts.org,
         productSlug: opts.product,
         category: opts.category,
@@ -81,12 +80,8 @@ export function registerListCommand(program: Command) {
         includeHidden: opts.includeDisabled,
         limit: pageSize,
         page,
+        envelope: true,
       });
-
-      // Drop once the API returns pagination envelopes with totals.
-      const knownTotalOnTail = pageItems.length < pageSize
-        ? (page - 1) * pageSize + pageItems.length
-        : undefined;
 
       if (pageItems.length === 0 && page === 1 && !opts.json) {
         console.log("No sources configured.");
@@ -118,19 +113,12 @@ export function registerListCommand(program: Command) {
           };
         });
 
-        const pagination = computePagination({
-          page,
-          pageSize,
-          returned: items.length,
-          totalItems: knownTotalOnTail,
-        });
-
-        const warnTruncated = !explicitLimit && pagination.hasMore;
+        const warnTruncated = !explicitLimit && apiPagination.hasMore;
 
         if (opts.flat) {
           console.log(JSON.stringify(items, null, 2));
         } else {
-          const response: ListResponse<Record<string, unknown>> = { items, pagination };
+          const response: ListResponse<Record<string, unknown>> = { items, pagination: apiPagination };
           console.log(JSON.stringify(response, null, 2));
         }
 
@@ -164,7 +152,7 @@ export function registerListCommand(program: Command) {
       }
 
       console.log(table.toString());
-      if (!explicitLimit && pageItems.length === pageSize) {
+      if (!explicitLimit && apiPagination.hasMore) {
         console.error(formatTruncationWarning({
           returned: pageItems.length,
           pageSize,

--- a/tests/unit/api-client.test.ts
+++ b/tests/unit/api-client.test.ts
@@ -144,4 +144,27 @@ describe("listSourcesWithOrg", () => {
     expect(capturedUrl).toContain("has_feed=true");
     expect(capturedUrl).toContain("category=ai");
   });
+
+  it("returns envelope with pagination totals when envelope=true", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = (async (url: string) => {
+      capturedUrl = url;
+      return new Response(
+        JSON.stringify({
+          items: [apiRow],
+          pagination: {
+            page: 2, pageSize: 50, returned: 1,
+            totalItems: 233, totalPages: 5, hasMore: true,
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }) as any;
+
+    const res = await client.listSourcesWithOrg({ envelope: true, limit: 50, page: 2 });
+    expect(capturedUrl).toContain("envelope=true");
+    expect(res.items).toHaveLength(1);
+    expect(res.pagination.totalItems).toBe(233);
+    expect(res.pagination.hasMore).toBe(true);
+  });
 });


### PR DESCRIPTION
Companion to [buildinternet/releases#356](https://github.com/buildinternet/releases/pull/356) (merged). Closes the loop on the CLI-DX work tracked in #24.

## Summary

`releases list --json` now pulls `totalItems` / `totalPages` / `hasMore` straight from the API's `?envelope=true` response instead of inferring them. Accurate on every page, not just the tail.

## Why

Before #356 shipped, the API only returned a bare array, so the CLI inferred `totalItems` only when `pageItems.length < pageSize` (i.e. once the caller had paged to the end). That left page 1 of a 233-item list with a missing `totalItems` and a truncation warning based on a heuristic — `returned === pageSize` flagged spuriously when `totalItems` happened to be an exact multiple of `pageSize`.

With #356 live, the API returns an authoritative `pagination` object on every page. This PR threads it through.

## Changes

- **`src/api/client.ts`** — `listSourcesWithOrg` now has TS overloads:
  - `listSourcesWithOrg(opts?): Promise<SourceWithOrg[]>` — unchanged for existing callers
  - `listSourcesWithOrg(opts & { envelope: true }): Promise<ListResponse<SourceWithOrg>>` — new envelope path
  - Existing bare-array callers (`check.ts`, `mcp/server.ts`) need no changes.
- **`src/cli/commands/list.ts`** — destructures `{ items, pagination }` from the envelope call. The JSON response now emits `apiPagination` directly (no re-computation — all fields come from the server). The table-view truncation warning now keys on `apiPagination.hasMore`.
- **`tests/unit/api-client.test.ts`** — new case mocks an envelope response and asserts `envelope=true` is sent and `totalItems`/`hasMore` are surfaced.

## Simplify pass

Caught one genuine finding: the JSON path was still calling `computePagination(...)` with `totalItems: apiPagination.totalItems`, re-deriving fields the API already returned. Removed the call entirely — the envelope *is* the pagination object. Removed the now-dead `computePagination` import.

## Test plan

- [x] `bun test` — 188 pass (+1 new)
- [x] `bunx tsc --noEmit` — clean
- [ ] Post-merge smoke: `releases list --json --limit 10 --page 1 | jq '.pagination.totalItems'` returns a real number (≠ null) from the first page, not only from the last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
