### PR TITLE
feat(cli): add `releases whoami` diagnostic command

### DIFF
--- a/.changeset/whoami-command.md
+++ b/.changeset/whoami-command.md
@@ -1,0 +1,18 @@
+---
+"@buildinternet/releases": minor
+"@buildinternet/releases-darwin-arm64": minor
+"@buildinternet/releases-darwin-x64": minor
+"@buildinternet/releases-linux-arm64": minor
+"@buildinternet/releases-linux-x64": minor
+---
+
+**Add `releases whoami` — mode, API URL, and auth diagnostic**
+
+New top-level command that reports how the CLI is configured:
+
+- Current CLI version
+- API URL and whether it's the default (`https://api.releases.sh`) or overridden via `RELEASED_API_URL`
+- Mode (`public` vs `admin`) based on whether `RELEASED_API_KEY` is set
+- Redacted API key hint (first 4 + last 4 characters) so users can confirm which key is active without leaking it
+- Optional `--check` flag that probes the API — a public read in public mode, an auth-gated read in admin mode, so an invalid key surfaces as a 401 instead of a silent success
+- `--json` flag for machine-readable output

--- a/src/cli/commands/whoami.ts
+++ b/src/cli/commands/whoami.ts
@@ -1,0 +1,90 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { getApiKey, getApiUrl, isAdminMode } from "../../lib/mode.js";
+import { VERSION } from "../version.js";
+
+export type WhoamiStatus = {
+  version: string;
+  apiUrl: string;
+  apiUrlSource: "default" | "env";
+  mode: "admin" | "public";
+  apiKey: { set: boolean; hint: string | null };
+  check?: { ok: boolean; status: number | null; message: string | null };
+};
+
+export function redactApiKey(key: string): string {
+  if (key.length <= 8) return "****";
+  return `${key.slice(0, 4)}…${key.slice(-4)}`;
+}
+
+export function collectWhoami(): WhoamiStatus {
+  const envUrl = process.env.RELEASED_API_URL;
+  const rawKey = process.env.RELEASED_API_KEY;
+  return {
+    version: VERSION,
+    apiUrl: getApiUrl(),
+    apiUrlSource: envUrl ? "env" : "default",
+    mode: isAdminMode() ? "admin" : "public",
+    apiKey: {
+      set: !!rawKey,
+      hint: rawKey ? redactApiKey(rawKey) : null,
+    },
+  };
+}
+
+async function probeApi(mode: WhoamiStatus["mode"]): Promise<NonNullable<WhoamiStatus["check"]>> {
+  // Admin probe hits an auth-gated read so a bad key surfaces as 401.
+  // Public probe hits a public read to confirm connectivity.
+  // We call fetch directly (not apiFetch) because apiFetch returns null on
+  // GET 404 — which would false-positive the probe for a misconfigured URL.
+  const path = mode === "admin" ? "/v1/blocked-urls?limit=1" : "/v1/sources?limit=1";
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (mode === "admin") headers["Authorization"] = `Bearer ${getApiKey()}`;
+  try {
+    const res = await fetch(`${getApiUrl()}${path}`, { headers });
+    res.body?.cancel();
+    return res.ok
+      ? { ok: true, status: res.status, message: null }
+      : { ok: false, status: res.status, message: `HTTP ${res.status} ${res.statusText}` };
+  } catch (err) {
+    return { ok: false, status: null, message: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+export function registerWhoamiCommand(parent: Command): void {
+  parent
+    .command("whoami")
+    .description("Show current CLI mode, API URL, and auth status")
+    .option("--json", "Output as JSON")
+    .option("--check", "Probe the API to verify connectivity and auth")
+    .action(async (opts: { json?: boolean; check?: boolean }) => {
+      const status: WhoamiStatus = collectWhoami();
+      if (opts.check) status.check = await probeApi(status.mode);
+
+      if (opts.json) {
+        console.log(JSON.stringify(status, null, 2));
+        return;
+      }
+
+      const label = (k: string) => chalk.dim(k.padEnd(10));
+      const row = (k: string, v: string) => console.log(`${label(k)} ${v}`);
+
+      console.log(`${chalk.bold("releases")} ${chalk.dim(`v${status.version}`)}`);
+      const urlSuffix = status.apiUrlSource === "default" ? " (default)" : " (RELEASED_API_URL)";
+      row("API URL", `${status.apiUrl}${chalk.dim(urlSuffix)}`);
+      row("Mode", status.mode === "admin" ? chalk.green("admin") : chalk.cyan("public"));
+      row("Auth", status.apiKey.set
+        ? `${chalk.green("✓")} RELEASED_API_KEY set ${chalk.dim(`(${status.apiKey.hint})`)}`
+        : `${chalk.dim("—")} RELEASED_API_KEY not set`);
+
+      if (status.check) {
+        const probeLabel = status.mode === "admin" ? "API + auth" : "API";
+        row("Probe", status.check.ok
+          ? `${chalk.green("✓")} ${probeLabel} reachable`
+          : `${chalk.red("✗")} ${status.check.message}`);
+      } else {
+        console.log("");
+        console.log(chalk.dim('Run "releases whoami --check" to verify connectivity.'));
+      }
+    });
+}

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -24,6 +24,7 @@ import { registerShowCommand } from "./commands/show.js";
 import { registerEmbedCommand } from "./commands/admin/embed.js";
 import { registerTelemetryCommand } from "./commands/telemetry.js";
 import { registerServeCommand } from "./commands/serve.js";
+import { registerWhoamiCommand } from "./commands/whoami.js";
 import { CATEGORIES } from "@releases/core/categories";
 import { isAdminMode } from "../lib/mode.js";
 import { VERSION } from "./version.js";
@@ -143,6 +144,7 @@ registerStatsCommand(program);
 registerListCommand(program);
 registerShowCommand(program);
 registerTelemetryCommand(program);
+registerWhoamiCommand(program);
 
 const admin = program
   .command("admin")

--- a/tests/unit/whoami.test.ts
+++ b/tests/unit/whoami.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "bun:test";
+import { redactApiKey } from "../../src/cli/commands/whoami.js";
+
+describe("redactApiKey", () => {
+  it("masks short keys entirely", () => {
+    expect(redactApiKey("short")).toBe("****");
+    expect(redactApiKey("12345678")).toBe("****");
+  });
+
+  it("preserves prefix and suffix for long keys", () => {
+    expect(redactApiKey("rk_live_abcdefghij1234567890")).toBe("rk_l…7890");
+  });
+
+  it("does not reveal the middle of the key", () => {
+    const key = "abcd1234SECRETSECRETwxyz";
+    const redacted = redactApiKey(key);
+    expect(redacted).not.toContain("SECRET");
+  });
+});


### PR DESCRIPTION
First bite of the CLI-DX work tracked in [#24](https://github.com/buildinternet/releases-cli/issues/24).

## Summary

New top-level `releases whoami` reports how the CLI is configured — mode, API URL, auth status, and (with `--check`) a live API probe.

```
$ releases whoami
releases v0.15.0
API URL    https://api.releases.sh (default)
Mode       admin
Auth       ✓ RELEASED_API_KEY set (wWFF…6Tk=)

Run "releases whoami --check" to verify connectivity.

$ releases whoami --check
releases v0.15.0
API URL    https://api.releases.sh (default)
Mode       admin
Auth       ✓ RELEASED_API_KEY set (wWFF…6Tk=)
Probe      ✓ API + auth reachable
```

## Why

Debugging "why isn't my key working?" / "which API am I hitting?" currently requires reading `src/lib/mode.ts` and/or grepping env. `whoami` puts the answer one command away, matching the ergonomics users expect (`aws sts get-caller-identity`, `gh auth status`, etc.).

## Design notes

- **Mode-aware probe.** `--check` hits `/v1/sources?limit=1` in public mode (confirms connectivity) and `/v1/blocked-urls?limit=1` in admin mode (admin-gated, so a bad key surfaces as 401 instead of a silent success on a public endpoint).
- **Direct `fetch` inside the probe, not `apiFetch`.** `apiFetch` returns `null` on GET 404 by design — reusing it would false-positive the probe against a misconfigured `RELEASED_API_URL`. The probe reads `res.status` directly and cancels the body stream (no decode overhead).
- **Key redaction.** `redactApiKey` shows `<first4>…<last4>` so users can confirm which key is active without leaking it. Keys ≤ 8 chars redact entirely.
- **`--json` for scripts.** Full `WhoamiStatus` surface including the probe result.

## Changes

- **`src/cli/commands/whoami.ts`** — new command + `collectWhoami()` + `redactApiKey()` + `probeApi()`.
- **`src/cli/program.ts`** — register as public (non-admin) command, alongside `telemetry`/`stats`/`list`.
- **`tests/unit/whoami.test.ts`** — redaction tests (short keys masked entirely, long keys preserve prefix + suffix, middle never leaked).

## Simplify pass

Caught one correctness bug and two cleanups:
- **Bug:** first draft used `apiFetch` for the probe — which returns `null` on 404 instead of throwing, so a wrong `RELEASED_API_URL` would report `ok: true`. Fixed by calling `fetch` directly and reading `res.status`.
- Dropped a leaky regex that was scraping HTTP status out of `apiFetch`'s error string. Real status now comes from `res.status`.
- Extracted a local `row(key, value)` helper to dedupe the `label()` + `console.log` pattern.

Deferred (noted but out of scope):
- A typed `ApiError` class in `src/api/client.ts` — worth doing but touches every caller. Separate PR.
- Shared `formatLabel()` in `src/lib/format.ts` — `list.ts`, `telemetry.ts`, and now `whoami.ts` each roll their own. Consolidation PR would be mechanical.

## Test plan

- [x] `bun test` — 191 pass (+3 new)
- [x] `bunx tsc --noEmit` — clean
- [x] Smoke: `releases whoami` (public + admin modes)
- [x] Smoke: `releases whoami --check` (happy path, live API)
- [x] Smoke: `RELEASED_API_URL=https://api.releases.sh/notfound releases whoami --check` — now correctly reports `✗ HTTP 404 Not Found` (was the bug caught by simplify)
- [x] Smoke: `releases whoami --check --json` — full envelope including `check.status: 200`
- [ ] Post-merge: confirm the command is listed in `releases --help` styled help (it's registered as a public command, but the styled help in `program.ts` has a hand-picked list — may want to add it in a follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
