### PR TITLE
chore: adopt oxlint + prettier conventions from releases

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  lint:
+    name: Lint & Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          # Matches the release workflow pin; see release.yml for context.
+          bun-version: canary
+
+      - run: bun install --frozen-lockfile
+
+      - name: Oxlint
+        run: bun run lint
+
+      - name: Prettier
+        run: bun run format:check
+
   test:
     name: Type-check and test
     runs-on: ubuntu-latest

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "plugins": ["typescript", "unicorn", "oxc"],
+  "categories": {
+    "correctness": "error",
+    "suspicious": "warn",
+    "perf": "warn"
+  },
+  "rules": {
+    "no-console": "off",
+    "no-unused-vars": ["warn", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
+    "typescript/no-explicit-any": "off",
+    "typescript/no-non-null-assertion": "off",
+    "unicorn/no-null": "off",
+    "unicorn/no-array-reduce": "off",
+    "unicorn/no-await-expression-member": "off"
+  },
+  "ignorePatterns": [
+    "node_modules",
+    "dist",
+    "**/*.d.ts",
+    "packages/*/dist/**",
+    "npm/*/bin/**",
+    "skills/**",
+    "plugins/claude/releases/skills/**"
+  ]
+}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,10 @@
+node_modules
+dist
+**/*.d.ts
+bun.lock
+package-lock.json
+packages/*/dist
+npm/*/bin
+skills
+plugins/claude/releases/skills
+.*.bun-build

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,10 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "tabWidth": 2,
+  "useTabs": false,
+  "arrowParens": "always",
+  "endOfLine": "lf"
+}

--- a/bun.lock
+++ b/bun.lock
@@ -17,12 +17,14 @@
       "devDependencies": {
         "@changesets/cli": "^2.27.10",
         "@types/bun": "latest",
+        "oxlint": "^1.60.0",
+        "prettier": "^3.8.3",
         "typescript": "^5.6.3",
       },
     },
     "npm/releases": {
       "name": "@buildinternet/releases",
-      "version": "0.12.0",
+      "version": "0.15.0",
       "bin": {
         "releases": "bin/releases",
       },
@@ -35,23 +37,23 @@
     },
     "npm/releases-darwin-arm64": {
       "name": "@buildinternet/releases-darwin-arm64",
-      "version": "0.12.0",
+      "version": "0.15.0",
     },
     "npm/releases-darwin-x64": {
       "name": "@buildinternet/releases-darwin-x64",
-      "version": "0.12.0",
+      "version": "0.15.0",
     },
     "npm/releases-linux-arm64": {
       "name": "@buildinternet/releases-linux-arm64",
-      "version": "0.12.0",
+      "version": "0.15.0",
     },
     "npm/releases-linux-x64": {
       "name": "@buildinternet/releases-linux-x64",
-      "version": "0.12.0",
+      "version": "0.15.0",
     },
     "packages/core": {
       "name": "@buildinternet/releases-core",
-      "version": "0.0.0",
+      "version": "0.15.0",
       "dependencies": {
         "drizzle-orm": "^0.45.2",
         "js-tiktoken": "^1.0.21",
@@ -60,11 +62,11 @@
     },
     "packages/lib": {
       "name": "@buildinternet/releases-lib",
-      "version": "0.0.0",
+      "version": "0.15.0",
     },
     "packages/skills": {
       "name": "@buildinternet/releases-skills",
-      "version": "0.0.0",
+      "version": "0.15.0",
     },
   },
   "packages": {
@@ -137,6 +139,44 @@
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
+
+    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.60.0", "", { "os": "android", "cpu": "arm" }, "sha512-YdeJKaZckDQL1qa62a1aKq/goyq48aX3yOxaaWqWb4sau4Ee4IiLbamftNLU3zbePky6QsDj6thnSSzHRBjDfA=="],
+
+    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.60.0", "", { "os": "android", "cpu": "arm64" }, "sha512-7ANS7PpXCfq84xZQ8E5WPs14gwcuPcl+/8TFNXfpSu0CQBXz3cUo2fDpHT8v8HJN+Ut02eacvMAzTnc9s6X4tw=="],
+
+    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.60.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-pJsgd9AfplLGBm1fIr25V6V14vMrayhx4uIQvlfH7jWs2SZwSrvi3TfgfJySB8T+hvyEH8K2zXljQiUnkgUnfQ=="],
+
+    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.60.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-Ue1aXHX49ivwflKqGJc7zcd/LeLgbhaTcDCQStgx5x06AXgjEAZmvrlMuIkWd4AL4FHQe6QJ9f33z04Cg448VQ=="],
+
+    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.60.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-YCyQzsQtusQw+gNRW9rRTifSO+Dt/+dtCl2NHoDMZqJlRTEZ/Oht9YnuporI9yiTx7+cB+eqzX3MtHHVHGIWhg=="],
+
+    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.60.0", "", { "os": "linux", "cpu": "arm" }, "sha512-c7dxM2Zksa45Qw16i2iGY3Fti2NirJ38FrsBsKw+qcJ0OtqTsBgKJLF0xV+yLG56UH01Z8WRPgsw31e0MoRoGQ=="],
+
+    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.60.0", "", { "os": "linux", "cpu": "arm" }, "sha512-ZWALoA42UYqBEP1Tbw9OWURgFGS1nWj2AAvLdY6ZcGx/Gj93qVCBKjcvwXMupZibYwFbi9s/rzqkZseb/6gVtQ=="],
+
+    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.60.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-tpy+1w4p9hN5CicMCxqNy6ymfRtV5ayE573vFNjp1k1TN/qhLFgflveZoE/0++RlkHikBz2vY545NWm/hp7big=="],
+
+    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.60.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-eDYDXZGhQAXyn6GwtwiX/qcLS0HlOLPJ/+iiIY8RYr+3P8oKBmgKxADLlniL6FtWfE7pPk7IGN9/xvDEvDvFeg=="],
+
+    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.60.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-nxehly5XYBHUWI9VJX1bqCf9j/B43DaK/aS/T1fcxCpX3PA4Rm9BB54nPD1CKayT8xg6REN1ao+01hSRNgy8OA=="],
+
+    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.60.0", "", { "os": "linux", "cpu": "none" }, "sha512-j1qf/NaUfOWQutjeoooNG1Q0zsK0XGmSu1uDLq3cctquRF3j7t9Hxqf/76ehCc5GEUAanth2W4Fa+XT1RFg/nw=="],
+
+    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.60.0", "", { "os": "linux", "cpu": "none" }, "sha512-YELKPRefQ/q/h3RUmeRfPCUhh2wBvgV1RyZ/F9M9u8cDyXsQW2ojv1DeWQTt466yczDITjZnIOg/s05pk7Ve2A=="],
+
+    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.60.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-JkO3C6Gki7Y6h/MiIkFKvHFOz98/YWvQ4WYbK9DLXACMP2rjULzkeGyAzorJE5S1dzLQGFgeqvN779kSFwoV1g=="],
+
+    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.60.0", "", { "os": "linux", "cpu": "x64" }, "sha512-XjKHdFVCpZZZSWBCKyyqCq65s2AKXykMXkjLoKYODrD+f5toLhlwsMESscu8FbgnJQ4Y/dpR/zdazsahmgBJIA=="],
+
+    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.60.0", "", { "os": "linux", "cpu": "x64" }, "sha512-js29ZWIuPhNWzY8NC7KoffEMEeWG105vbmm+8EOJsC+T/jHBiKIJEUF78+F/IrgEWMMP9N0kRND4Pp75+xAhKg=="],
+
+    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.60.0", "", { "os": "none", "cpu": "arm64" }, "sha512-H+PUITKHk04stFpWj3x3Kg08Afp/bcXSBi0EhasR5a0Vw7StXHTzdl655PUI0fB4qdh2Wsu6Dsi+3ACxPoyQnA=="],
+
+    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.60.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-WA/yc7f7ZfCefBXVzNHn1Ztulb1EFwNBb4jMZ6pjML0zz6pHujlF3Q3jySluz3XHl/GNeMTntG1seUBWVMlMag=="],
+
+    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.60.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-33YxL1sqwYNZXtn3MD/4dno6s0xeedXOJlT1WohkVD565WvohClZUr7vwKdAk954n4xiEWJkewiCr+zLeq7AeA=="],
+
+    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.60.0", "", { "os": "win32", "cpu": "x64" }, "sha512-JOro4ZcfBLamJCyfURQmOQByoorgOdx3ZjAkSqnb/CyG/i+lN3KoV5LAgk5ZAW6DPq7/Cx7n23f8DuTWXTWgyQ=="],
 
     "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
 
@@ -352,6 +392,8 @@
 
     "outdent": ["outdent@0.5.0", "", {}, "sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q=="],
 
+    "oxlint": ["oxlint@1.60.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.60.0", "@oxlint/binding-android-arm64": "1.60.0", "@oxlint/binding-darwin-arm64": "1.60.0", "@oxlint/binding-darwin-x64": "1.60.0", "@oxlint/binding-freebsd-x64": "1.60.0", "@oxlint/binding-linux-arm-gnueabihf": "1.60.0", "@oxlint/binding-linux-arm-musleabihf": "1.60.0", "@oxlint/binding-linux-arm64-gnu": "1.60.0", "@oxlint/binding-linux-arm64-musl": "1.60.0", "@oxlint/binding-linux-ppc64-gnu": "1.60.0", "@oxlint/binding-linux-riscv64-gnu": "1.60.0", "@oxlint/binding-linux-riscv64-musl": "1.60.0", "@oxlint/binding-linux-s390x-gnu": "1.60.0", "@oxlint/binding-linux-x64-gnu": "1.60.0", "@oxlint/binding-linux-x64-musl": "1.60.0", "@oxlint/binding-openharmony-arm64": "1.60.0", "@oxlint/binding-win32-arm64-msvc": "1.60.0", "@oxlint/binding-win32-ia32-msvc": "1.60.0", "@oxlint/binding-win32-x64-msvc": "1.60.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.18.0" }, "optionalPeers": ["oxlint-tsgolint"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-tnRzTWiWJ9pg3ftRWnD0+Oqh78L6ZSwcEudvCZaER0PIqiAnNyXj5N1dPwjmNpDalkKS9m/WMLN1CTPUBPmsgw=="],
+
     "p-filter": ["p-filter@2.1.0", "", { "dependencies": { "p-map": "^2.0.0" } }, "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw=="],
 
     "p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
@@ -382,7 +424,7 @@
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
-    "prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
+    "prettier": ["prettier@3.8.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
@@ -471,6 +513,10 @@
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "@changesets/apply-release-plan/prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
+
+    "@changesets/write/prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
 
     "@manypkg/find-root/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
 

--- a/npm/releases/CHANGELOG.md
+++ b/npm/releases/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Minor Changes
 
 - 08b7297: Add `releases tail` as the canonical "latest releases" command (with `latest` retained as an alias), plus `-f/--follow` streaming mode:
-
   - `releases tail -f` polls the cached `/v1/releases/latest` endpoint on a 60-second interval (configurable with `--interval <seconds>`) and streams new releases as they arrive. Novelty detection is client-side via a bounded seen-id set, so every follow-poller collapses onto the shared KV cache entry rather than forking it with a per-client `since`.
   - `getLatestReleases` now calls the unified `/v1/releases/latest` endpoint in a single request. Replaces the previous scatter-gather (fetch `/sources`, call `/sources/:slug` for the first 10, sort locally), which sampled rather than enumerated and meant the CLI's "latest across all sources" was incomplete for indexes larger than 10 sources.
   - Extracted `renderLatestReleasesTable` into `src/cli/render/` so `tail` and `show` share one formatter.
@@ -17,7 +16,6 @@
 ### Minor Changes
 
 - 972ff89: Surface AI-generated org overviews more readily in the CLI:
-
   - `releases org show <slug>` now prints a short preview (first ~80 words) of the AI overview with a generated-at hint and a "⚠ older than 30 days" stale warning where appropriate.
   - New `releases org overview <slug>` command (public read, no auth) prints the full overview body with the same staleness signal.
   - `@buildinternet/releases-core/overview` exports shared helpers — `OVERVIEW_STALE_DAYS`, `overviewAgeDays`, `isOverviewStale`, `overviewPreview` — used by both the CLI and the upstream MCP server.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,11 @@
     "changeset:version": "changeset version && bun scripts/sync-version.ts && bun install",
     "changeset:publish": "changeset publish",
     "test": "bun test",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "lint": "oxlint",
+    "lint:fix": "oxlint --fix",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "workspaces": [
     "npm/*",
@@ -53,6 +57,8 @@
   "devDependencies": {
     "@changesets/cli": "^2.27.10",
     "@types/bun": "latest",
+    "oxlint": "^1.60.0",
+    "prettier": "^3.8.3",
     "typescript": "^5.6.3"
   }
 }

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -7,7 +7,6 @@
 ### Minor Changes
 
 - 972ff89: Surface AI-generated org overviews more readily in the CLI:
-
   - `releases org show <slug>` now prints a short preview (first ~80 words) of the AI overview with a generated-at hint and a "⚠ older than 30 days" stale warning where appropriate.
   - New `releases org overview <slug>` command (public read, no auth) prints the full overview body with the same staleness signal.
   - `@buildinternet/releases-core/overview` exports shared helpers — `OVERVIEW_STALE_DAYS`, `overviewAgeDays`, `isOverviewStale`, `overviewPreview` — used by both the CLI and the upstream MCP server.

--- a/packages/core/src/changelog-slice.ts
+++ b/packages/core/src/changelog-slice.ts
@@ -145,9 +145,10 @@ export function sliceChangelog(
   let snappedEnd: number;
 
   if (tokenBudget !== undefined) {
-    snappedEnd = snappedStart >= totalChars
-      ? totalChars
-      : findTokenSliceEnd(content, snappedStart, tokenBudget, headings, totalChars);
+    snappedEnd =
+      snappedStart >= totalChars
+        ? totalChars
+        : findTokenSliceEnd(content, snappedStart, tokenBudget, headings, totalChars);
   } else {
     const requestedEnd = snappedStart + limit;
     if (requestedEnd >= totalChars) {
@@ -191,7 +192,11 @@ export function sliceChangelog(
   return result;
 }
 
-export function hasRangeParams(params: { offset?: string | null; limit?: string | null; tokens?: string | null }): boolean {
+export function hasRangeParams(params: {
+  offset?: string | null;
+  limit?: string | null;
+  tokens?: string | null;
+}): boolean {
   return params.offset != null || params.limit != null || params.tokens != null;
 }
 
@@ -288,14 +293,18 @@ export type ChangelogResponse = Omit<ChangelogFileRow, "tokens"> &
  * caller requested a token budget and whether more content follows.
  */
 export function formatChangelogSliceLine(
-  response: Pick<ChangelogResponse, "offset" | "content" | "totalChars" | "totalTokens" | "sliceTokens" | "nextOffset">,
+  response: Pick<
+    ChangelogResponse,
+    "offset" | "content" | "totalChars" | "totalTokens" | "sliceTokens" | "nextOffset"
+  >,
 ): string {
   const end = response.offset + response.content.length;
   const tail = response.nextOffset != null ? `next: offset=${response.nextOffset}` : "end of file";
   const charPart = `chars ${response.offset}–${end} of ${response.totalChars}`;
-  const head = response.sliceTokens !== undefined
-    ? `${response.sliceTokens} tokens (${charPart} / ${response.totalTokens} total tokens)`
-    : `${charPart} (${response.totalTokens} total tokens)`;
+  const head =
+    response.sliceTokens !== undefined
+      ? `${response.sliceTokens} tokens (${charPart} / ${response.totalTokens} total tokens)`
+      : `${charPart} (${response.totalTokens} total tokens)`;
   return `Slice: ${head} — ${tail}`;
 }
 

--- a/packages/core/src/overview.ts
+++ b/packages/core/src/overview.ts
@@ -31,7 +31,10 @@ function stripLeadingHeading(content: string): string {
   return content.replace(/^\s*#{1,6}\s+[^\n]+\n+/, "");
 }
 
-export function overviewPreview(content: string, maxWords: number = OVERVIEW_PREVIEW_WORDS): string {
+export function overviewPreview(
+  content: string,
+  maxWords: number = OVERVIEW_PREVIEW_WORDS,
+): string {
   const trimmed = stripLeadingHeading(content.trim());
   if (!trimmed) return "";
 

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -1,5 +1,22 @@
 import { sqliteTable, text, integer, uniqueIndex, index } from "drizzle-orm/sqlite-core";
-import { newSourceId, newReleaseId, newOrgId, newOrgAccountId, newFetchLogId, newIgnoredUrlId, newBlockedUrlId, newSummaryId, newMediaAssetId, newProductId, newTagId, newDomainAliasId, newKnowledgePageId, newSourceChangelogFileId, newSourceChangelogChunkId, newTelemetryEventId } from "./id.js";
+import {
+  newSourceId,
+  newReleaseId,
+  newOrgId,
+  newOrgAccountId,
+  newFetchLogId,
+  newIgnoredUrlId,
+  newBlockedUrlId,
+  newSummaryId,
+  newMediaAssetId,
+  newProductId,
+  newTagId,
+  newDomainAliasId,
+  newKnowledgePageId,
+  newSourceChangelogFileId,
+  newSourceChangelogChunkId,
+  newTelemetryEventId,
+} from "./id.js";
 
 export const RELEASE_TYPES = ["feature", "rollup"] as const;
 export type ReleaseType = (typeof RELEASE_TYPES)[number];
@@ -12,8 +29,12 @@ export const organizations = sqliteTable("organizations", {
   description: text("description"),
   category: text("category"),
   avatarUrl: text("avatar_url"),
-  createdAt: text("created_at").notNull().$defaultFn(() => new Date().toISOString()),
-  updatedAt: text("updated_at").notNull().$defaultFn(() => new Date().toISOString()),
+  createdAt: text("created_at")
+    .notNull()
+    .$defaultFn(() => new Date().toISOString()),
+  updatedAt: text("updated_at")
+    .notNull()
+    .$defaultFn(() => new Date().toISOString()),
   metadata: text("metadata").default("{}"),
   embeddedAt: text("embedded_at"),
 });
@@ -27,28 +48,32 @@ export const orgAccounts = sqliteTable(
       .references(() => organizations.id, { onDelete: "cascade" }),
     platform: text("platform").notNull(),
     handle: text("handle").notNull(),
-    createdAt: text("created_at").notNull().$defaultFn(() => new Date().toISOString()),
+    createdAt: text("created_at")
+      .notNull()
+      .$defaultFn(() => new Date().toISOString()),
   },
-  (table) => [
-    uniqueIndex("idx_org_accounts_platform_handle").on(table.platform, table.handle),
-  ],
+  (table) => [uniqueIndex("idx_org_accounts_platform_handle").on(table.platform, table.handle)],
 );
 
-export const products = sqliteTable("products", {
-  id: text("id").primaryKey().$defaultFn(newProductId),
-  name: text("name").notNull(),
-  slug: text("slug").notNull().unique(),
-  orgId: text("org_id")
-    .notNull()
-    .references(() => organizations.id, { onDelete: "cascade" }),
-  url: text("url"),
-  description: text("description"),
-  category: text("category"),
-  createdAt: text("created_at").notNull().$defaultFn(() => new Date().toISOString()),
-  embeddedAt: text("embedded_at"),
-}, (table) => [
-  index("idx_products_org").on(table.orgId),
-]);
+export const products = sqliteTable(
+  "products",
+  {
+    id: text("id").primaryKey().$defaultFn(newProductId),
+    name: text("name").notNull(),
+    slug: text("slug").notNull().unique(),
+    orgId: text("org_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    url: text("url"),
+    description: text("description"),
+    category: text("category"),
+    createdAt: text("created_at")
+      .notNull()
+      .$defaultFn(() => new Date().toISOString()),
+    embeddedAt: text("embedded_at"),
+  },
+  (table) => [index("idx_products_org").on(table.orgId)],
+);
 
 export const domainAliases = sqliteTable(
   "domain_aliases",
@@ -57,7 +82,9 @@ export const domainAliases = sqliteTable(
     domain: text("domain").notNull().unique(),
     orgId: text("org_id").references(() => organizations.id, { onDelete: "cascade" }),
     productId: text("product_id").references(() => products.id, { onDelete: "cascade" }),
-    createdAt: text("created_at").notNull().$defaultFn(() => new Date().toISOString()),
+    createdAt: text("created_at")
+      .notNull()
+      .$defaultFn(() => new Date().toISOString()),
   },
   (table) => [
     index("idx_domain_aliases_org").on(table.orgId),
@@ -72,7 +99,9 @@ export const tags = sqliteTable("tags", {
   id: text("id").primaryKey().$defaultFn(newTagId),
   name: text("name").notNull(),
   slug: text("slug").notNull().unique(),
-  createdAt: text("created_at").notNull().$defaultFn(() => new Date().toISOString()),
+  createdAt: text("created_at")
+    .notNull()
+    .$defaultFn(() => new Date().toISOString()),
 });
 
 export const orgTags = sqliteTable(
@@ -84,7 +113,9 @@ export const orgTags = sqliteTable(
     tagId: text("tag_id")
       .notNull()
       .references(() => tags.id, { onDelete: "cascade" }),
-    createdAt: text("created_at").notNull().$defaultFn(() => new Date().toISOString()),
+    createdAt: text("created_at")
+      .notNull()
+      .$defaultFn(() => new Date().toISOString()),
   },
   (table) => [
     uniqueIndex("idx_org_tags_pk").on(table.orgId, table.tagId),
@@ -101,7 +132,9 @@ export const productTags = sqliteTable(
     tagId: text("tag_id")
       .notNull()
       .references(() => tags.id, { onDelete: "cascade" }),
-    createdAt: text("created_at").notNull().$defaultFn(() => new Date().toISOString()),
+    createdAt: text("created_at")
+      .notNull()
+      .$defaultFn(() => new Date().toISOString()),
   },
   (table) => [
     uniqueIndex("idx_product_tags_pk").on(table.productId, table.tagId),
@@ -109,32 +142,38 @@ export const productTags = sqliteTable(
   ],
 );
 
-export const sources = sqliteTable("sources", {
-  id: text("id").primaryKey().$defaultFn(newSourceId),
-  name: text("name").notNull(),
-  slug: text("slug").notNull().unique(),
-  type: text("type", { enum: ["github", "scrape", "feed", "agent"] }).notNull(),
-  url: text("url").notNull(),
-  orgId: text("org_id").references(() => organizations.id, { onDelete: "set null" }),
-  productId: text("product_id").references(() => products.id, { onDelete: "set null" }),
-  metadata: text("metadata").default("{}"),
-  createdAt: text("created_at").notNull().$defaultFn(() => new Date().toISOString()),
-  lastFetchedAt: text("last_fetched_at"),
-  lastContentHash: text("last_content_hash"),
-  fetchPriority: text("fetch_priority", { enum: ["normal", "low", "paused"] }).default("normal"),
-  consecutiveNoChange: integer("consecutive_no_change").default(0),
-  consecutiveErrors: integer("consecutive_errors").default(0),
-  nextFetchAfter: text("next_fetch_after"),
-  changeDetectedAt: text("change_detected_at"),
-  lastPolledAt: text("last_polled_at"),
-  isPrimary: integer("is_primary", { mode: "boolean" }).default(false),
-  isHidden: integer("is_hidden", { mode: "boolean" }).default(false),
-  embeddedAt: text("embedded_at"),
-}, (table) => [
-  index("idx_sources_org").on(table.orgId),
-  index("idx_sources_org_hidden").on(table.orgId, table.isHidden),
-  index("idx_sources_product").on(table.productId),
-]);
+export const sources = sqliteTable(
+  "sources",
+  {
+    id: text("id").primaryKey().$defaultFn(newSourceId),
+    name: text("name").notNull(),
+    slug: text("slug").notNull().unique(),
+    type: text("type", { enum: ["github", "scrape", "feed", "agent"] }).notNull(),
+    url: text("url").notNull(),
+    orgId: text("org_id").references(() => organizations.id, { onDelete: "set null" }),
+    productId: text("product_id").references(() => products.id, { onDelete: "set null" }),
+    metadata: text("metadata").default("{}"),
+    createdAt: text("created_at")
+      .notNull()
+      .$defaultFn(() => new Date().toISOString()),
+    lastFetchedAt: text("last_fetched_at"),
+    lastContentHash: text("last_content_hash"),
+    fetchPriority: text("fetch_priority", { enum: ["normal", "low", "paused"] }).default("normal"),
+    consecutiveNoChange: integer("consecutive_no_change").default(0),
+    consecutiveErrors: integer("consecutive_errors").default(0),
+    nextFetchAfter: text("next_fetch_after"),
+    changeDetectedAt: text("change_detected_at"),
+    lastPolledAt: text("last_polled_at"),
+    isPrimary: integer("is_primary", { mode: "boolean" }).default(false),
+    isHidden: integer("is_hidden", { mode: "boolean" }).default(false),
+    embeddedAt: text("embedded_at"),
+  },
+  (table) => [
+    index("idx_sources_org").on(table.orgId),
+    index("idx_sources_org_hidden").on(table.orgId, table.isHidden),
+    index("idx_sources_product").on(table.productId),
+  ],
+);
 
 export const releases = sqliteTable(
   "releases",
@@ -155,7 +194,9 @@ export const releases = sqliteTable(
     publishedAt: text("published_at"),
     suppressed: integer("suppressed", { mode: "boolean" }).default(false),
     suppressedReason: text("suppressed_reason"),
-    fetchedAt: text("fetched_at").notNull().$defaultFn(() => new Date().toISOString()),
+    fetchedAt: text("fetched_at")
+      .notNull()
+      .$defaultFn(() => new Date().toISOString()),
     embeddedAt: text("embedded_at"),
   },
   (table) => [
@@ -179,27 +220,35 @@ export const usageLog = sqliteTable("usage_log", {
   outputTokens: integer("output_tokens").notNull(),
   sourceSlug: text("source_slug"),
   releaseCount: integer("release_count"),
-  createdAt: text("created_at").notNull().$defaultFn(() => new Date().toISOString()),
+  createdAt: text("created_at")
+    .notNull()
+    .$defaultFn(() => new Date().toISOString()),
 });
 
-export const fetchLog = sqliteTable("fetch_log", {
-  id: text("id").primaryKey().$defaultFn(newFetchLogId),
-  sourceId: text("source_id")
-    .notNull()
-    .references(() => sources.id, { onDelete: "cascade" }),
-  sessionId: text("session_id"),
-  releasesFound: integer("releases_found").notNull(),
-  releasesInserted: integer("releases_inserted").notNull(),
-  durationMs: integer("duration_ms"),
-  status: text("status", { enum: ["success", "error", "no_change", "dry_run"] }).notNull(),
-  error: text("error"),
-  rawContent: text("raw_content"),
-  createdAt: text("created_at").notNull().$defaultFn(() => new Date().toISOString()),
-}, (table) => [
-  index("idx_fetch_log_source").on(table.sourceId),
-  index("idx_fetch_log_created").on(table.createdAt),
-  index("idx_fetch_log_session").on(table.sessionId),
-]);
+export const fetchLog = sqliteTable(
+  "fetch_log",
+  {
+    id: text("id").primaryKey().$defaultFn(newFetchLogId),
+    sourceId: text("source_id")
+      .notNull()
+      .references(() => sources.id, { onDelete: "cascade" }),
+    sessionId: text("session_id"),
+    releasesFound: integer("releases_found").notNull(),
+    releasesInserted: integer("releases_inserted").notNull(),
+    durationMs: integer("duration_ms"),
+    status: text("status", { enum: ["success", "error", "no_change", "dry_run"] }).notNull(),
+    error: text("error"),
+    rawContent: text("raw_content"),
+    createdAt: text("created_at")
+      .notNull()
+      .$defaultFn(() => new Date().toISOString()),
+  },
+  (table) => [
+    index("idx_fetch_log_source").on(table.sourceId),
+    index("idx_fetch_log_created").on(table.createdAt),
+    index("idx_fetch_log_session").on(table.sessionId),
+  ],
+);
 
 export type Source = typeof sources.$inferSelect;
 export type NewSource = typeof sources.$inferInsert;
@@ -262,24 +311,32 @@ export const telemetryEvents = sqliteTable(
 export type TelemetryEvent = typeof telemetryEvents.$inferSelect;
 export type NewTelemetryEvent = typeof telemetryEvents.$inferInsert;
 
-export const ignoredUrls = sqliteTable("ignored_urls", {
-  id: text("id").primaryKey().$defaultFn(newIgnoredUrlId),
-  url: text("url").notNull(),
-  orgId: text("org_id")
-    .notNull()
-    .references(() => organizations.id, { onDelete: "cascade" }),
-  reason: text("reason"),
-  ignoredAt: text("ignored_at").notNull().$defaultFn(() => new Date().toISOString()),
-}, (table) => [
-  uniqueIndex("idx_ignored_urls_org_url").on(table.orgId, table.url),
-]);
+export const ignoredUrls = sqliteTable(
+  "ignored_urls",
+  {
+    id: text("id").primaryKey().$defaultFn(newIgnoredUrlId),
+    url: text("url").notNull(),
+    orgId: text("org_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    reason: text("reason"),
+    ignoredAt: text("ignored_at")
+      .notNull()
+      .$defaultFn(() => new Date().toISOString()),
+  },
+  (table) => [uniqueIndex("idx_ignored_urls_org_url").on(table.orgId, table.url)],
+);
 
 export const blockedUrls = sqliteTable("blocked_urls", {
   id: text("id").primaryKey().$defaultFn(newBlockedUrlId),
   pattern: text("pattern").notNull().unique(),
-  type: text("type", { enum: ["exact", "domain"] }).notNull().default("exact"),
+  type: text("type", { enum: ["exact", "domain"] })
+    .notNull()
+    .default("exact"),
   reason: text("reason"),
-  createdAt: text("created_at").notNull().$defaultFn(() => new Date().toISOString()),
+  createdAt: text("created_at")
+    .notNull()
+    .$defaultFn(() => new Date().toISOString()),
 });
 
 export type IgnoredUrl = typeof ignoredUrls.$inferSelect;
@@ -299,10 +356,18 @@ export const releaseSummaries = sqliteTable(
     windowDays: integer("window_days"),
     summary: text("summary").notNull(),
     releaseCount: integer("release_count").notNull(),
-    generatedAt: text("generated_at").notNull().$defaultFn(() => new Date().toISOString()),
+    generatedAt: text("generated_at")
+      .notNull()
+      .$defaultFn(() => new Date().toISOString()),
   },
   (table) => [
-    uniqueIndex("idx_summaries_unique").on(table.sourceId, table.orgId, table.type, table.year, table.month),
+    uniqueIndex("idx_summaries_unique").on(
+      table.sourceId,
+      table.orgId,
+      table.type,
+      table.year,
+      table.month,
+    ),
     index("idx_summaries_source_type").on(table.sourceId, table.type),
     index("idx_summaries_org_type").on(table.orgId, table.type),
   ],
@@ -325,7 +390,9 @@ export const mediaAssets = sqliteTable(
     height: integer("height"),
     sourceId: text("source_id").references(() => sources.id, { onDelete: "set null" }),
     releaseId: text("release_id").references(() => releases.id, { onDelete: "set null" }),
-    createdAt: text("created_at").notNull().$defaultFn(() => new Date().toISOString()),
+    createdAt: text("created_at")
+      .notNull()
+      .$defaultFn(() => new Date().toISOString()),
   },
   (table) => [
     index("idx_media_assets_source").on(table.sourceId),
@@ -349,8 +416,12 @@ export const knowledgePages = sqliteTable(
     notes: text("notes"),
     releaseCount: integer("release_count").notNull().default(0),
     lastContributingReleaseAt: text("last_contributing_release_at"),
-    generatedAt: text("generated_at").notNull().$defaultFn(() => new Date().toISOString()),
-    updatedAt: text("updated_at").notNull().$defaultFn(() => new Date().toISOString()),
+    generatedAt: text("generated_at")
+      .notNull()
+      .$defaultFn(() => new Date().toISOString()),
+    updatedAt: text("updated_at")
+      .notNull()
+      .$defaultFn(() => new Date().toISOString()),
   },
   (table) => [
     uniqueIndex("idx_knowledge_pages_scope_org").on(table.scope, table.orgId),
@@ -377,7 +448,9 @@ export const sourceChangelogFiles = sqliteTable(
     contentHash: text("content_hash").notNull(),
     bytes: integer("bytes").notNull(),
     tokens: integer("tokens"),
-    fetchedAt: text("fetched_at").notNull().$defaultFn(() => new Date().toISOString()),
+    fetchedAt: text("fetched_at")
+      .notNull()
+      .$defaultFn(() => new Date().toISOString()),
   },
   (table) => [
     uniqueIndex("scf_source_path_uq").on(table.sourceId, table.path),
@@ -405,7 +478,9 @@ export const sourceChangelogChunks = sqliteTable(
     heading: text("heading"),
     vectorId: text("vector_id"),
     embeddedAt: text("embedded_at"),
-    createdAt: text("created_at").notNull().$defaultFn(() => new Date().toISOString()),
+    createdAt: text("created_at")
+      .notNull()
+      .$defaultFn(() => new Date().toISOString()),
   },
   (table) => [
     uniqueIndex("scc_file_offset_uq").on(table.sourceChangelogFileId, table.offset),

--- a/packages/lib/src/logger.ts
+++ b/packages/lib/src/logger.ts
@@ -12,9 +12,9 @@ function getLogFile(): string {
 
 function writeToFile(level: string, args: unknown[]) {
   const timestamp = new Date().toISOString();
-  const message = args.map((a) =>
-    typeof a === "string" ? a : JSON.stringify(a, null, 2)
-  ).join(" ");
+  const message = args
+    .map((a) => (typeof a === "string" ? a : JSON.stringify(a, null, 2)))
+    .join(" ");
   appendFileSync(getLogFile(), `${timestamp} [${level}] ${message}\n`);
 }
 

--- a/plugins/claude/releases/README.md
+++ b/plugins/claude/releases/README.md
@@ -27,33 +27,43 @@ claude --plugin-dir plugins/claude/releases
 ## Available MCP Tools
 
 ### search_releases
+
 Full-text search across all indexed release notes. Filter by product, organization, or release `type`.
 
 ### get_latest_releases
+
 Get the most recent releases, optionally filtered by product, organization, or release `type`.
 
 ### list_sources
+
 List all indexed changelog sources, optionally scoped to one organization.
 
 ### get_source
+
 Detail for a single source including org/product linkage, release count, last-fetched timestamp, and whether a CHANGELOG file is stored.
 
 ### get_source_changelog
+
 Return the canonical `CHANGELOG.md` (or `CHANGES`/`HISTORY`/`RELEASES`/`NEWS`) stored for a GitHub source. The file is refreshed on every fetch. Supports heading-aligned slicing by chars (`offset` + `limit`) or tokens (`tokens`, cl100k_base). Every response includes `totalTokens` for budget planning; token-mode calls also return `sliceTokens`. Chain successive calls via the returned `nextOffset` to page through large files without blowing out the context window. Recommended token brackets: 2000 / 5000 / 10000 / 20000.
 
 ### list_organizations
+
 List all indexed organizations, with optional search.
 
 ### get_organization
+
 Get detailed information about a single organization. Includes a short preview of the AI-generated overview when one exists, with a stale warning if it's older than 30 days.
 
 ### get_organization_overview
+
 Read the full AI-generated overview for an organization — a short briefing that distills recent changelog activity into themed sections.
 
 ### list_products
+
 List products, optionally scoped to one organization.
 
 ### get_product
+
 Detail for a single product with its organization, category, tags, and the sources grouped under it.
 
 ## Usage Examples
@@ -80,16 +90,16 @@ Use the worker agent to fetch all Vercel sources
 
 ## Bundled Skills
 
-| Skill | Trigger |
-|---|---|
-| `releases-mcp` | User asks about recent releases, changelogs, breaking changes, or version updates ("what's new in Next.js 15?") |
-| `releases-cli` | User mentions the `releases` CLI, runs a `releases` command, or asks about installing or using the CLI |
-| `finding-changelogs` | Adding a new source or evaluating a URL as a candidate |
-| `managing-sources` | Add/remove/edit/validate operations on indexed sources |
-| `parsing-changelogs` | Questions about how ingest works or debugging fetched content |
-| `analyzing-releases` | Cross-company trend or competitive-intel questions |
-| `classify-media-relevance` | Deciding which images to keep on a release |
-| `seeding-playbooks` | Bootstrapping ingestion notes for a new source |
+| Skill                      | Trigger                                                                                                         |
+| -------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `releases-mcp`             | User asks about recent releases, changelogs, breaking changes, or version updates ("what's new in Next.js 15?") |
+| `releases-cli`             | User mentions the `releases` CLI, runs a `releases` command, or asks about installing or using the CLI          |
+| `finding-changelogs`       | Adding a new source or evaluating a URL as a candidate                                                          |
+| `managing-sources`         | Add/remove/edit/validate operations on indexed sources                                                          |
+| `parsing-changelogs`       | Questions about how ingest works or debugging fetched content                                                   |
+| `analyzing-releases`       | Cross-company trend or competitive-intel questions                                                              |
+| `classify-media-relevance` | Deciding which images to keep on a release                                                                      |
+| `seeding-playbooks`        | Bootstrapping ingestion notes for a new source                                                                  |
 
 ## Skill Sync
 

--- a/plugins/claude/releases/agents/discovery.md
+++ b/plugins/claude/releases/agents/discovery.md
@@ -11,7 +11,9 @@ You manage changelog sources for the Releases.sh registry. You find, evaluate, a
 You have two kinds of tools:
 
 ### MCP tools (reads)
+
 Connected via the Releases MCP server. Use for all read/search operations:
+
 - **search_releases** — Hybrid lexical + semantic search across releases and CHANGELOG chunks (default `mode: "hybrid"`); each hit carries a `kind: "release"|"changelog_chunk"` discriminator
 - **search_registry** — Vector-backed lookup across orgs, products, and sources by name/description/category
 - **get_latest_releases** — Recent releases for a product or organization
@@ -22,9 +24,11 @@ Connected via the Releases MCP server. Use for all read/search operations:
 - **compare_products** — AI comparison between two products
 
 ### CLI commands (writes + utilities)
+
 Run via Bash using `bun src/index.ts` (dev) or `releases` (compiled binary). Use `--json` for structured output.
 
 Key commands:
+
 - `releases admin discovery evaluate <url> --json` — Evaluate a changelog URL for best ingestion method
 - `releases admin source add <name> --url <url> --org <org> [--type <type>] [--feed-url <url>]` — Add a source
 - `releases admin source edit <identifier> [--primary] [--priority <p>]` — Edit source config (accepts ID or slug)

--- a/plugins/claude/releases/agents/worker.md
+++ b/plugins/claude/releases/agents/worker.md
@@ -9,7 +9,9 @@ You are a worker agent for the Releases.sh registry. Your job is to execute fetc
 ## Tool Architecture
 
 ### MCP tools (reads)
+
 Connected via the Releases MCP server:
+
 - **search_releases** — Hybrid lexical + semantic search across releases and CHANGELOG chunks (default `mode: "hybrid"`); each hit carries a `kind: "release"|"changelog_chunk"` discriminator
 - **get_latest_releases** — Recent releases for a product or organization
 - **list_sources** — List indexed changelog sources
@@ -17,9 +19,11 @@ Connected via the Releases MCP server:
 - **get_organization** — Detailed view of a single org
 
 ### CLI commands (writes)
+
 Run via Bash using `bun src/index.ts` (dev) or `releases` (compiled binary). Use `--json` for structured output.
 
 Key commands:
+
 - `releases admin source fetch <slug> [--max <n>]` — Fetch releases from a source
 - `releases admin source edit <identifier> [--primary] [--priority <p>]` — Edit source config (accepts ID or slug)
 - `releases admin org edit <slug> [--category <c>]` — Edit org
@@ -43,6 +47,7 @@ When asked to fetch sources:
 ## Update Operations
 
 When asked to update source metadata or org details:
+
 1. Use the appropriate CLI command (`releases admin source edit`, `releases admin org edit`, `releases admin product add`)
 2. Confirm each change was applied
 3. Report any errors

--- a/scripts/sync-plugin-skills.ts
+++ b/scripts/sync-plugin-skills.ts
@@ -11,7 +11,15 @@
  *   bun scripts/sync-plugin-skills.ts --dry-run  # preview without changes
  */
 
-import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync, rmSync, cpSync } from "fs";
+import {
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  existsSync,
+  readdirSync,
+  rmSync,
+  cpSync,
+} from "fs";
 import { resolve, join } from "path";
 
 const PROJECT_ROOT = resolve(import.meta.dir, "..");
@@ -47,19 +55,20 @@ function main() {
 
     // Insert comment after frontmatter so YAML parsing isn't broken
     const fmEnd = sourceContent.indexOf("---", 3);
-    const destContent = fmEnd !== -1
-      ? sourceContent.slice(0, fmEnd + 3) + "\n\n" + AUTO_GEN_COMMENT + "\n" + sourceContent.slice(fmEnd + 3)
-      : AUTO_GEN_COMMENT + "\n\n" + sourceContent;
+    const destContent =
+      fmEnd !== -1
+        ? sourceContent.slice(0, fmEnd + 3) +
+          "\n\n" +
+          AUTO_GEN_COMMENT +
+          "\n" +
+          sourceContent.slice(fmEnd + 3)
+        : AUTO_GEN_COMMENT + "\n\n" + sourceContent;
 
     const sourceRefs = join(SOURCE_SKILLS_DIR, dirName, "references");
     const destRefs = join(destDir, "references");
     const refsInSync = refsEqual(sourceRefs, destRefs);
 
-    if (
-      existsSync(destPath) &&
-      readFileSync(destPath, "utf8") === destContent &&
-      refsInSync
-    ) {
+    if (existsSync(destPath) && readFileSync(destPath, "utf8") === destContent && refsInSync) {
       console.log(`  ✓ ${dirName} — up to date`);
       unchanged++;
       continue;

--- a/scripts/sync-version.ts
+++ b/scripts/sync-version.ts
@@ -15,9 +15,8 @@ import { join, resolve } from "node:path";
 
 const ROOT = resolve(new URL("..", import.meta.url).pathname);
 
-const newVersion = JSON.parse(
-  readFileSync(join(ROOT, "npm/releases/package.json"), "utf8"),
-).version as string;
+const newVersion = JSON.parse(readFileSync(join(ROOT, "npm/releases/package.json"), "utf8"))
+  .version as string;
 
 function updateJson(path: string, mutate: (j: Record<string, unknown>) => void) {
   const full = join(ROOT, path);

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -2,29 +2,57 @@ import { getApiUrl, getApiKey, isAdminMode } from "../lib/mode.js";
 import { logger } from "@releases/lib/logger";
 import { daysAgoIso } from "@releases/core/dates";
 import type {
-  Source, Release, Organization, OrgAccount, IgnoredUrl, BlockedUrl,
-  ReleaseSummary, NewReleaseSummary, Product, Tag, DomainAlias, KnowledgePage,
+  Source,
+  Release,
+  Organization,
+  OrgAccount,
+  IgnoredUrl,
+  BlockedUrl,
+  ReleaseSummary,
+  NewReleaseSummary,
+  Product,
+  Tag,
+  DomainAlias,
+  KnowledgePage,
   ReleaseType,
 } from "@releases/core/schema";
 import type {
-  SourceWithOrg, Stats, UnifiedSearchResponse, SourceChangelogResponse,
-  ReleaseWithSource, StatsSummary, FetchLogEntry, LatestRelease,
-  UsageStatsResponse, Session,
-  EmbedBackfillResponse, EmbedStatusResponse, MediaItem,
+  SourceWithOrg,
+  Stats,
+  UnifiedSearchResponse,
+  SourceChangelogResponse,
+  ReleaseWithSource,
+  StatsSummary,
+  FetchLogEntry,
+  LatestRelease,
+  UsageStatsResponse,
+  Session,
+  EmbedBackfillResponse,
+  EmbedStatusResponse,
+  MediaItem,
 } from "./types.js";
 import type { ListResponse } from "@releases/core/cli-contracts";
 export type {
-  SourceWithOrg, SourcePatchInput, ReleaseWithSource, StatsSummary,
-  FetchLogEntry, LatestRelease, UsageBreakdownRow, UsageStatsResponse,
-  Session, EmbedBackfillResponse, EmbedStatusResponse,
-  Stats, SourceListItem,
+  SourceWithOrg,
+  SourcePatchInput,
+  ReleaseWithSource,
+  StatsSummary,
+  FetchLogEntry,
+  LatestRelease,
+  UsageBreakdownRow,
+  UsageStatsResponse,
+  Session,
+  EmbedBackfillResponse,
+  EmbedStatusResponse,
+  Stats,
+  SourceListItem,
 } from "./types.js";
 
 export async function apiFetch<T>(path: string, opts?: RequestInit): Promise<T> {
   const url = `${getApiUrl()}${path}`;
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
-    ...opts?.headers as Record<string, string>,
+    ...(opts?.headers as Record<string, string>),
   };
   // Only send auth header when an API key is configured (admin mode)
   if (isAdminMode()) {
@@ -63,7 +91,9 @@ export async function sourceChangelog(
   if (range?.limit !== undefined) params.set("limit", String(range.limit));
   if (range?.tokens !== undefined) params.set("tokens", String(range.tokens));
   const qs = params.toString();
-  return apiFetch<SourceChangelogResponse | null>(`/v1/sources/${slug}/changelog${qs ? `?${qs}` : ""}`);
+  return apiFetch<SourceChangelogResponse | null>(
+    `/v1/sources/${slug}/changelog${qs ? `?${qs}` : ""}`,
+  );
 }
 
 export async function findSourcesByUrls(urls: string[]): Promise<Source[]> {
@@ -83,21 +113,27 @@ async function suggestEntities(
   term: string,
   limit: number,
 ): Promise<Array<{ slug: string; name: string }>> {
-  const all = await apiFetch<Array<{ slug: string; name: string }>>(`${endpoint}?limit=200`) ?? [];
+  const all =
+    (await apiFetch<Array<{ slug: string; name: string }>>(`${endpoint}?limit=200`)) ?? [];
   const lower = term.toLowerCase();
   return all
     .filter((e) => e.slug.includes(lower) || e.name.toLowerCase().includes(lower))
     .slice(0, limit);
 }
 
-export const suggestOrgs = (term: string, limit: number) => suggestEntities("/v1/orgs", term, limit);
-export const suggestSources = (term: string, limit: number) => suggestEntities("/v1/sources", term, limit);
+export const suggestOrgs = (term: string, limit: number) =>
+  suggestEntities("/v1/orgs", term, limit);
+export const suggestSources = (term: string, limit: number) =>
+  suggestEntities("/v1/sources", term, limit);
 
 export async function getSourcesByOrg(orgId: string): Promise<Source[]> {
   return apiFetch<Source[]>(`/v1/sources?orgId=${orgId}`);
 }
 
-export async function listOrgs(opts?: { query?: string; platform?: string }): Promise<Organization[]> {
+export async function listOrgs(opts?: {
+  query?: string;
+  platform?: string;
+}): Promise<Organization[]> {
   const params = new URLSearchParams();
   if (opts?.query) params.set("q", opts.query);
   if (opts?.platform) params.set("platform", opts.platform);
@@ -105,7 +141,10 @@ export async function listOrgs(opts?: { query?: string; platform?: string }): Pr
   return apiFetch<Organization[]>(`/v1/orgs${qs ? `?${qs}` : ""}`);
 }
 
-export async function getOrgAccountByPlatform(orgId: string, platform: string): Promise<OrgAccount | null> {
+export async function getOrgAccountByPlatform(
+  orgId: string,
+  platform: string,
+): Promise<OrgAccount | null> {
   return apiFetch<OrgAccount | null>(`/v1/orgs/${orgId}/accounts?platform=${platform}`);
 }
 
@@ -138,7 +177,11 @@ export async function findBlockedUrl(url: string): Promise<BlockedUrl | null> {
   return apiFetch<BlockedUrl | null>(`/v1/blocked-urls?url=${encoded}&single=true`);
 }
 
-export async function addBlockedUrl(pattern: string, type: "exact" | "domain", reason?: string): Promise<void> {
+export async function addBlockedUrl(
+  pattern: string,
+  type: "exact" | "domain",
+  reason?: string,
+): Promise<void> {
   await apiFetch("/v1/blocked-urls", {
     method: "POST",
     body: JSON.stringify({ pattern, type, reason }),
@@ -160,11 +203,16 @@ export async function getRelease(id: string): Promise<ReleaseWithSource | null> 
 }
 
 export async function deleteRelease(id: string): Promise<boolean> {
-  const result = await apiFetch<{ deleted: boolean } | null>(`/v1/releases/${id}`, { method: "DELETE" });
+  const result = await apiFetch<{ deleted: boolean } | null>(`/v1/releases/${id}`, {
+    method: "DELETE",
+  });
   return result?.deleted ?? false;
 }
 
-export async function updateRelease(id: string, data: Record<string, unknown>): Promise<ReleaseWithSource> {
+export async function updateRelease(
+  id: string,
+  data: Record<string, unknown>,
+): Promise<ReleaseWithSource> {
   return apiFetch<ReleaseWithSource>(`/v1/releases/${id}`, {
     method: "PATCH",
     body: JSON.stringify(data),
@@ -191,10 +239,13 @@ export async function unsuppressRelease(releaseId: string): Promise<boolean> {
 // ── Content hash ──
 
 export async function checkContentHash(source: Source, contentHash: string): Promise<boolean> {
-  const result = await apiFetch<{ unchanged: boolean } | null>(`/v1/sources/${source.slug}/content-hash`, {
-    method: "POST",
-    body: JSON.stringify({ contentHash }),
-  });
+  const result = await apiFetch<{ unchanged: boolean } | null>(
+    `/v1/sources/${source.slug}/content-hash`,
+    {
+      method: "POST",
+      body: JSON.stringify({ contentHash }),
+    },
+  );
   return result?.unchanged ?? false;
 }
 
@@ -243,7 +294,9 @@ export async function listSourcesWithOrg(
   if (opts?.envelope) params.set("envelope", "true");
   const qs = params.toString();
 
-  return apiFetch<SourceWithOrg[] | ListResponse<SourceWithOrg>>(`/v1/sources${qs ? `?${qs}` : ""}`);
+  return apiFetch<SourceWithOrg[] | ListResponse<SourceWithOrg>>(
+    `/v1/sources${qs ? `?${qs}` : ""}`,
+  );
 }
 
 // ── Stats ──
@@ -254,14 +307,28 @@ export async function getStatsSummary(days: number): Promise<StatsSummary> {
   // Compose from existing endpoints
   const [statsData, fetchLogData, sourcesData] = await Promise.all([
     apiFetch<Stats>("/v1/stats"),
-    apiFetch<Array<{
-      id: string; sourceId: string; releasesFound: number; releasesInserted: number;
-      durationMs: number | null; status: string; error: string | null; createdAt: string;
-    }>>("/v1/fetch-log?limit=20"),
-    apiFetch<Array<{
-      slug: string; name: string; type: string; url: string;
-      orgSlug: string | null; releaseCount: number;
-    }>>("/v1/sources"),
+    apiFetch<
+      Array<{
+        id: string;
+        sourceId: string;
+        releasesFound: number;
+        releasesInserted: number;
+        durationMs: number | null;
+        status: string;
+        error: string | null;
+        createdAt: string;
+      }>
+    >("/v1/fetch-log?limit=20"),
+    apiFetch<
+      Array<{
+        slug: string;
+        name: string;
+        type: string;
+        url: string;
+        orgSlug: string | null;
+        releaseCount: number;
+      }>
+    >("/v1/sources"),
   ]);
 
   return {
@@ -347,11 +414,19 @@ export async function getFetchLogs(opts: {
 }): Promise<FetchLogEntry[]> {
   const params = new URLSearchParams({ limit: String(opts.limit) });
   if (opts.sourceSlug) params.set("source", opts.sourceSlug);
-  const logs = await apiFetch<Array<{
-    id: string; sourceId: string; releasesFound: number; releasesInserted: number;
-    durationMs: number | null; status: string; error: string | null;
-    rawContent: string | null; createdAt: string;
-  }>>(`/v1/fetch-log?${params}`);
+  const logs = await apiFetch<
+    Array<{
+      id: string;
+      sourceId: string;
+      releasesFound: number;
+      releasesInserted: number;
+      durationMs: number | null;
+      status: string;
+      error: string | null;
+      rawContent: string | null;
+      createdAt: string;
+    }>
+  >(`/v1/fetch-log?${params}`);
 
   // The API fetch-log endpoint returns raw fetch_log rows without source name/slug.
   // In remote mode we don't have the join data, so we provide what we can.
@@ -370,8 +445,15 @@ export async function getFetchLogs(opts: {
 
 // ── Latest releases ──
 
-function toMediaItems(raw: Array<{ type: string; url: string; alt?: string; r2Url?: string }> | undefined): MediaItem[] {
-  return (raw ?? []).map((m) => ({ type: m.type as MediaItem["type"], url: m.url, alt: m.alt, r2Url: m.r2Url }));
+function toMediaItems(
+  raw: Array<{ type: string; url: string; alt?: string; r2Url?: string }> | undefined,
+): MediaItem[] {
+  return (raw ?? []).map((m) => ({
+    type: m.type as MediaItem["type"],
+    url: m.url,
+    alt: m.alt,
+    r2Url: m.r2Url,
+  }));
 }
 
 type LatestReleasesResponse = {
@@ -420,9 +502,9 @@ export async function getKnownReleasesForSource(
   sourceSlug: string,
   limit: number,
 ): Promise<Array<{ version: string | null; title: string; publishedAt: string | null }>> {
-  const data = await apiFetch<Array<{ version: string | null; title: string; publishedAt: string | null }>>(
-    `/v1/sources/${sourceSlug}/known-releases?limit=${limit}`,
-  );
+  const data = await apiFetch<
+    Array<{ version: string | null; title: string; publishedAt: string | null }>
+  >(`/v1/sources/${sourceSlug}/known-releases?limit=${limit}`);
   return data ?? [];
 }
 
@@ -458,12 +540,19 @@ export async function deleteSource(slug: string): Promise<void> {
   await apiFetch(`/v1/sources/${slug}`, { method: "DELETE" });
 }
 
-export async function insertReleasesBatch(sourceSlug: string, releaseRows: Array<{
-  version?: string | null; title: string; content: string;
-  url?: string | null; contentHash?: string | null; publishedAt?: string | null;
-  type?: ReleaseType;
-}>): Promise<{ inserted: number; total: number }> {
-  const chunks: typeof releaseRows[] = [];
+export async function insertReleasesBatch(
+  sourceSlug: string,
+  releaseRows: Array<{
+    version?: string | null;
+    title: string;
+    content: string;
+    url?: string | null;
+    contentHash?: string | null;
+    publishedAt?: string | null;
+    type?: ReleaseType;
+  }>,
+): Promise<{ inserted: number; total: number }> {
+  const chunks: (typeof releaseRows)[] = [];
   for (let i = 0; i < releaseRows.length; i += 5) {
     chunks.push(releaseRows.slice(i, i + 5));
   }
@@ -472,8 +561,8 @@ export async function insertReleasesBatch(sourceSlug: string, releaseRows: Array
       apiFetch<{ inserted: number; total: number }>(`/v1/sources/${sourceSlug}/releases/batch`, {
         method: "POST",
         body: JSON.stringify({ releases: chunk }),
-      })
-    )
+      }),
+    ),
   );
 
   const succeeded = settled.flatMap((r) => (r.status === "fulfilled" ? [r.value] : []));
@@ -517,7 +606,13 @@ export async function createSource(data: {
 
 export async function createOrg(
   name: string,
-  opts?: { slug?: string; domain?: string; description?: string; category?: string; avatarUrl?: string },
+  opts?: {
+    slug?: string;
+    domain?: string;
+    description?: string;
+    category?: string;
+    avatarUrl?: string;
+  },
 ): Promise<Organization> {
   return apiFetch<Organization>("/v1/orgs", {
     method: "POST",
@@ -536,7 +631,10 @@ export async function removeOrg(slug: string): Promise<void> {
   await apiFetch(`/v1/orgs/${slug}`, { method: "DELETE" });
 }
 
-export async function updateOrg(slug: string, data: Record<string, unknown>): Promise<Organization> {
+export async function updateOrg(
+  slug: string,
+  data: Record<string, unknown>,
+): Promise<Organization> {
   return apiFetch<Organization>(`/v1/orgs/${slug}`, {
     method: "PATCH",
     body: JSON.stringify(data),
@@ -585,7 +683,14 @@ export async function createProduct(
 ): Promise<Product> {
   return apiFetch<Product>(`/v1/products`, {
     method: "POST",
-    body: JSON.stringify({ orgId, name, slug: opts?.slug, url: opts?.url, description: opts?.description, category: opts?.category }),
+    body: JSON.stringify({
+      orgId,
+      name,
+      slug: opts?.slug,
+      url: opts?.url,
+      description: opts?.description,
+      category: opts?.category,
+    }),
   });
 }
 
@@ -593,7 +698,9 @@ export async function findProduct(identifier: string): Promise<Product | null> {
   return apiFetch<Product | null>(`/v1/products/${identifier}`);
 }
 
-export async function getProductsByOrg(orgId: string): Promise<Array<Product & { sourceCount: number }>> {
+export async function getProductsByOrg(
+  orgId: string,
+): Promise<Array<Product & { sourceCount: number }>> {
   return apiFetch<Array<Product & { sourceCount: number }>>(`/v1/products?orgId=${orgId}`);
 }
 
@@ -711,9 +818,7 @@ export async function getOverview(
   return apiFetch<KnowledgePage | null>(`/v1/overview?scope=${scope}&slug=${slug}`);
 }
 
-export async function getPlaybook(
-  slug: string,
-): Promise<KnowledgePage | null> {
+export async function getPlaybook(slug: string): Promise<KnowledgePage | null> {
   return apiFetch<KnowledgePage | null>(`/v1/playbook?slug=${slug}`);
 }
 
@@ -751,9 +856,7 @@ export interface MediaAssetInput {
   releaseId?: string;
 }
 
-export async function insertMediaAssets(
-  assets: MediaAssetInput[],
-): Promise<{ inserted: number }> {
+export async function insertMediaAssets(assets: MediaAssetInput[]): Promise<{ inserted: number }> {
   return apiFetch("/v1/media/assets", {
     method: "POST",
     body: JSON.stringify({ assets }),
@@ -764,7 +867,9 @@ export async function getMediaAssetStats(): Promise<{ count: number; totalBytes:
   return apiFetch("/v1/media/assets/stats");
 }
 
-export async function queryReleasesWithMedia(): Promise<{ id: string; sourceId: string; media: string }[]> {
+export async function queryReleasesWithMedia(): Promise<
+  { id: string; sourceId: string; media: string }[]
+> {
   return apiFetch("/v1/releases?hasMedia=true&fields=id,sourceId,media");
 }
 
@@ -778,8 +883,13 @@ export async function getSession(sessionId: string): Promise<Session | null> {
   return apiFetch<Session | null>(`/v1/sessions/${sessionId}`);
 }
 
-export async function getActiveSources(): Promise<{ slugs: string[]; sessionMap: Record<string, string> }> {
-  return apiFetch<{ slugs: string[]; sessionMap: Record<string, string> }>("/v1/sessions/active-sources");
+export async function getActiveSources(): Promise<{
+  slugs: string[];
+  sessionMap: Record<string, string>;
+}> {
+  return apiFetch<{ slugs: string[]; sessionMap: Record<string, string> }>(
+    "/v1/sessions/active-sources",
+  );
 }
 
 export async function cancelSession(sessionId: string): Promise<{ ok: boolean; error?: string }> {
@@ -840,13 +950,17 @@ export async function addDomainAlias(
 }
 
 export async function removeDomainAlias(domain: string): Promise<boolean> {
-  const result = await apiFetch<{ deleted: boolean } | null>(`/v1/aliases/${encodeURIComponent(domain)}`, { method: "DELETE" });
+  const result = await apiFetch<{ deleted: boolean } | null>(
+    `/v1/aliases/${encodeURIComponent(domain)}`,
+    { method: "DELETE" },
+  );
   return result !== null;
 }
 
-export async function listDomainAliases(
-  target: { orgId?: string; productId?: string },
-): Promise<DomainAlias[]> {
+export async function listDomainAliases(target: {
+  orgId?: string;
+  productId?: string;
+}): Promise<DomainAlias[]> {
   if (!target.orgId && !target.productId) return [];
   const params = target.orgId ? `orgId=${target.orgId}` : `productId=${target.productId}`;
   return apiFetch<DomainAlias[]>(`/v1/aliases?${params}`);
@@ -903,10 +1017,7 @@ export async function isUrlExcluded(
   orgId?: string,
 ): Promise<{ excluded: boolean; reason?: string; scope?: "blocked" | "ignored" }> {
   if (orgId) {
-    const [blocked, ignored] = await Promise.all([
-      findBlockedUrl(url),
-      findIgnoredUrl(url, orgId),
-    ]);
+    const [blocked, ignored] = await Promise.all([findBlockedUrl(url), findIgnoredUrl(url, orgId)]);
     if (blocked) return { excluded: true, reason: blocked.reason ?? undefined, scope: "blocked" };
     if (ignored) return { excluded: true, reason: ignored.reason ?? undefined, scope: "ignored" };
     return { excluded: false };

--- a/src/cli/commands/add.ts
+++ b/src/cli/commands/add.ts
@@ -42,7 +42,14 @@ async function addSingleSource(input: AddSourceInput): Promise<AddSourceResult> 
   const { name, url } = input;
 
   if (input.type && !isValidType(input.type)) {
-    return { name, slug: input.slug ?? toSlug(name), type: input.type, url, status: "error", error: `Invalid type "${input.type}". Must be one of: ${VALID_TYPES.join(", ")}` };
+    return {
+      name,
+      slug: input.slug ?? toSlug(name),
+      type: input.type,
+      url,
+      status: "error",
+      error: `Invalid type "${input.type}". Must be one of: ${VALID_TYPES.join(", ")}`,
+    };
   }
 
   const slug = input.slug ?? toSlug(name);
@@ -63,7 +70,14 @@ async function addSingleSource(input: AddSourceInput): Promise<AddSourceResult> 
   if (input.product) {
     const prod = await findProduct(input.product);
     if (!prod) {
-      return { name, slug, type: "scrape", url, status: "error", error: `Product not found: "${input.product}"` };
+      return {
+        name,
+        slug,
+        type: "scrape",
+        url,
+        status: "error",
+        error: `Product not found: "${input.product}"`,
+      };
     }
     productId = prod.id;
     if (!orgId) orgId = prod.orgId;
@@ -72,8 +86,18 @@ async function addSingleSource(input: AddSourceInput): Promise<AddSourceResult> 
   const exclusion = await isUrlExcluded(url, orgId ?? undefined);
   if (exclusion.excluded) {
     const scopeLabel = exclusion.scope === "blocked" ? "blocked" : "ignored";
-    logger.warn(`Skipping ${scopeLabel} URL: ${url}${exclusion.reason ? ` (${exclusion.reason})` : ""}`);
-    return { name, slug, type: "scrape", url, org: orgName ?? undefined, status: "ignored", reason: exclusion.reason };
+    logger.warn(
+      `Skipping ${scopeLabel} URL: ${url}${exclusion.reason ? ` (${exclusion.reason})` : ""}`,
+    );
+    return {
+      name,
+      slug,
+      type: "scrape",
+      url,
+      org: orgName ?? undefined,
+      status: "ignored",
+      reason: exclusion.reason,
+    };
   }
 
   let sourceType: SourceType;
@@ -119,7 +143,15 @@ async function addSingleSource(input: AddSourceInput): Promise<AddSourceResult> 
     });
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
-    return { name, slug, type: sourceType, url, org: orgName ?? undefined, status: "error", error: message };
+    return {
+      name,
+      slug,
+      type: sourceType,
+      url,
+      org: orgName ?? undefined,
+      status: "error",
+      error: message,
+    };
   }
 
   return { name, slug, type: sourceType, url, org: orgName ?? undefined, status: "added" };
@@ -130,7 +162,10 @@ export function registerAddCommand(program: Command) {
     .command("add")
     .description("Add a new changelog source")
     .argument("[name]", "Display name for the source")
-    .option("--type <type>", "Source type: github, scrape, feed, or agent (auto-detected from URL if omitted)")
+    .option(
+      "--type <type>",
+      "Source type: github, scrape, feed, or agent (auto-detected from URL if omitted)",
+    )
     .option("--url <url>", "URL of the source")
     .option("--slug <slug>", "Custom slug (auto-derived from name if omitted)")
     .option("--org <org>", "Organization name or slug (creates if not found)")
@@ -139,101 +174,133 @@ export function registerAddCommand(program: Command) {
     .option("--feed-url <feedUrl>", "Explicit feed URL")
     .option("--batch <file>", "JSON file with sources to add (use - for stdin)")
     .option("--json", "Output as JSON")
-    .addHelpText("after", `
+    .addHelpText(
+      "after",
+      `
 Examples:
   releases admin source add "Next.js" --url https://github.com/vercel/next.js
   releases admin source add "Astro" --url https://astro.build/blog --type scrape
-  releases admin source add --batch sources.json`)
-    .action(async (name: string | undefined, opts: { type?: string; url?: string; slug?: string; org?: string; product?: string; name?: string; feedUrl?: string; batch?: string; json?: boolean }) => {
-      if (opts.batch) {
-        let raw: string;
-        if (opts.batch === "-") {
-          raw = await Bun.stdin.text();
-        } else {
-          raw = readFileSync(opts.batch, "utf-8");
-        }
+  releases admin source add --batch sources.json`,
+    )
+    .action(
+      async (
+        name: string | undefined,
+        opts: {
+          type?: string;
+          url?: string;
+          slug?: string;
+          org?: string;
+          product?: string;
+          name?: string;
+          feedUrl?: string;
+          batch?: string;
+          json?: boolean;
+        },
+      ) => {
+        if (opts.batch) {
+          let raw: string;
+          if (opts.batch === "-") {
+            raw = await Bun.stdin.text();
+          } else {
+            raw = readFileSync(opts.batch, "utf-8");
+          }
 
-        let entries: AddSourceInput[];
-        try {
-          entries = JSON.parse(raw);
-        } catch {
-          logger.error("Failed to parse batch JSON input");
-          process.exit(1);
-        }
-
-        if (!Array.isArray(entries)) {
-          logger.error("Batch input must be a JSON array");
-          process.exit(1);
-        }
-
-        for (const [i, entry] of entries.entries()) {
-          if (!entry.name || !entry.url) {
-            logger.error(`Entry ${i} is missing required "name" or "url" field`);
+          let entries: AddSourceInput[];
+          try {
+            entries = JSON.parse(raw);
+          } catch {
+            logger.error("Failed to parse batch JSON input");
             process.exit(1);
           }
-        }
 
-        const results: AddSourceResult[] = [];
-        let hasError = false;
-
-        for (const entry of entries) {
-          const result = await addSingleSource({ ...entry, batch: true });
-          results.push(result);
-
-          if (result.status === "error") {
-            hasError = true;
-            if (!opts.json) logger.error(chalk.red(`Failed to add ${result.name}: ${result.error}`));
-          } else if (result.status === "ignored") {
-            if (!opts.json) logger.info(chalk.yellow(`Skipped (ignored): ${result.name} (${result.url})${result.reason ? ` — ${result.reason}` : ""}`));
-          } else if (!opts.json) {
-            const orgLabel = result.org ? ` [org: ${result.org}]` : "";
-            logger.info(chalk.green(`Source added: ${result.name} (${result.slug}) [${result.type}]${orgLabel}`));
+          if (!Array.isArray(entries)) {
+            logger.error("Batch input must be a JSON array");
+            process.exit(1);
           }
+
+          for (const [i, entry] of entries.entries()) {
+            if (!entry.name || !entry.url) {
+              logger.error(`Entry ${i} is missing required "name" or "url" field`);
+              process.exit(1);
+            }
+          }
+
+          const results: AddSourceResult[] = [];
+          let hasError = false;
+
+          for (const entry of entries) {
+            const result = await addSingleSource({ ...entry, batch: true });
+            results.push(result);
+
+            if (result.status === "error") {
+              hasError = true;
+              if (!opts.json)
+                logger.error(chalk.red(`Failed to add ${result.name}: ${result.error}`));
+            } else if (result.status === "ignored") {
+              if (!opts.json)
+                logger.info(
+                  chalk.yellow(
+                    `Skipped (ignored): ${result.name} (${result.url})${result.reason ? ` — ${result.reason}` : ""}`,
+                  ),
+                );
+            } else if (!opts.json) {
+              const orgLabel = result.org ? ` [org: ${result.org}]` : "";
+              logger.info(
+                chalk.green(
+                  `Source added: ${result.name} (${result.slug}) [${result.type}]${orgLabel}`,
+                ),
+              );
+            }
+          }
+
+          if (opts.json) console.log(JSON.stringify(results, null, 2));
+          if (hasError) process.exit(1);
+          return;
         }
 
-        if (opts.json) console.log(JSON.stringify(results, null, 2));
-        if (hasError) process.exit(1);
-        return;
-      }
+        const effectiveName = name ?? opts.name;
+        if (!effectiveName) {
+          console.error("Error: missing required argument: name\n");
+          console.error(
+            '  releases admin source add "My Source" --url https://example.com/changelog',
+          );
+          process.exit(1);
+        }
+        if (!opts.url) {
+          console.error("Error: missing required option: --url\n");
+          process.exit(1);
+        }
 
-      const effectiveName = name ?? opts.name;
-      if (!effectiveName) {
-        console.error("Error: missing required argument: name\n");
-        console.error("  releases admin source add \"My Source\" --url https://example.com/changelog");
-        process.exit(1);
-      }
-      if (!opts.url) {
-        console.error("Error: missing required option: --url\n");
-        process.exit(1);
-      }
+        const result = await addSingleSource({
+          name: effectiveName,
+          url: opts.url,
+          type: opts.type,
+          slug: opts.slug,
+          org: opts.org,
+          product: opts.product,
+          feedUrl: opts.feedUrl,
+        });
 
-      const result = await addSingleSource({
-        name: effectiveName,
-        url: opts.url,
-        type: opts.type,
-        slug: opts.slug,
-        org: opts.org,
-        product: opts.product,
-        feedUrl: opts.feedUrl,
-      });
+        if (result.status === "error") {
+          if (opts.json) console.log(JSON.stringify(result, null, 2));
+          else logger.error(chalk.red(result.error!));
+          process.exit(1);
+        }
 
-      if (result.status === "error") {
-        if (opts.json) console.log(JSON.stringify(result, null, 2));
-        else logger.error(chalk.red(result.error!));
-        process.exit(1);
-      }
+        if (result.status === "ignored") {
+          if (opts.json) console.log(JSON.stringify(result, null, 2));
+          return;
+        }
 
-      if (result.status === "ignored") {
-        if (opts.json) console.log(JSON.stringify(result, null, 2));
-        return;
-      }
-
-      if (opts.json) {
-        console.log(JSON.stringify(result, null, 2));
-      } else {
-        const orgLabel = result.org ? ` [org: ${result.org}]` : "";
-        const typeLabel = !opts.type ? ` (auto-detected: ${result.type})` : "";
-        console.log(chalk.green(`Source added: ${result.name} (${result.slug})${typeLabel}${orgLabel}`));
-      }
-    });
+        if (opts.json) {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          const orgLabel = result.org ? ` [org: ${result.org}]` : "";
+          const typeLabel = !opts.type ? ` (auto-detected: ${result.type})` : "";
+          console.log(
+            chalk.green(`Source added: ${result.name} (${result.slug})${typeLabel}${orgLabel}`),
+          );
+        }
+      },
+    );
 }

--- a/src/cli/commands/admin/embed.ts
+++ b/src/cli/commands/admin/embed.ts
@@ -82,7 +82,9 @@ async function runBackfillLoop(
     summary.remaining = result.remaining;
 
     if (!opts.json) {
-      console.log(`  Batch ${summary.batches}: processed ${result.processed}, succeeded ${result.succeeded}, failed ${result.failed}, remaining ${result.remaining}`);
+      console.log(
+        `  Batch ${summary.batches}: processed ${result.processed}, succeeded ${result.succeeded}, failed ${result.failed}, remaining ${result.remaining}`,
+      );
     }
 
     if (dryRun) break;
@@ -100,16 +102,18 @@ function printSummary(label: string, summary: LoopSummary, json: boolean): void 
   }
   console.log(`Done. Total: ${summary.totalProcessed} processed, ${summary.totalFailed} failed.`);
   if (summary.remaining > 0) {
-    console.log(chalk.dim(`  ${summary.remaining} remaining. Run again or use 'releases admin embed status' to check.`));
+    console.log(
+      chalk.dim(
+        `  ${summary.remaining} remaining. Run again or use 'releases admin embed status' to check.`,
+      ),
+    );
   } else {
     console.log(chalk.dim("  Run 'releases admin embed status' to verify."));
   }
 }
 
 export function registerEmbedCommand(parent: Command): void {
-  const embed = parent
-    .command("embed")
-    .description("Backfill semantic-search embeddings");
+  const embed = parent.command("embed").description("Backfill semantic-search embeddings");
 
   embed
     .command("releases")
@@ -162,16 +166,14 @@ export function registerEmbedCommand(parent: Command): void {
     .option("--limit <n>", "Max files to process across all batches", (v) => parseInt(v, 10))
     .option("--dry-run", "Report what would be processed without writing")
     .option("--json", "Machine-readable JSON output")
-    .action(
-      async (opts: { source?: string; limit?: number; dryRun?: boolean; json?: boolean }) => {
-        const summary = await runBackfillLoop(
-          "changelogs",
-          (limit) => embedChangelogs({ sourceSlug: opts.source, limit, dryRun: opts.dryRun }),
-          opts,
-        );
-        printSummary("changelogs", summary, opts.json === true);
-      },
-    );
+    .action(async (opts: { source?: string; limit?: number; dryRun?: boolean; json?: boolean }) => {
+      const summary = await runBackfillLoop(
+        "changelogs",
+        (limit) => embedChangelogs({ sourceSlug: opts.source, limit, dryRun: opts.dryRun }),
+        opts,
+      );
+      printSummary("changelogs", summary, opts.json === true);
+    });
 
   embed
     .command("status")
@@ -201,9 +203,21 @@ export function registerEmbedCommand(parent: Command): void {
       console.log("");
       console.log(`  Releases:  ${fmt(status.releases.embedded, status.releases.total)}`);
       console.log(`  Entities:  ${fmt(status.entities.embedded, status.entities.total)}`);
-      console.log(chalk.dim(`    orgs:     ${fmt(status.entities.breakdown.org.embedded, status.entities.breakdown.org.total)}`));
-      console.log(chalk.dim(`    products: ${fmt(status.entities.breakdown.product.embedded, status.entities.breakdown.product.total)}`));
-      console.log(chalk.dim(`    sources:  ${fmt(status.entities.breakdown.source.embedded, status.entities.breakdown.source.total)}`));
+      console.log(
+        chalk.dim(
+          `    orgs:     ${fmt(status.entities.breakdown.org.embedded, status.entities.breakdown.org.total)}`,
+        ),
+      );
+      console.log(
+        chalk.dim(
+          `    products: ${fmt(status.entities.breakdown.product.embedded, status.entities.breakdown.product.total)}`,
+        ),
+      );
+      console.log(
+        chalk.dim(
+          `    sources:  ${fmt(status.entities.breakdown.source.embedded, status.entities.breakdown.source.total)}`,
+        ),
+      );
       console.log(`  Chunks:    ${fmt(status.chunks.embedded, status.chunks.total)}`);
     });
 }

--- a/src/cli/commands/block.ts
+++ b/src/cli/commands/block.ts
@@ -4,18 +4,19 @@ import { listBlockedUrls, addBlockedUrl, removeBlockedUrl } from "../../api/clie
 import { logger } from "@releases/lib/logger";
 
 export function registerBlockCommand(program: Command) {
-  const block = program
-    .command("block")
-    .description("Manage globally blocked URLs and domains");
+  const block = program.command("block").description("Manage globally blocked URLs and domains");
 
   block
     .command("list")
     .description("List all globally blocked patterns")
     .option("--json", "Output as JSON")
-    .addHelpText("after", `
+    .addHelpText(
+      "after",
+      `
 Examples:
   releases admin policy block list
-  releases admin policy block list --json`)
+  releases admin policy block list --json`,
+    )
     .action(async (opts: { json?: boolean }) => {
       const rows = await listBlockedUrls();
 
@@ -43,40 +44,67 @@ Examples:
     .option("--reason <reason>", "Reason for blocking")
     .option("--dry-run", "Show what would be blocked without writing")
     .option("--json", "Output as JSON")
-    .addHelpText("after", `
+    .addHelpText(
+      "after",
+      `
 Examples:
   releases admin policy block add https://example.com/spam
   releases admin policy block add example.com --domain --reason "spam site"
-  releases admin policy block add https://example.com/spam --dry-run`)
-    .action(async (pattern: string, opts: { domain?: boolean; reason?: string; dryRun?: boolean; json?: boolean }) => {
-      const type = opts.domain ? "domain" as const : "exact" as const;
-      const typeLabel = type === "domain" ? "domain" : "URL";
+  releases admin policy block add https://example.com/spam --dry-run`,
+    )
+    .action(
+      async (
+        pattern: string,
+        opts: { domain?: boolean; reason?: string; dryRun?: boolean; json?: boolean },
+      ) => {
+        const type = opts.domain ? ("domain" as const) : ("exact" as const);
+        const typeLabel = type === "domain" ? "domain" : "URL";
 
-      if (opts.dryRun) {
-        if (opts.json) {
-          console.log(JSON.stringify({ pattern, type, reason: opts.reason ?? null, dryRun: true }, null, 2));
-        } else {
-          logger.info(chalk.yellow(`[dry-run] Would block ${typeLabel}: ${pattern}${opts.reason ? ` (${opts.reason})` : ""}`));
+        if (opts.dryRun) {
+          if (opts.json) {
+            console.log(
+              JSON.stringify({ pattern, type, reason: opts.reason ?? null, dryRun: true }, null, 2),
+            );
+          } else {
+            logger.info(
+              chalk.yellow(
+                `[dry-run] Would block ${typeLabel}: ${pattern}${opts.reason ? ` (${opts.reason})` : ""}`,
+              ),
+            );
+          }
+          return;
         }
-        return;
-      }
 
-      await addBlockedUrl(pattern, type, opts.reason);
-      if (opts.json) {
-        console.log(JSON.stringify({ pattern, type, reason: opts.reason ?? null, status: "blocked" }, null, 2));
-      } else {
-        logger.info(chalk.green(`Blocked ${typeLabel}: ${pattern}${opts.reason ? ` (${opts.reason})` : ""}`));
-      }
-    });
+        await addBlockedUrl(pattern, type, opts.reason);
+        if (opts.json) {
+          console.log(
+            JSON.stringify(
+              { pattern, type, reason: opts.reason ?? null, status: "blocked" },
+              null,
+              2,
+            ),
+          );
+        } else {
+          logger.info(
+            chalk.green(
+              `Blocked ${typeLabel}: ${pattern}${opts.reason ? ` (${opts.reason})` : ""}`,
+            ),
+          );
+        }
+      },
+    );
 
   block
     .command("remove <pattern>")
     .description("Unblock a URL or domain")
     .option("--json", "Output as JSON")
-    .addHelpText("after", `
+    .addHelpText(
+      "after",
+      `
 Examples:
   releases admin policy block remove https://example.com/spam
-  releases admin policy block remove example.com`)
+  releases admin policy block remove example.com`,
+    )
     .action(async (pattern: string, opts: { json?: boolean }) => {
       await removeBlockedUrl(pattern);
       if (opts.json) {

--- a/src/cli/commands/changelog.ts
+++ b/src/cli/commands/changelog.ts
@@ -8,35 +8,48 @@ import { logger } from "@releases/lib/logger";
 export function registerChangelogCommand(program: Command) {
   program
     .command("changelog")
-    .description("Print the tracked CHANGELOG file for a source, optionally sliced by char range or token budget")
+    .description(
+      "Print the tracked CHANGELOG file for a source, optionally sliced by char range or token budget",
+    )
     .argument("<slug>", "Source ID or slug")
     .option("--path <path>", "Specific file path to read (e.g. packages/next/CHANGELOG.md)")
     .option("--offset <n>", "Character offset to start reading from", (v) => parseInt(v, 10))
-    .option("--limit <n>", "Max characters to read (snapped to heading boundaries)", (v) => parseInt(v, 10))
-    .option("--tokens <n>", "Target slice size in tokens (cl100k_base). Overrides --limit.", (v) => parseInt(v, 10))
+    .option("--limit <n>", "Max characters to read (snapped to heading boundaries)", (v) =>
+      parseInt(v, 10),
+    )
+    .option("--tokens <n>", "Target slice size in tokens (cl100k_base). Overrides --limit.", (v) =>
+      parseInt(v, 10),
+    )
     .option("--json", "Output as JSON")
-    .action(async (slug: string, opts: { path?: string; offset?: number; limit?: number; tokens?: number; json?: boolean }) => {
-      const source = await findSource(slug);
-      if (!source) return sourceNotFound(slug);
+    .action(
+      async (
+        slug: string,
+        opts: { path?: string; offset?: number; limit?: number; tokens?: number; json?: boolean },
+      ) => {
+        const source = await findSource(slug);
+        if (!source) return sourceNotFound(slug);
 
-      const response = await sourceChangelog(source.slug, {
-        path: opts.path,
-        offset: opts.offset,
-        limit: opts.limit,
-        tokens: opts.tokens,
-      });
-      if (!response) {
-        logger.error(`No CHANGELOG file is tracked for ${source.slug}. Only GitHub sources expose this.`);
-        process.exit(1);
-      }
+        const response = await sourceChangelog(source.slug, {
+          path: opts.path,
+          offset: opts.offset,
+          limit: opts.limit,
+          tokens: opts.tokens,
+        });
+        if (!response) {
+          logger.error(
+            `No CHANGELOG file is tracked for ${source.slug}. Only GitHub sources expose this.`,
+          );
+          process.exit(1);
+        }
 
-      if (opts.json) {
-        console.log(JSON.stringify(response, null, 2));
-        return;
-      }
+        if (opts.json) {
+          console.log(JSON.stringify(response, null, 2));
+          return;
+        }
 
-      process.stdout.write(response.content);
-      if (!response.content.endsWith("\n")) process.stdout.write("\n");
-      console.error(chalk.dim(`\n— ${formatChangelogSliceLine(response)} —`));
-    });
+        process.stdout.write(response.content);
+        if (!response.content.endsWith("\n")) process.stdout.write("\n");
+        console.error(chalk.dim(`\n— ${formatChangelogSliceLine(response)} —`));
+      },
+    );
 }

--- a/src/cli/commands/check.ts
+++ b/src/cli/commands/check.ts
@@ -111,14 +111,16 @@ export function registerCheckCommand(program: Command) {
           console.error(`Source not found: ${slug}`);
           process.exit(1);
         }
-        sourcesToCheck = [{
-          name: source.name,
-          slug: source.slug,
-          type: source.type,
-          url: source.url,
-          metadata: source.metadata,
-          lastFetchedAt: source.lastFetchedAt,
-        }];
+        sourcesToCheck = [
+          {
+            name: source.name,
+            slug: source.slug,
+            type: source.type,
+            url: source.url,
+            metadata: source.metadata,
+            lastFetchedAt: source.lastFetchedAt,
+          },
+        ];
       } else {
         const rows = await listSourcesWithOrg();
         sourcesToCheck = rows.map((r) => ({

--- a/src/cli/commands/edit.ts
+++ b/src/cli/commands/edit.ts
@@ -1,6 +1,13 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { findSource, findOrg, createOrg, updateSource, findProduct, updateSourceMeta } from "../../api/client.js";
+import {
+  findSource,
+  findOrg,
+  createOrg,
+  updateSource,
+  findProduct,
+  updateSourceMeta,
+} from "../../api/client.js";
 import { sourceNotFound } from "../suggest.js";
 import { toSlug } from "@releases/core/slug";
 import { logger } from "@releases/lib/logger";
@@ -43,162 +50,214 @@ export function registerEditCommand(program: Command) {
     .option("--disable", "Disable source")
     .option("--enable", "Re-enable a disabled source")
     .option("--json", "Output as JSON")
-    .action(async (identifier: string, opts: {
-      name?: string; url?: string; type?: string; slug?: string;
-      confirmSlugChange?: boolean;
-      org?: string | boolean; product?: string | boolean; feedUrl?: string | boolean; json?: boolean;
-      markdownUrl?: string; provider?: string; fetchMethod?: string;
-      parseInstructions?: string | boolean;
-      render?: boolean;
-      primary?: boolean;
-      priority?: string;
-      disable?: boolean;
-      enable?: boolean;
-    }) => {
-      const source = await findSource(identifier);
-      if (!source) return sourceNotFound(identifier);
+    .action(
+      async (
+        identifier: string,
+        opts: {
+          name?: string;
+          url?: string;
+          type?: string;
+          slug?: string;
+          confirmSlugChange?: boolean;
+          org?: string | boolean;
+          product?: string | boolean;
+          feedUrl?: string | boolean;
+          json?: boolean;
+          markdownUrl?: string;
+          provider?: string;
+          fetchMethod?: string;
+          parseInstructions?: string | boolean;
+          render?: boolean;
+          primary?: boolean;
+          priority?: string;
+          disable?: boolean;
+          enable?: boolean;
+        },
+      ) => {
+        const source = await findSource(identifier);
+        if (!source) return sourceNotFound(identifier);
 
-      if (opts.type && !(VALID_TYPES as readonly string[]).includes(opts.type)) {
-        console.error(chalk.red(`Invalid type "${opts.type}". Must be one of: ${VALID_TYPES.join(", ")}`));
-        process.exit(1);
-      }
-
-      const VALID_METHODS = ["feed", "markdown", "scrape", "crawl", "github"];
-      if (opts.fetchMethod && !VALID_METHODS.includes(opts.fetchMethod)) {
-        console.error(chalk.red(`Invalid fetch method "${opts.fetchMethod}". Must be one of: ${VALID_METHODS.join(", ")}`));
-        process.exit(1);
-      }
-
-      if (opts.slug && !opts.confirmSlugChange) {
-        console.error(chalk.red("Slug changes break existing web links and bookmarks."));
-        console.error(chalk.yellow(`  Current: releases.sh/${source.slug}`));
-        console.error(chalk.yellow(`  New:     releases.sh/${opts.slug}`));
-        console.error(`\nAdd ${chalk.bold("--confirm-slug-change")} to proceed.`);
-        process.exit(1);
-      }
-
-      const updates: Record<string, unknown> = {};
-      const changes: string[] = [];
-
-      if (opts.name) { updates.name = opts.name; changes.push(`name → ${opts.name}`); }
-      if (opts.url) { updates.url = opts.url; changes.push(`url → ${opts.url}`); }
-      if (opts.type) { updates.type = opts.type; changes.push(`type → ${opts.type}`); }
-      if (opts.slug) { updates.slug = opts.slug; changes.push(`slug → ${opts.slug}`); }
-
-      if (opts.org === false) {
-        updates.orgId = null;
-        changes.push("org removed");
-      } else if (typeof opts.org === "string") {
-        let org = await findOrg(opts.org);
-        if (!org) {
-          org = await createOrg(opts.org, { slug: toSlug(opts.org) });
-          logger.info(`Created organization: ${org.name} (${org.slug})`);
-        }
-        updates.orgId = org.id;
-        changes.push(`org → ${org.name}`);
-      }
-
-      if (opts.product === false) {
-        updates.productId = null;
-        changes.push("product removed");
-      } else if (typeof opts.product === "string") {
-        const prod = await findProduct(opts.product);
-        if (!prod) {
-          console.error(chalk.red(`Product not found: ${opts.product}`));
+        if (opts.type && !(VALID_TYPES as readonly string[]).includes(opts.type)) {
+          console.error(
+            chalk.red(`Invalid type "${opts.type}". Must be one of: ${VALID_TYPES.join(", ")}`),
+          );
           process.exit(1);
         }
-        updates.productId = prod.id;
-        changes.push(`product → ${prod.name}`);
-      }
 
-      if (opts.primary !== undefined) {
-        updates.isPrimary = opts.primary;
-        changes.push(opts.primary ? "marked as primary" : "unmarked as primary");
-      }
-
-      if (opts.priority) {
-        const validPriorities = ["normal", "low", "paused"];
-        if (!validPriorities.includes(opts.priority)) {
-          console.error(chalk.red(`Invalid priority "${opts.priority}". Must be one of: ${validPriorities.join(", ")}`));
+        const VALID_METHODS = ["feed", "markdown", "scrape", "crawl", "github"];
+        if (opts.fetchMethod && !VALID_METHODS.includes(opts.fetchMethod)) {
+          console.error(
+            chalk.red(
+              `Invalid fetch method "${opts.fetchMethod}". Must be one of: ${VALID_METHODS.join(", ")}`,
+            ),
+          );
           process.exit(1);
         }
-        updates.fetchPriority = opts.priority;
-        changes.push(`priority → ${opts.priority}`);
-      }
 
-      if (opts.disable) { updates.isHidden = true; changes.push("disabled"); }
-      else if (opts.enable) { updates.isHidden = false; changes.push("enabled"); }
-
-      const metaUpdates: Record<string, unknown> = {};
-
-      if (opts.feedUrl === false) {
-        Object.assign(metaUpdates, { feedUrl: undefined, feedType: undefined, feedDiscoveredAt: undefined, noFeedFound: true });
-        changes.push("feed URL removed (feed discovery disabled)");
-      } else if (typeof opts.feedUrl === "string") {
-        const feedType = inferFeedTypeFromUrl(opts.feedUrl);
-        Object.assign(metaUpdates, { feedUrl: opts.feedUrl, feedType, feedDiscoveredAt: new Date().toISOString(), noFeedFound: false });
-        changes.push(`feed URL → ${opts.feedUrl} (${feedType})`);
-      }
-
-      if (opts.markdownUrl) {
-        metaUpdates.markdownUrl = opts.markdownUrl;
-        changes.push(`markdown URL → ${opts.markdownUrl}`);
-      }
-
-      if (opts.provider) {
-        metaUpdates.provider = opts.provider;
-        metaUpdates.providerDetectedAt = new Date().toISOString();
-        changes.push(`provider → ${opts.provider}`);
-      }
-
-      if (opts.fetchMethod) {
-        metaUpdates.evaluatedMethod = opts.fetchMethod;
-        metaUpdates.evaluatedAt = new Date().toISOString();
-        changes.push(`fetch method → ${opts.fetchMethod}`);
-      }
-
-      if (opts.parseInstructions === false || opts.parseInstructions === "") {
-        metaUpdates.parseInstructions = undefined;
-        changes.push("parse instructions removed");
-      } else if (typeof opts.parseInstructions === "string") {
-        metaUpdates.parseInstructions = opts.parseInstructions;
-        changes.push(`parse instructions → "${opts.parseInstructions.slice(0, 60)}${opts.parseInstructions.length > 60 ? "..." : ""}"`);
-      }
-
-      if (opts.render === true) {
-        metaUpdates.renderRequired = true;
-        changes.push("rendering → required (headless browser)");
-      } else if (opts.render === false) {
-        metaUpdates.renderRequired = false;
-        changes.push("rendering → disabled (fast fetch)");
-      }
-
-      if (Object.keys(metaUpdates).length > 0) {
-        await updateSourceMeta(source, metaUpdates);
-      }
-
-      if (Object.keys(updates).length > 0) {
-        const updated = await updateSource(source.slug, updates);
-        if (opts.slug && updated.slug !== opts.slug) {
-          const idx = changes.findIndex((c) => c.startsWith("slug →"));
-          if (idx !== -1) changes.splice(idx, 1);
-          logger.warn(`Slug was not updated (API returned slug="${updated.slug}")`);
+        if (opts.slug && !opts.confirmSlugChange) {
+          console.error(chalk.red("Slug changes break existing web links and bookmarks."));
+          console.error(chalk.yellow(`  Current: releases.sh/${source.slug}`));
+          console.error(chalk.yellow(`  New:     releases.sh/${opts.slug}`));
+          console.error(`\nAdd ${chalk.bold("--confirm-slug-change")} to proceed.`);
+          process.exit(1);
         }
-      }
 
-      if (changes.length === 0) {
-        console.log(chalk.yellow("No changes specified. Use --help to see options."));
-        return;
-      }
+        const updates: Record<string, unknown> = {};
+        const changes: string[] = [];
 
-      const displaySlug = opts.slug ?? source.slug;
+        if (opts.name) {
+          updates.name = opts.name;
+          changes.push(`name → ${opts.name}`);
+        }
+        if (opts.url) {
+          updates.url = opts.url;
+          changes.push(`url → ${opts.url}`);
+        }
+        if (opts.type) {
+          updates.type = opts.type;
+          changes.push(`type → ${opts.type}`);
+        }
+        if (opts.slug) {
+          updates.slug = opts.slug;
+          changes.push(`slug → ${opts.slug}`);
+        }
 
-      if (opts.json) {
-        const refreshed = await findSource(displaySlug);
-        console.log(JSON.stringify(refreshed, null, 2));
-      } else {
-        console.log(chalk.green(`Updated ${source.name} (${displaySlug}):`));
-        for (const change of changes) console.log(`  ${change}`);
-      }
-    });
+        if (opts.org === false) {
+          updates.orgId = null;
+          changes.push("org removed");
+        } else if (typeof opts.org === "string") {
+          let org = await findOrg(opts.org);
+          if (!org) {
+            org = await createOrg(opts.org, { slug: toSlug(opts.org) });
+            logger.info(`Created organization: ${org.name} (${org.slug})`);
+          }
+          updates.orgId = org.id;
+          changes.push(`org → ${org.name}`);
+        }
+
+        if (opts.product === false) {
+          updates.productId = null;
+          changes.push("product removed");
+        } else if (typeof opts.product === "string") {
+          const prod = await findProduct(opts.product);
+          if (!prod) {
+            console.error(chalk.red(`Product not found: ${opts.product}`));
+            process.exit(1);
+          }
+          updates.productId = prod.id;
+          changes.push(`product → ${prod.name}`);
+        }
+
+        if (opts.primary !== undefined) {
+          updates.isPrimary = opts.primary;
+          changes.push(opts.primary ? "marked as primary" : "unmarked as primary");
+        }
+
+        if (opts.priority) {
+          const validPriorities = ["normal", "low", "paused"];
+          if (!validPriorities.includes(opts.priority)) {
+            console.error(
+              chalk.red(
+                `Invalid priority "${opts.priority}". Must be one of: ${validPriorities.join(", ")}`,
+              ),
+            );
+            process.exit(1);
+          }
+          updates.fetchPriority = opts.priority;
+          changes.push(`priority → ${opts.priority}`);
+        }
+
+        if (opts.disable) {
+          updates.isHidden = true;
+          changes.push("disabled");
+        } else if (opts.enable) {
+          updates.isHidden = false;
+          changes.push("enabled");
+        }
+
+        const metaUpdates: Record<string, unknown> = {};
+
+        if (opts.feedUrl === false) {
+          Object.assign(metaUpdates, {
+            feedUrl: undefined,
+            feedType: undefined,
+            feedDiscoveredAt: undefined,
+            noFeedFound: true,
+          });
+          changes.push("feed URL removed (feed discovery disabled)");
+        } else if (typeof opts.feedUrl === "string") {
+          const feedType = inferFeedTypeFromUrl(opts.feedUrl);
+          Object.assign(metaUpdates, {
+            feedUrl: opts.feedUrl,
+            feedType,
+            feedDiscoveredAt: new Date().toISOString(),
+            noFeedFound: false,
+          });
+          changes.push(`feed URL → ${opts.feedUrl} (${feedType})`);
+        }
+
+        if (opts.markdownUrl) {
+          metaUpdates.markdownUrl = opts.markdownUrl;
+          changes.push(`markdown URL → ${opts.markdownUrl}`);
+        }
+
+        if (opts.provider) {
+          metaUpdates.provider = opts.provider;
+          metaUpdates.providerDetectedAt = new Date().toISOString();
+          changes.push(`provider → ${opts.provider}`);
+        }
+
+        if (opts.fetchMethod) {
+          metaUpdates.evaluatedMethod = opts.fetchMethod;
+          metaUpdates.evaluatedAt = new Date().toISOString();
+          changes.push(`fetch method → ${opts.fetchMethod}`);
+        }
+
+        if (opts.parseInstructions === false || opts.parseInstructions === "") {
+          metaUpdates.parseInstructions = undefined;
+          changes.push("parse instructions removed");
+        } else if (typeof opts.parseInstructions === "string") {
+          metaUpdates.parseInstructions = opts.parseInstructions;
+          changes.push(
+            `parse instructions → "${opts.parseInstructions.slice(0, 60)}${opts.parseInstructions.length > 60 ? "..." : ""}"`,
+          );
+        }
+
+        if (opts.render === true) {
+          metaUpdates.renderRequired = true;
+          changes.push("rendering → required (headless browser)");
+        } else if (opts.render === false) {
+          metaUpdates.renderRequired = false;
+          changes.push("rendering → disabled (fast fetch)");
+        }
+
+        if (Object.keys(metaUpdates).length > 0) {
+          await updateSourceMeta(source, metaUpdates);
+        }
+
+        if (Object.keys(updates).length > 0) {
+          const updated = await updateSource(source.slug, updates);
+          if (opts.slug && updated.slug !== opts.slug) {
+            const idx = changes.findIndex((c) => c.startsWith("slug →"));
+            if (idx !== -1) changes.splice(idx, 1);
+            logger.warn(`Slug was not updated (API returned slug="${updated.slug}")`);
+          }
+        }
+
+        if (changes.length === 0) {
+          console.log(chalk.yellow("No changes specified. Use --help to see options."));
+          return;
+        }
+
+        const displaySlug = opts.slug ?? source.slug;
+
+        if (opts.json) {
+          const refreshed = await findSource(displaySlug);
+          console.log(JSON.stringify(refreshed, null, 2));
+        } else {
+          console.log(chalk.green(`Updated ${source.name} (${displaySlug}):`));
+          for (const change of changes) console.log(`  ${change}`);
+        }
+      },
+    );
 }

--- a/src/cli/commands/fetch-log.ts
+++ b/src/cli/commands/fetch-log.ts
@@ -11,12 +11,15 @@ export function registerFetchLogCommand(program: Command) {
     .description("Show fetch history for sources")
     .option("--limit <n>", "Number of log entries", "20")
     .option("--json", "Output as JSON")
-    .addHelpText("after", `
+    .addHelpText(
+      "after",
+      `
 Examples:
   releases admin source fetch-log                 Show recent fetch history
   releases admin source fetch-log my-source       Show history for one source
   releases admin source fetch-log --limit 50
-  releases admin source fetch-log --json`)
+  releases admin source fetch-log --json`,
+    )
     .action(async (slug: string | undefined, opts: { limit?: string; json?: boolean }) => {
       const limit = parseInt(opts.limit ?? "20", 10);
       const logs = await getFetchLogs({ sourceSlug: slug, limit });
@@ -48,13 +51,14 @@ Examples:
       });
 
       for (const log of logs) {
-        const statusLabel = log.status === "dry_run"
-          ? chalk.magenta("dry run")
-          : log.status === "success"
-            ? chalk.green("success")
-            : log.status === "error"
-              ? chalk.red("error")
-              : chalk.dim("no change");
+        const statusLabel =
+          log.status === "dry_run"
+            ? chalk.magenta("dry run")
+            : log.status === "success"
+              ? chalk.green("success")
+              : log.status === "error"
+                ? chalk.red("error")
+                : chalk.dim("no change");
 
         const errorText = log.error
           ? chalk.red(stripAnsi(log.error.length > 40 ? log.error.slice(0, 40) + "..." : log.error))

--- a/src/cli/commands/fetch.ts
+++ b/src/cli/commands/fetch.ts
@@ -2,8 +2,13 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { logger } from "@releases/lib/logger";
 import {
-  apiFetch, getActiveSources, listFetchableSources, listSourcesWithChanges,
-  findSource, findOrg, getSourcesByOrg,
+  apiFetch,
+  getActiveSources,
+  listFetchableSources,
+  listSourcesWithChanges,
+  findSource,
+  findOrg,
+  getSourcesByOrg,
 } from "../../api/client.js";
 import { newCorrelationId } from "@releases/core/id";
 import { orgNotFound, sourceNotFound } from "../suggest.js";
@@ -11,7 +16,9 @@ import { orgNotFound, sourceNotFound } from "../suggest.js";
 export function registerFetchCommand(program: Command) {
   program
     .command("fetch")
-    .description("Fetch releases from configured sources (delegated to a remote managed-agent session)")
+    .description(
+      "Fetch releases from configured sources (delegated to a remote managed-agent session)",
+    )
     .argument("[identifier]", "Source ID (src_...) or slug to fetch")
     .option("--source <identifier>", "Source ID or slug")
     .option("--json", "Output as JSON")
@@ -20,7 +27,9 @@ export function registerFetchCommand(program: Command) {
     .option("--changed", "Only fetch sources where poll detected upstream changes")
     .option("--retry-errors", "Only fetch sources whose last fetch was an error")
     .option("--org <slug>", "Fetch all active sources for an organization")
-    .addHelpText("after", `
+    .addHelpText(
+      "after",
+      `
 Examples:
   releases admin source fetch src_abc123            Fetch a single source by ID
   releases admin source fetch my-source             Fetch a single source by slug
@@ -28,103 +37,137 @@ Examples:
   releases admin source fetch --unfetched           Fetch sources never fetched before
   releases admin source fetch --changed             Fetch sources where poll detected changes
   releases admin source fetch --retry-errors        Retry sources that errored last time
-  releases admin source fetch --org acme            Fetch all active sources for an org`)
-    .action(async (slugArg: string | undefined, opts: {
-      source?: string; json?: boolean;
-      unfetched?: boolean; stale?: string; changed?: boolean; retryErrors?: boolean;
-      org?: string;
-    }) => {
-      const identifier = slugArg ?? opts.source;
+  releases admin source fetch --org acme            Fetch all active sources for an org`,
+    )
+    .action(
+      async (
+        slugArg: string | undefined,
+        opts: {
+          source?: string;
+          json?: boolean;
+          unfetched?: boolean;
+          stale?: string;
+          changed?: boolean;
+          retryErrors?: boolean;
+          org?: string;
+        },
+      ) => {
+        const identifier = slugArg ?? opts.source;
 
-      let entries: Array<{ id: string; slug: string }> = [];
-      let label = "manual fetch";
-      let orgId: string | undefined;
+        let entries: Array<{ id: string; slug: string }> = [];
+        let label = "manual fetch";
+        let orgId: string | undefined;
 
-      if (opts.org) {
-        const org = await findOrg(opts.org);
-        if (!org) return orgNotFound(opts.org);
-        orgId = org.id;
-        const activeSources = (await getSourcesByOrg(org.id)).filter((s) => !s.isHidden && s.fetchPriority !== "paused");
-        if (activeSources.length === 0) {
-          if (opts.json) console.log(JSON.stringify({ sessionId: null, message: "No active sources" }));
-          else logger.info(`No active sources for ${org.name}.`);
-          return;
-        }
-        entries = activeSources.map((s) => ({ id: s.id, slug: s.slug }));
-        label = `all sources for ${org.slug} (${entries.length})`;
-      } else if (identifier) {
-        const src = await findSource(identifier);
-        if (!src) return sourceNotFound(identifier);
-        entries = [{ id: src.id, slug: src.slug }];
-        if (src.orgId) orgId = src.orgId;
-        label = src.slug;
-      } else if (opts.unfetched) {
-        const sources = await listFetchableSources({ mode: "unfetched" });
-        entries = sources.map((s) => ({ id: s.id, slug: s.slug }));
-        label = `${entries.length} unfetched sources`;
-      } else if (opts.stale) {
-        const hours = parseInt(opts.stale, 10);
-        const sources = await listFetchableSources({ mode: "stale", staleHours: hours });
-        entries = sources.map((s) => ({ id: s.id, slug: s.slug }));
-        label = `${entries.length} stale sources (>${hours}h)`;
-      } else if (opts.changed) {
-        const allChanged = await listSourcesWithChanges();
-        const sources = allChanged.filter((s) => s.type === "scrape" || s.type === "agent");
-        const skipped = allChanged.length - sources.length;
-        if (skipped > 0) logger.info(`Skipping ${skipped} feed/github source(s) (handled by cron)`);
-        entries = sources.map((s) => ({ id: s.id, slug: s.slug }));
-        label = `${entries.length} changed scrape/agent sources`;
-      } else if (opts.retryErrors) {
-        const sources = await listFetchableSources({ mode: "retry_errors" });
-        entries = sources.map((s) => ({ id: s.id, slug: s.slug }));
-        label = `${entries.length} errored sources`;
-      } else {
-        logger.error("fetch requires a source slug or filter (--stale, --unfetched, --changed, --retry-errors, --org)");
-        process.exit(1);
-      }
-
-      if (entries.length === 0) {
-        if (opts.json) console.log(JSON.stringify({ sessionId: null, message: "No matching sources" }));
-        else logger.info("No matching sources to fetch.");
-        return;
-      }
-
-      if (entries.length > 20) {
-        logger.warn(`Capping at 20 sources (${entries.length} matched). Use multiple sessions for larger batches.`);
-        entries = entries.slice(0, 20);
-      }
-
-      try {
-        const { slugs: activeSlugs, sessionMap } = await getActiveSources();
-        const overlapping = entries.filter((e) => activeSlugs.includes(e.slug));
-        if (overlapping.length > 0) {
-          const overlapSessionId = sessionMap[overlapping[0].slug];
-          const sourceList = overlapping.length <= 3 ? overlapping.map((e) => e.slug).join(", ") : `${overlapping.length} sources`;
-          console.error(chalk.red(`Source ${sourceList} already being fetched in session ${overlapSessionId.slice(0, 8)}.`));
+        if (opts.org) {
+          const org = await findOrg(opts.org);
+          if (!org) return orgNotFound(opts.org);
+          orgId = org.id;
+          const activeSources = (await getSourcesByOrg(org.id)).filter(
+            (s) => !s.isHidden && s.fetchPriority !== "paused",
+          );
+          if (activeSources.length === 0) {
+            if (opts.json)
+              console.log(JSON.stringify({ sessionId: null, message: "No active sources" }));
+            else logger.info(`No active sources for ${org.name}.`);
+            return;
+          }
+          entries = activeSources.map((s) => ({ id: s.id, slug: s.slug }));
+          label = `all sources for ${org.slug} (${entries.length})`;
+        } else if (identifier) {
+          const src = await findSource(identifier);
+          if (!src) return sourceNotFound(identifier);
+          entries = [{ id: src.id, slug: src.slug }];
+          if (src.orgId) orgId = src.orgId;
+          label = src.slug;
+        } else if (opts.unfetched) {
+          const sources = await listFetchableSources({ mode: "unfetched" });
+          entries = sources.map((s) => ({ id: s.id, slug: s.slug }));
+          label = `${entries.length} unfetched sources`;
+        } else if (opts.stale) {
+          const hours = parseInt(opts.stale, 10);
+          const sources = await listFetchableSources({ mode: "stale", staleHours: hours });
+          entries = sources.map((s) => ({ id: s.id, slug: s.slug }));
+          label = `${entries.length} stale sources (>${hours}h)`;
+        } else if (opts.changed) {
+          const allChanged = await listSourcesWithChanges();
+          const sources = allChanged.filter((s) => s.type === "scrape" || s.type === "agent");
+          const skipped = allChanged.length - sources.length;
+          if (skipped > 0)
+            logger.info(`Skipping ${skipped} feed/github source(s) (handled by cron)`);
+          entries = sources.map((s) => ({ id: s.id, slug: s.slug }));
+          label = `${entries.length} changed scrape/agent sources`;
+        } else if (opts.retryErrors) {
+          const sources = await listFetchableSources({ mode: "retry_errors" });
+          entries = sources.map((s) => ({ id: s.id, slug: s.slug }));
+          label = `${entries.length} errored sources`;
+        } else {
+          logger.error(
+            "fetch requires a source slug or filter (--stale, --unfetched, --changed, --retry-errors, --org)",
+          );
           process.exit(1);
         }
-      } catch {
-        if (!opts.json) logger.warn("Could not check for overlapping sessions — proceeding anyway.");
-      }
 
-      const sourceIdentifiers = entries.map((e) => e.id);
+        if (entries.length === 0) {
+          if (opts.json)
+            console.log(JSON.stringify({ sessionId: null, message: "No matching sources" }));
+          else logger.info("No matching sources to fetch.");
+          return;
+        }
 
-      let result: { sessionId: string };
-      try {
-        result = await apiFetch<{ sessionId: string }>("/v1/update", {
-          method: "POST",
-          body: JSON.stringify({ company: label, sourceIdentifiers, orgId, correlationId: newCorrelationId() }),
-        });
-      } catch (err) {
-        logger.error(`Failed to start update session: ${err instanceof Error ? err.message : String(err)}`);
-        process.exit(1);
-      }
-      if (opts.json) {
-        console.log(JSON.stringify(result, null, 2));
-      } else {
-        logger.info(`Update session started: ${result.sessionId}`);
-        logger.info(`Fetching ${sourceIdentifiers.length} source(s).`);
-        logger.info(`Track progress: releases admin discovery task list`);
-      }
-    });
+        if (entries.length > 20) {
+          logger.warn(
+            `Capping at 20 sources (${entries.length} matched). Use multiple sessions for larger batches.`,
+          );
+          entries = entries.slice(0, 20);
+        }
+
+        try {
+          const { slugs: activeSlugs, sessionMap } = await getActiveSources();
+          const overlapping = entries.filter((e) => activeSlugs.includes(e.slug));
+          if (overlapping.length > 0) {
+            const overlapSessionId = sessionMap[overlapping[0].slug];
+            const sourceList =
+              overlapping.length <= 3
+                ? overlapping.map((e) => e.slug).join(", ")
+                : `${overlapping.length} sources`;
+            console.error(
+              chalk.red(
+                `Source ${sourceList} already being fetched in session ${overlapSessionId.slice(0, 8)}.`,
+              ),
+            );
+            process.exit(1);
+          }
+        } catch {
+          if (!opts.json)
+            logger.warn("Could not check for overlapping sessions — proceeding anyway.");
+        }
+
+        const sourceIdentifiers = entries.map((e) => e.id);
+
+        let result: { sessionId: string };
+        try {
+          result = await apiFetch<{ sessionId: string }>("/v1/update", {
+            method: "POST",
+            body: JSON.stringify({
+              company: label,
+              sourceIdentifiers,
+              orgId,
+              correlationId: newCorrelationId(),
+            }),
+          });
+        } catch (err) {
+          logger.error(
+            `Failed to start update session: ${err instanceof Error ? err.message : String(err)}`,
+          );
+          process.exit(1);
+        }
+        if (opts.json) {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          logger.info(`Update session started: ${result.sessionId}`);
+          logger.info(`Fetching ${sourceIdentifiers.length} source(s).`);
+          logger.info(`Track progress: releases admin discovery task list`);
+        }
+      },
+    );
 }

--- a/src/cli/commands/ignore.ts
+++ b/src/cli/commands/ignore.ts
@@ -13,10 +13,13 @@ export function registerIgnoreCommand(program: Command) {
     .description("List ignored URLs for an organization")
     .requiredOption("--org <org>", "Organization slug, domain, or name")
     .option("--json", "Output as JSON")
-    .addHelpText("after", `
+    .addHelpText(
+      "after",
+      `
 Examples:
   releases admin policy ignore list --org acme
-  releases admin policy ignore list --org acme --json`)
+  releases admin policy ignore list --org acme --json`,
+    )
     .action(async (opts: { org: string; json?: boolean }) => {
       const org = await findOrg(opts.org);
       if (!org) {
@@ -48,11 +51,14 @@ Examples:
     .requiredOption("--org <org>", "Organization slug, domain, or name")
     .option("--reason <reason>", "Reason for ignoring this URL")
     .option("--dry-run", "Show what would be ignored without writing")
-    .addHelpText("after", `
+    .addHelpText(
+      "after",
+      `
 Examples:
   releases admin policy ignore add https://example.com/blog --org acme
   releases admin policy ignore add https://example.com/blog --org acme --reason "not a changelog"
-  releases admin policy ignore add https://example.com/blog --org acme --dry-run`)
+  releases admin policy ignore add https://example.com/blog --org acme --dry-run`,
+    )
     .action(async (url: string, opts: { org: string; reason?: string; dryRun?: boolean }) => {
       const org = await findOrg(opts.org);
       if (!org) {
@@ -61,12 +67,18 @@ Examples:
       }
 
       if (opts.dryRun) {
-        logger.info(chalk.yellow(`[dry-run] Would ignore for ${org.name}: ${url}${opts.reason ? ` (${opts.reason})` : ""}`));
+        logger.info(
+          chalk.yellow(
+            `[dry-run] Would ignore for ${org.name}: ${url}${opts.reason ? ` (${opts.reason})` : ""}`,
+          ),
+        );
         return;
       }
 
       await addIgnoredUrl(url, org.id, opts.reason);
-      logger.info(chalk.green(`Ignored for ${org.name}: ${url}${opts.reason ? ` (${opts.reason})` : ""}`));
+      logger.info(
+        chalk.green(`Ignored for ${org.name}: ${url}${opts.reason ? ` (${opts.reason})` : ""}`),
+      );
     });
 
   ignore
@@ -74,9 +86,12 @@ Examples:
     .description("Un-ignore a URL for an organization")
     .requiredOption("--org <org>", "Organization slug, domain, or name")
     .option("--json", "Output as JSON")
-    .addHelpText("after", `
+    .addHelpText(
+      "after",
+      `
 Examples:
-  releases admin policy ignore remove https://example.com/blog --org acme`)
+  releases admin policy ignore remove https://example.com/blog --org acme`,
+    )
     .action(async (url: string, opts: { org: string; json?: boolean }) => {
       const org = await findOrg(opts.org);
       if (!org) {

--- a/src/cli/commands/import.ts
+++ b/src/cli/commands/import.ts
@@ -19,7 +19,10 @@ import {
   addTagsToProduct,
 } from "../../api/client.js";
 
-interface ManifestAccount { platform: string; handle: string }
+interface ManifestAccount {
+  platform: string;
+  handle: string;
+}
 
 interface ManifestSource {
   name: string;
@@ -92,14 +95,18 @@ function validateManifest(data: unknown): Manifest {
       if (org.sources) {
         for (const [j, src] of org.sources.entries()) {
           if (!src.name || !src.url) {
-            throw new Error(`organizations[${i}].sources[${j}] is missing required 'name' or 'url'`);
+            throw new Error(
+              `organizations[${i}].sources[${j}] is missing required 'name' or 'url'`,
+            );
           }
         }
       }
       if (org.accounts) {
         for (const [j, acc] of org.accounts.entries()) {
           if (!acc.platform || !acc.handle) {
-            throw new Error(`organizations[${i}].accounts[${j}] is missing required 'platform' or 'handle'`);
+            throw new Error(
+              `organizations[${i}].accounts[${j}] is missing required 'platform' or 'handle'`,
+            );
           }
         }
       }
@@ -108,14 +115,19 @@ function validateManifest(data: unknown): Manifest {
       }
       if (org.products) {
         for (const [k, prod] of org.products.entries()) {
-          if (!prod.name) throw new Error(`organizations[${i}].products[${k}] is missing required 'name' field`);
+          if (!prod.name)
+            throw new Error(`organizations[${i}].products[${k}] is missing required 'name' field`);
           if (prod.category && !isValidCategory(prod.category)) {
-            throw new Error(`organizations[${i}].products[${k}].category "${prod.category}" is not a valid category`);
+            throw new Error(
+              `organizations[${i}].products[${k}].category "${prod.category}" is not a valid category`,
+            );
           }
           if (prod.sources) {
             for (const [j, src] of prod.sources.entries()) {
               if (!src.name || !src.url) {
-                throw new Error(`organizations[${i}].products[${k}].sources[${j}] is missing required 'name' or 'url'`);
+                throw new Error(
+                  `organizations[${i}].products[${k}].sources[${j}] is missing required 'name' or 'url'`,
+                );
               }
             }
           }
@@ -126,7 +138,8 @@ function validateManifest(data: unknown): Manifest {
 
   if (manifest.sources) {
     for (const [i, src] of (manifest.sources as ManifestSource[]).entries()) {
-      if (!src.name || !src.url) throw new Error(`sources[${i}] is missing required 'name' or 'url'`);
+      if (!src.name || !src.url)
+        throw new Error(`sources[${i}] is missing required 'name' or 'url'`);
     }
   }
 
@@ -157,79 +170,256 @@ export function registerImportCommand(program: Command) {
     .option("--dry-run", "Show what would be created without writing")
     .option("--json", "Output as JSON")
     .option("--skip-existing", "Skip sources that already exist (default: error)")
-    .action(async (file: string, opts: { dryRun?: boolean; json?: boolean; skipExisting?: boolean }) => {
-      if (!existsSync(file)) {
-        logger.error(`File not found: ${file}`);
-        process.exit(1);
-      }
+    .action(
+      async (file: string, opts: { dryRun?: boolean; json?: boolean; skipExisting?: boolean }) => {
+        if (!existsSync(file)) {
+          logger.error(`File not found: ${file}`);
+          process.exit(1);
+        }
 
-      let raw: string;
-      try {
-        raw = readFileSync(file, "utf-8");
-      } catch (err) {
-        logger.error(`Failed to read file: ${err instanceof Error ? err.message : String(err)}`);
-        process.exit(1);
-      }
+        let raw: string;
+        try {
+          raw = readFileSync(file, "utf-8");
+        } catch (err) {
+          logger.error(`Failed to read file: ${err instanceof Error ? err.message : String(err)}`);
+          process.exit(1);
+        }
 
-      let data: unknown;
-      try {
-        data = JSON.parse(raw);
-      } catch {
-        logger.error("Failed to parse JSON — file is not valid JSON");
-        process.exit(1);
-      }
+        let data: unknown;
+        try {
+          data = JSON.parse(raw);
+        } catch {
+          logger.error("Failed to parse JSON — file is not valid JSON");
+          process.exit(1);
+        }
 
-      let manifest: Manifest;
-      try {
-        manifest = validateManifest(data);
-      } catch (err) {
-        logger.error(err instanceof Error ? err.message : String(err));
-        process.exit(1);
-      }
+        let manifest: Manifest;
+        try {
+          manifest = validateManifest(data);
+        } catch (err) {
+          logger.error(err instanceof Error ? err.message : String(err));
+          process.exit(1);
+        }
 
-      const allUrls = collectAllUrls(manifest);
-      const existingSources = await findSourcesByUrls(allUrls);
-      const existingUrlSet = new Set(existingSources.map((s) => s.url));
+        const allUrls = collectAllUrls(manifest);
+        const existingSources = await findSourcesByUrls(allUrls);
+        const existingUrlSet = new Set(existingSources.map((s) => s.url));
 
-      const report: ImportReport = {
-        created: { orgs: 0, accounts: 0, products: 0, sources: 0 },
-        skipped: 0,
-        errors: [],
-      };
+        const report: ImportReport = {
+          created: { orgs: 0, accounts: 0, products: 0, sources: 0 },
+          skipped: 0,
+          errors: [],
+        };
 
-      if (manifest.organizations) {
-        for (const orgEntry of manifest.organizations) {
-          const orgSlug = orgEntry.slug ?? toSlug(orgEntry.name);
+        if (manifest.organizations) {
+          for (const orgEntry of manifest.organizations) {
+            const orgSlug = orgEntry.slug ?? toSlug(orgEntry.name);
 
-          if (opts.dryRun) {
-            const existing = await findOrg(orgSlug);
-            if (existing) {
-              if (!opts.json) logger.info(chalk.yellow(`[dry-run] Org already exists: ${orgEntry.name} (${orgSlug})`));
+            if (opts.dryRun) {
+              const existing = await findOrg(orgSlug);
+              if (existing) {
+                if (!opts.json)
+                  logger.info(
+                    chalk.yellow(`[dry-run] Org already exists: ${orgEntry.name} (${orgSlug})`),
+                  );
+              } else {
+                report.created.orgs++;
+                if (!opts.json)
+                  logger.info(
+                    chalk.green(`[dry-run] Would create org: ${orgEntry.name} (${orgSlug})`),
+                  );
+              }
+
+              if (orgEntry.accounts) {
+                for (const acc of orgEntry.accounts) {
+                  if (!opts.json)
+                    logger.info(
+                      chalk.green(
+                        `[dry-run] Would link account: ${acc.platform}/${acc.handle} -> ${orgSlug}`,
+                      ),
+                    );
+                  report.created.accounts++;
+                }
+              }
+
+              if (orgEntry.products) {
+                for (const prodEntry of orgEntry.products) {
+                  report.created.products++;
+                  if (!opts.json)
+                    logger.info(
+                      chalk.green(
+                        `[dry-run] Would create product: ${prodEntry.name} -> ${orgSlug}`,
+                      ),
+                    );
+                  if (prodEntry.sources) {
+                    for (const srcEntry of prodEntry.sources) {
+                      if (existingUrlSet.has(srcEntry.url)) {
+                        report.skipped++;
+                        if (!opts.json)
+                          logger.info(
+                            chalk.yellow(`[dry-run] Source URL already exists: ${srcEntry.url}`),
+                          );
+                      } else {
+                        report.created.sources++;
+                        const srcType = resolveSourceType(srcEntry);
+                        if (!opts.json)
+                          logger.info(
+                            chalk.green(
+                              `[dry-run] Would create source: ${srcEntry.name} [${srcType}] -> ${prodEntry.name}`,
+                            ),
+                          );
+                      }
+                    }
+                  }
+                }
+              }
+
+              if (orgEntry.sources) {
+                for (const srcEntry of orgEntry.sources) {
+                  if (existingUrlSet.has(srcEntry.url)) {
+                    report.skipped++;
+                    if (!opts.json)
+                      logger.info(
+                        chalk.yellow(`[dry-run] Source URL already exists: ${srcEntry.url}`),
+                      );
+                  } else {
+                    report.created.sources++;
+                    const srcType = resolveSourceType(srcEntry);
+                    if (!opts.json)
+                      logger.info(
+                        chalk.green(
+                          `[dry-run] Would create source: ${srcEntry.name} [${srcType}] -> ${orgSlug}`,
+                        ),
+                      );
+                  }
+                }
+              }
+
+              continue;
+            }
+
+            let org = await findOrg(orgSlug);
+            if (org) {
+              if (!opts.json)
+                logger.info(chalk.yellow(`Org already exists: ${org.name} (${org.slug})`));
             } else {
-              report.created.orgs++;
-              if (!opts.json) logger.info(chalk.green(`[dry-run] Would create org: ${orgEntry.name} (${orgSlug})`));
+              try {
+                org = await createOrg(orgEntry.name, {
+                  slug: orgSlug,
+                  domain: orgEntry.domain,
+                  description: orgEntry.description,
+                  category: orgEntry.category,
+                });
+                report.created.orgs++;
+                if (!opts.json) logger.info(chalk.green(`Created org: ${org.name} (${org.slug})`));
+              } catch (err) {
+                const msg = `Failed to create org "${orgEntry.name}": ${err instanceof Error ? err.message : String(err)}`;
+                report.errors.push(msg);
+                if (!opts.json) logger.error(chalk.red(msg));
+                continue;
+              }
+              if (orgEntry.tags && orgEntry.tags.length > 0) {
+                await addTagsToOrg(org.id, orgEntry.tags);
+              }
             }
 
             if (orgEntry.accounts) {
               for (const acc of orgEntry.accounts) {
-                if (!opts.json) logger.info(chalk.green(`[dry-run] Would link account: ${acc.platform}/${acc.handle} -> ${orgSlug}`));
-                report.created.accounts++;
+                const existing = await getOrgAccountByPlatform(org.id, acc.platform);
+                if (existing) {
+                  if (!opts.json)
+                    logger.info(
+                      chalk.yellow(`Account already linked: ${acc.platform}/${acc.handle}`),
+                    );
+                } else {
+                  try {
+                    await linkOrgAccount(org.slug, acc.platform, acc.handle);
+                    report.created.accounts++;
+                    if (!opts.json)
+                      logger.info(
+                        chalk.green(`Linked account: ${acc.platform}/${acc.handle} -> ${org.slug}`),
+                      );
+                  } catch (err) {
+                    const msg = `Failed to link account ${acc.platform}/${acc.handle}: ${err instanceof Error ? err.message : String(err)}`;
+                    report.errors.push(msg);
+                    if (!opts.json) logger.error(chalk.red(msg));
+                  }
+                }
               }
             }
 
             if (orgEntry.products) {
               for (const prodEntry of orgEntry.products) {
-                report.created.products++;
-                if (!opts.json) logger.info(chalk.green(`[dry-run] Would create product: ${prodEntry.name} -> ${orgSlug}`));
+                const prodSlug = prodEntry.slug ?? toSlug(prodEntry.name);
+                let prod = await findProduct(prodSlug);
+
+                if (prod) {
+                  if (!opts.json)
+                    logger.info(
+                      chalk.yellow(`Product already exists: ${prod.name} (${prod.slug})`),
+                    );
+                } else {
+                  try {
+                    prod = await createProduct(org.id, prodEntry.name, {
+                      slug: prodSlug,
+                      url: prodEntry.url,
+                      description: prodEntry.description,
+                      category: prodEntry.category,
+                    });
+                    report.created.products++;
+                    if (!opts.json)
+                      logger.info(
+                        chalk.green(`Created product: ${prod.name} (${prod.slug}) -> ${org.slug}`),
+                      );
+                  } catch (err) {
+                    const msg = `Failed to create product "${prodEntry.name}": ${err instanceof Error ? err.message : String(err)}`;
+                    report.errors.push(msg);
+                    if (!opts.json) logger.error(chalk.red(msg));
+                    continue;
+                  }
+                  if (prodEntry.tags && prodEntry.tags.length > 0) {
+                    await addTagsToProduct(prod.id, prodEntry.tags);
+                  }
+                }
+
                 if (prodEntry.sources) {
                   for (const srcEntry of prodEntry.sources) {
                     if (existingUrlSet.has(srcEntry.url)) {
                       report.skipped++;
-                      if (!opts.json) logger.info(chalk.yellow(`[dry-run] Source URL already exists: ${srcEntry.url}`));
-                    } else {
+                      if (opts.skipExisting) {
+                        if (!opts.json)
+                          logger.info(chalk.yellow(`Skipped existing source: ${srcEntry.url}`));
+                      } else {
+                        const msg = `Source URL already exists: ${srcEntry.url}`;
+                        report.errors.push(msg);
+                        if (!opts.json) logger.error(chalk.red(msg));
+                      }
+                      continue;
+                    }
+
+                    const srcSlug = srcEntry.slug ?? toSlug(srcEntry.name);
+                    const srcType = resolveSourceType(srcEntry);
+
+                    try {
+                      await createSource({
+                        name: srcEntry.name,
+                        slug: srcSlug,
+                        type: srcType,
+                        url: srcEntry.url,
+                        orgId: org.id,
+                        productId: prod.id,
+                      });
                       report.created.sources++;
-                      const srcType = resolveSourceType(srcEntry);
-                      if (!opts.json) logger.info(chalk.green(`[dry-run] Would create source: ${srcEntry.name} [${srcType}] -> ${prodEntry.name}`));
+                      if (!opts.json)
+                        logger.info(
+                          chalk.green(
+                            `Created source: ${srcEntry.name} (${srcSlug}) [${srcType}] -> ${prod.slug}`,
+                          ),
+                        );
+                    } catch (err) {
+                      const msg = `Failed to create source "${srcEntry.name}": ${err instanceof Error ? err.message : String(err)}`;
+                      report.errors.push(msg);
+                      if (!opts.json) logger.error(chalk.red(msg));
                     }
                   }
                 }
@@ -240,226 +430,118 @@ export function registerImportCommand(program: Command) {
               for (const srcEntry of orgEntry.sources) {
                 if (existingUrlSet.has(srcEntry.url)) {
                   report.skipped++;
-                  if (!opts.json) logger.info(chalk.yellow(`[dry-run] Source URL already exists: ${srcEntry.url}`));
-                } else {
-                  report.created.sources++;
-                  const srcType = resolveSourceType(srcEntry);
-                  if (!opts.json) logger.info(chalk.green(`[dry-run] Would create source: ${srcEntry.name} [${srcType}] -> ${orgSlug}`));
-                }
-              }
-            }
-
-            continue;
-          }
-
-          let org = await findOrg(orgSlug);
-          if (org) {
-            if (!opts.json) logger.info(chalk.yellow(`Org already exists: ${org.name} (${org.slug})`));
-          } else {
-            try {
-              org = await createOrg(orgEntry.name, {
-                slug: orgSlug,
-                domain: orgEntry.domain,
-                description: orgEntry.description,
-                category: orgEntry.category,
-              });
-              report.created.orgs++;
-              if (!opts.json) logger.info(chalk.green(`Created org: ${org.name} (${org.slug})`));
-            } catch (err) {
-              const msg = `Failed to create org "${orgEntry.name}": ${err instanceof Error ? err.message : String(err)}`;
-              report.errors.push(msg);
-              if (!opts.json) logger.error(chalk.red(msg));
-              continue;
-            }
-            if (orgEntry.tags && orgEntry.tags.length > 0) {
-              await addTagsToOrg(org.id, orgEntry.tags);
-            }
-          }
-
-          if (orgEntry.accounts) {
-            for (const acc of orgEntry.accounts) {
-              const existing = await getOrgAccountByPlatform(org.id, acc.platform);
-              if (existing) {
-                if (!opts.json) logger.info(chalk.yellow(`Account already linked: ${acc.platform}/${acc.handle}`));
-              } else {
-                try {
-                  await linkOrgAccount(org.slug, acc.platform, acc.handle);
-                  report.created.accounts++;
-                  if (!opts.json) logger.info(chalk.green(`Linked account: ${acc.platform}/${acc.handle} -> ${org.slug}`));
-                } catch (err) {
-                  const msg = `Failed to link account ${acc.platform}/${acc.handle}: ${err instanceof Error ? err.message : String(err)}`;
-                  report.errors.push(msg);
-                  if (!opts.json) logger.error(chalk.red(msg));
-                }
-              }
-            }
-          }
-
-          if (orgEntry.products) {
-            for (const prodEntry of orgEntry.products) {
-              const prodSlug = prodEntry.slug ?? toSlug(prodEntry.name);
-              let prod = await findProduct(prodSlug);
-
-              if (prod) {
-                if (!opts.json) logger.info(chalk.yellow(`Product already exists: ${prod.name} (${prod.slug})`));
-              } else {
-                try {
-                  prod = await createProduct(org.id, prodEntry.name, {
-                    slug: prodSlug,
-                    url: prodEntry.url,
-                    description: prodEntry.description,
-                    category: prodEntry.category,
-                  });
-                  report.created.products++;
-                  if (!opts.json) logger.info(chalk.green(`Created product: ${prod.name} (${prod.slug}) -> ${org.slug}`));
-                } catch (err) {
-                  const msg = `Failed to create product "${prodEntry.name}": ${err instanceof Error ? err.message : String(err)}`;
-                  report.errors.push(msg);
-                  if (!opts.json) logger.error(chalk.red(msg));
-                  continue;
-                }
-                if (prodEntry.tags && prodEntry.tags.length > 0) {
-                  await addTagsToProduct(prod.id, prodEntry.tags);
-                }
-              }
-
-              if (prodEntry.sources) {
-                for (const srcEntry of prodEntry.sources) {
-                  if (existingUrlSet.has(srcEntry.url)) {
-                    report.skipped++;
-                    if (opts.skipExisting) {
-                      if (!opts.json) logger.info(chalk.yellow(`Skipped existing source: ${srcEntry.url}`));
-                    } else {
-                      const msg = `Source URL already exists: ${srcEntry.url}`;
-                      report.errors.push(msg);
-                      if (!opts.json) logger.error(chalk.red(msg));
-                    }
-                    continue;
-                  }
-
-                  const srcSlug = srcEntry.slug ?? toSlug(srcEntry.name);
-                  const srcType = resolveSourceType(srcEntry);
-
-                  try {
-                    await createSource({
-                      name: srcEntry.name,
-                      slug: srcSlug,
-                      type: srcType,
-                      url: srcEntry.url,
-                      orgId: org.id,
-                      productId: prod.id,
-                    });
-                    report.created.sources++;
-                    if (!opts.json) logger.info(chalk.green(`Created source: ${srcEntry.name} (${srcSlug}) [${srcType}] -> ${prod.slug}`));
-                  } catch (err) {
-                    const msg = `Failed to create source "${srcEntry.name}": ${err instanceof Error ? err.message : String(err)}`;
+                  if (opts.skipExisting) {
+                    if (!opts.json)
+                      logger.info(chalk.yellow(`Skipped existing source: ${srcEntry.url}`));
+                  } else {
+                    const msg = `Source URL already exists: ${srcEntry.url}`;
                     report.errors.push(msg);
                     if (!opts.json) logger.error(chalk.red(msg));
                   }
+                  continue;
                 }
-              }
-            }
-          }
 
-          if (orgEntry.sources) {
-            for (const srcEntry of orgEntry.sources) {
-              if (existingUrlSet.has(srcEntry.url)) {
-                report.skipped++;
-                if (opts.skipExisting) {
-                  if (!opts.json) logger.info(chalk.yellow(`Skipped existing source: ${srcEntry.url}`));
-                } else {
-                  const msg = `Source URL already exists: ${srcEntry.url}`;
+                const srcSlug = srcEntry.slug ?? toSlug(srcEntry.name);
+                const srcType = resolveSourceType(srcEntry);
+
+                try {
+                  await createSource({
+                    name: srcEntry.name,
+                    slug: srcSlug,
+                    type: srcType,
+                    url: srcEntry.url,
+                    orgId: org.id,
+                  });
+                  report.created.sources++;
+                  if (!opts.json)
+                    logger.info(
+                      chalk.green(
+                        `Created source: ${srcEntry.name} (${srcSlug}) [${srcType}] -> ${org.slug}`,
+                      ),
+                    );
+                } catch (err) {
+                  const msg = `Failed to create source "${srcEntry.name}": ${err instanceof Error ? err.message : String(err)}`;
                   report.errors.push(msg);
                   if (!opts.json) logger.error(chalk.red(msg));
                 }
+              }
+            }
+          }
+        }
+
+        if (manifest.sources) {
+          for (const srcEntry of manifest.sources) {
+            if (existingUrlSet.has(srcEntry.url)) {
+              report.skipped++;
+
+              if (opts.dryRun) {
+                if (!opts.json)
+                  logger.info(chalk.yellow(`[dry-run] Source URL already exists: ${srcEntry.url}`));
                 continue;
               }
 
-              const srcSlug = srcEntry.slug ?? toSlug(srcEntry.name);
-              const srcType = resolveSourceType(srcEntry);
-
-              try {
-                await createSource({
-                  name: srcEntry.name,
-                  slug: srcSlug,
-                  type: srcType,
-                  url: srcEntry.url,
-                  orgId: org.id,
-                });
-                report.created.sources++;
-                if (!opts.json) logger.info(chalk.green(`Created source: ${srcEntry.name} (${srcSlug}) [${srcType}] -> ${org.slug}`));
-              } catch (err) {
-                const msg = `Failed to create source "${srcEntry.name}": ${err instanceof Error ? err.message : String(err)}`;
+              if (opts.skipExisting) {
+                if (!opts.json)
+                  logger.info(chalk.yellow(`Skipped existing source: ${srcEntry.url}`));
+              } else {
+                const msg = `Source URL already exists: ${srcEntry.url}`;
                 report.errors.push(msg);
                 if (!opts.json) logger.error(chalk.red(msg));
               }
-            }
-          }
-        }
-      }
-
-      if (manifest.sources) {
-        for (const srcEntry of manifest.sources) {
-          if (existingUrlSet.has(srcEntry.url)) {
-            report.skipped++;
-
-            if (opts.dryRun) {
-              if (!opts.json) logger.info(chalk.yellow(`[dry-run] Source URL already exists: ${srcEntry.url}`));
               continue;
             }
 
-            if (opts.skipExisting) {
-              if (!opts.json) logger.info(chalk.yellow(`Skipped existing source: ${srcEntry.url}`));
-            } else {
-              const msg = `Source URL already exists: ${srcEntry.url}`;
+            const srcSlug = srcEntry.slug ?? toSlug(srcEntry.name);
+            const srcType = resolveSourceType(srcEntry);
+
+            if (opts.dryRun) {
+              report.created.sources++;
+              if (!opts.json)
+                logger.info(
+                  chalk.green(
+                    `[dry-run] Would create source: ${srcEntry.name} (${srcSlug}) [${srcType}]`,
+                  ),
+                );
+              continue;
+            }
+
+            try {
+              await createSource({
+                name: srcEntry.name,
+                slug: srcSlug,
+                type: srcType,
+                url: srcEntry.url,
+              });
+              report.created.sources++;
+              if (!opts.json)
+                logger.info(
+                  chalk.green(`Created source: ${srcEntry.name} (${srcSlug}) [${srcType}]`),
+                );
+            } catch (err) {
+              const msg = `Failed to create source "${srcEntry.name}": ${err instanceof Error ? err.message : String(err)}`;
               report.errors.push(msg);
               if (!opts.json) logger.error(chalk.red(msg));
             }
-            continue;
-          }
-
-          const srcSlug = srcEntry.slug ?? toSlug(srcEntry.name);
-          const srcType = resolveSourceType(srcEntry);
-
-          if (opts.dryRun) {
-            report.created.sources++;
-            if (!opts.json) logger.info(chalk.green(`[dry-run] Would create source: ${srcEntry.name} (${srcSlug}) [${srcType}]`));
-            continue;
-          }
-
-          try {
-            await createSource({
-              name: srcEntry.name,
-              slug: srcSlug,
-              type: srcType,
-              url: srcEntry.url,
-            });
-            report.created.sources++;
-            if (!opts.json) logger.info(chalk.green(`Created source: ${srcEntry.name} (${srcSlug}) [${srcType}]`));
-          } catch (err) {
-            const msg = `Failed to create source "${srcEntry.name}": ${err instanceof Error ? err.message : String(err)}`;
-            report.errors.push(msg);
-            if (!opts.json) logger.error(chalk.red(msg));
           }
         }
-      }
 
-      if (opts.json) {
-        console.log(JSON.stringify(report, null, 2));
-      } else {
-        console.log("");
-        const prefix = opts.dryRun ? "[dry-run] " : "";
-        console.log(chalk.bold(`${prefix}Import summary:`));
-        console.log(`  Organizations created: ${report.created.orgs}`);
-        console.log(`  Accounts linked:       ${report.created.accounts}`);
-        console.log(`  Products created:      ${report.created.products}`);
-        console.log(`  Sources created:       ${report.created.sources}`);
-        console.log(`  Sources skipped:       ${report.skipped}`);
-        if (report.errors.length > 0) {
-          console.log(chalk.red(`  Errors:                ${report.errors.length}`));
+        if (opts.json) {
+          console.log(JSON.stringify(report, null, 2));
+        } else {
+          console.log("");
+          const prefix = opts.dryRun ? "[dry-run] " : "";
+          console.log(chalk.bold(`${prefix}Import summary:`));
+          console.log(`  Organizations created: ${report.created.orgs}`);
+          console.log(`  Accounts linked:       ${report.created.accounts}`);
+          console.log(`  Products created:      ${report.created.products}`);
+          console.log(`  Sources created:       ${report.created.sources}`);
+          console.log(`  Sources skipped:       ${report.skipped}`);
+          if (report.errors.length > 0) {
+            console.log(chalk.red(`  Errors:                ${report.errors.length}`));
+          }
         }
-      }
 
-      if (report.errors.length > 0 && !opts.skipExisting) process.exit(1);
-    });
+        if (report.errors.length > 0 && !opts.skipExisting) process.exit(1);
+      },
+    );
 }

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -39,125 +39,153 @@ export function registerListCommand(program: Command) {
     .option("--limit <n>", `Limit the number of results (default ${DEFAULT_PAGE_SIZE})`)
     .option("--page <n>", "Page number for paginated results")
     .option("--flat", "Legacy: return a bare array instead of the paginated envelope (--json only)")
-    .action(async (slug: string | undefined, opts: { json?: boolean; org?: string; product?: string; category?: string; hasFeed?: boolean; query?: string; includeDisabled?: boolean; compact?: boolean; limit?: string; page?: string; flat?: boolean }) => {
-      if (slug) {
-        const source = await findSource(slug);
-        if (!source) return sourceNotFound(slug);
-        const parsedMeta = parseMetadataObject(source.metadata);
-        const method = getFetchMethod(source.type, parsedMeta);
-        if (opts.json) {
-          const parsed: Record<string, unknown> = { ...source, method, metadata: parsedMeta ?? source.metadata };
-          console.log(JSON.stringify(parsed, null, 2));
+    .action(
+      async (
+        slug: string | undefined,
+        opts: {
+          json?: boolean;
+          org?: string;
+          product?: string;
+          category?: string;
+          hasFeed?: boolean;
+          query?: string;
+          includeDisabled?: boolean;
+          compact?: boolean;
+          limit?: string;
+          page?: string;
+          flat?: boolean;
+        },
+      ) => {
+        if (slug) {
+          const source = await findSource(slug);
+          if (!source) return sourceNotFound(slug);
+          const parsedMeta = parseMetadataObject(source.metadata);
+          const method = getFetchMethod(source.type, parsedMeta);
+          if (opts.json) {
+            const parsed: Record<string, unknown> = {
+              ...source,
+              method,
+              metadata: parsedMeta ?? source.metadata,
+            };
+            console.log(JSON.stringify(parsed, null, 2));
+            return;
+          }
+          const label = (key: string, val: string | null | undefined) =>
+            `  ${chalk.bold(key.padEnd(16))} ${val ?? chalk.dim("—")}`;
+          console.log(chalk.bold(`\n${stripAnsi(source.name)}\n`));
+          console.log(label("Slug", source.slug));
+          console.log(label("Type", source.type));
+          console.log(label("Method", method === "-" ? null : method));
+          console.log(label("URL", source.url));
+          console.log(label("Org", source.orgId ?? null));
+          console.log(label("Last Fetched", source.lastFetchedAt));
+          console.log(label("Primary", source.isPrimary ? "yes" : null));
+          console.log(label("Status", source.isHidden ? "disabled" : "active"));
+          console.log(label("Fetch Priority", source.fetchPriority));
+          console.log("");
           return;
         }
-        const label = (key: string, val: string | null | undefined) =>
-          `  ${chalk.bold(key.padEnd(16))} ${val ?? chalk.dim("—")}`;
-        console.log(chalk.bold(`\n${stripAnsi(source.name)}\n`));
-        console.log(label("Slug", source.slug));
-        console.log(label("Type", source.type));
-        console.log(label("Method", method === "-" ? null : method));
-        console.log(label("URL", source.url));
-        console.log(label("Org", source.orgId ?? null));
-        console.log(label("Last Fetched", source.lastFetchedAt));
-        console.log(label("Primary", source.isPrimary ? "yes" : null));
-        console.log(label("Status", source.isHidden ? "disabled" : "active"));
-        console.log(label("Fetch Priority", source.fetchPriority));
-        console.log("");
-        return;
-      }
 
-      const limitOpt = opts.limit ? parseInt(opts.limit, 10) : undefined;
-      const explicitLimit = limitOpt != null && limitOpt > 0;
-      const pageSize = explicitLimit ? limitOpt : DEFAULT_PAGE_SIZE;
-      const page = opts.page ? Math.max(1, parseInt(opts.page, 10)) : 1;
+        const limitOpt = opts.limit ? parseInt(opts.limit, 10) : undefined;
+        const explicitLimit = limitOpt != null && limitOpt > 0;
+        const pageSize = explicitLimit ? limitOpt : DEFAULT_PAGE_SIZE;
+        const page = opts.page ? Math.max(1, parseInt(opts.page, 10)) : 1;
 
-      const { items: pageItems, pagination: apiPagination } = await listSourcesWithOrg({
-        orgSlug: opts.org,
-        productSlug: opts.product,
-        category: opts.category,
-        hasFeed: opts.hasFeed,
-        query: opts.query,
-        includeHidden: opts.includeDisabled,
-        limit: pageSize,
-        page,
-        envelope: true,
-      });
-
-      if (pageItems.length === 0 && page === 1 && !opts.json) {
-        console.log("No sources configured.");
-        return;
-      }
-
-      if (opts.json) {
-        const items: Record<string, unknown>[] = pageItems.map((row) => {
-          const parsedMeta = parseMetadataObject(row.metadata);
-          const method = getFetchMethod(row.type, parsedMeta);
-          if (opts.compact) {
-            return {
-              id: row.id,
-              slug: row.slug,
-              name: row.name,
-              type: row.type,
-              method,
-              orgName: row.orgName ?? null,
-              productName: row.productName ?? null,
-              releaseCount: row.releaseCount,
-              latestDate: row.latestDate ?? null,
-              lastFetchedAt: row.lastFetchedAt ?? null,
-            };
-          }
-          return {
-            ...row,
-            method,
-            metadata: parsedMeta ?? row.metadata,
-          };
+        const { items: pageItems, pagination: apiPagination } = await listSourcesWithOrg({
+          orgSlug: opts.org,
+          productSlug: opts.product,
+          category: opts.category,
+          hasFeed: opts.hasFeed,
+          query: opts.query,
+          includeHidden: opts.includeDisabled,
+          limit: pageSize,
+          page,
+          envelope: true,
         });
 
-        const warnTruncated = !explicitLimit && apiPagination.hasMore;
-
-        if (opts.flat) {
-          console.log(JSON.stringify(items, null, 2));
-        } else {
-          const response: ListResponse<Record<string, unknown>> = { items, pagination: apiPagination };
-          console.log(JSON.stringify(response, null, 2));
+        if (pageItems.length === 0 && page === 1 && !opts.json) {
+          console.log("No sources configured.");
+          return;
         }
 
-        if (warnTruncated) {
-          console.error(formatTruncationWarning({
-            returned: items.length,
-            pageSize,
-            commandExample: paginateExample(true),
-          }));
+        if (opts.json) {
+          const items: Record<string, unknown>[] = pageItems.map((row) => {
+            const parsedMeta = parseMetadataObject(row.metadata);
+            const method = getFetchMethod(row.type, parsedMeta);
+            if (opts.compact) {
+              return {
+                id: row.id,
+                slug: row.slug,
+                name: row.name,
+                type: row.type,
+                method,
+                orgName: row.orgName ?? null,
+                productName: row.productName ?? null,
+                releaseCount: row.releaseCount,
+                latestDate: row.latestDate ?? null,
+                lastFetchedAt: row.lastFetchedAt ?? null,
+              };
+            }
+            return {
+              ...row,
+              method,
+              metadata: parsedMeta ?? row.metadata,
+            };
+          });
+
+          const warnTruncated = !explicitLimit && apiPagination.hasMore;
+
+          if (opts.flat) {
+            console.log(JSON.stringify(items, null, 2));
+          } else {
+            const response: ListResponse<Record<string, unknown>> = {
+              items,
+              pagination: apiPagination,
+            };
+            console.log(JSON.stringify(response, null, 2));
+          }
+
+          if (warnTruncated) {
+            console.error(
+              formatTruncationWarning({
+                returned: items.length,
+                pageSize,
+                commandExample: paginateExample(true),
+              }),
+            );
+          }
+          return;
         }
-        return;
-      }
 
-      const table = new Table({
-        head: ["Name", "Slug", "Type", "Method", "URL", "Org", "Product", "Last Fetched"],
-      });
+        const table = new Table({
+          head: ["Name", "Slug", "Type", "Method", "URL", "Org", "Product", "Last Fetched"],
+        });
 
-      for (const row of pageItems) {
-        const method = getFetchMethod(row.type, parseMetadataObject(row.metadata));
-        const name = stripAnsi(row.name);
-        table.push([
-          row.isPrimary ? `${name} ${chalk.yellow("\u2605")}` : name,
-          row.slug,
-          row.type,
-          method,
-          row.url,
-          row.orgName ? stripAnsi(row.orgName) : chalk.dim("\u2014"),
-          row.productName ?? chalk.dim("\u2014"),
-          row.lastFetchedAt ?? chalk.dim("never"),
-        ]);
-      }
+        for (const row of pageItems) {
+          const method = getFetchMethod(row.type, parseMetadataObject(row.metadata));
+          const name = stripAnsi(row.name);
+          table.push([
+            row.isPrimary ? `${name} ${chalk.yellow("\u2605")}` : name,
+            row.slug,
+            row.type,
+            method,
+            row.url,
+            row.orgName ? stripAnsi(row.orgName) : chalk.dim("\u2014"),
+            row.productName ?? chalk.dim("\u2014"),
+            row.lastFetchedAt ?? chalk.dim("never"),
+          ]);
+        }
 
-      console.log(table.toString());
-      if (!explicitLimit && apiPagination.hasMore) {
-        console.error(formatTruncationWarning({
-          returned: pageItems.length,
-          pageSize,
-          commandExample: paginateExample(false),
-        }));
-      }
-    });
+        console.log(table.toString());
+        if (!explicitLimit && apiPagination.hasMore) {
+          console.error(
+            formatTruncationWarning({
+              returned: pageItems.length,
+              pageSize,
+              commandExample: paginateExample(false),
+            }),
+          );
+        }
+      },
+    );
 }

--- a/src/cli/commands/onboard-apply.ts
+++ b/src/cli/commands/onboard-apply.ts
@@ -58,7 +58,11 @@ async function applySource(source: AgentDiscoveredSource, orgId?: string): Promi
     return { slug, url, action: "added" };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    if (message.includes("UNIQUE constraint") || message.includes("409") || message.includes("already exists")) {
+    if (
+      message.includes("UNIQUE constraint") ||
+      message.includes("409") ||
+      message.includes("already exists")
+    ) {
       return { slug, url, action: "skipped" };
     }
     return { slug, url, action: "error", error: message };
@@ -72,9 +76,7 @@ export function registerOnboardApplyCommand(onboardCmd: Command) {
     .argument("<state-file>", "Path to a DiscoveryState JSON file (or - for stdin)")
     .option("--json", "Output results as JSON")
     .action(async (stateFile: string, opts: { json?: boolean }) => {
-      const raw = stateFile === "-"
-        ? await Bun.stdin.text()
-        : await Bun.file(stateFile).text();
+      const raw = stateFile === "-" ? await Bun.stdin.text() : await Bun.file(stateFile).text();
 
       let state: DiscoveryState;
       try {
@@ -119,7 +121,9 @@ export function registerOnboardApplyCommand(onboardCmd: Command) {
       if (opts.json) {
         console.log(JSON.stringify(results, null, 2));
       } else {
-        let added = 0, ignored = 0, errors = 0;
+        let added = 0,
+          ignored = 0,
+          errors = 0;
         for (const r of results) {
           if (r.action === "added") added++;
           else if (r.action === "ignored") ignored++;

--- a/src/cli/commands/onboard.ts
+++ b/src/cli/commands/onboard.ts
@@ -85,7 +85,9 @@ async function runRemoteDiscovery(
     });
     sessionId = result.sessionId;
   } catch (err) {
-    logger.error(`Failed to start remote discovery: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(
+      `Failed to start remote discovery: ${err instanceof Error ? err.message : String(err)}`,
+    );
     process.exit(1);
   }
 
@@ -103,7 +105,12 @@ async function runRemoteDiscovery(
 
     let status: {
       status: "running" | "complete" | "error" | "idle";
-      progress?: { step: string; sourcesFound: number; sourcesValidated: number; currentAction: string };
+      progress?: {
+        step: string;
+        sourcesFound: number;
+        sourcesValidated: number;
+        currentAction: string;
+      };
       result?: object;
       error?: string;
     };
@@ -179,7 +186,11 @@ function printSummary(state: DiscoveryState): void {
   const validated = sources.filter((s) => s.validated);
   const failed = sources.filter((s) => s.validationError);
 
-  write(chalk.gray(`  ${sources.length} source(s) found, ${validated.length} validated, ${failed.length} failed`));
+  write(
+    chalk.gray(
+      `  ${sources.length} source(s) found, ${validated.length} validated, ${failed.length} failed`,
+    ),
+  );
   write("");
 
   for (const s of sources) {

--- a/src/cli/commands/org.ts
+++ b/src/cli/commands/org.ts
@@ -2,10 +2,22 @@ import { Command } from "commander";
 import chalk from "chalk";
 import Table from "cli-table3";
 import {
-  findOrg, getSourcesByOrg, listOrgs, createOrg, removeOrg,
-  getOrgAccountsBySlug, linkOrgAccount, unlinkOrgAccount,
-  getProductsByOrg, addTagsToOrg, removeTagsFromOrg, getTagsForOrg, updateOrg,
-  listDomainAliases, addDomainAlias, removeDomainAlias,
+  findOrg,
+  getSourcesByOrg,
+  listOrgs,
+  createOrg,
+  removeOrg,
+  getOrgAccountsBySlug,
+  linkOrgAccount,
+  unlinkOrgAccount,
+  getProductsByOrg,
+  addTagsToOrg,
+  removeTagsFromOrg,
+  getTagsForOrg,
+  updateOrg,
+  listDomainAliases,
+  addDomainAlias,
+  removeDomainAlias,
   getOverview,
 } from "../../api/client.js";
 import { stripAnsi } from "../../lib/sanitize.js";
@@ -22,9 +34,7 @@ import {
 } from "@releases/core/overview";
 
 export function registerOrgCommand(program: Command) {
-  const org = program
-    .command("org")
-    .description("Manage organizations");
+  const org = program.command("org").description("Manage organizations");
 
   // ── org add ──
   org
@@ -37,32 +47,54 @@ export function registerOrgCommand(program: Command) {
     .option("--category <category>", "Category")
     .option("--tags <tags>", "Comma-separated tags")
     .option("--json", "Output as JSON")
-    .action(async (name: string, opts: { domain?: string; slug?: string; description?: string; category?: string; tags?: string; json?: boolean }) => {
-      const slug = opts.slug ?? toSlug(name);
+    .action(
+      async (
+        name: string,
+        opts: {
+          domain?: string;
+          slug?: string;
+          description?: string;
+          category?: string;
+          tags?: string;
+          json?: boolean;
+        },
+      ) => {
+        const slug = opts.slug ?? toSlug(name);
 
-      const existing = await findOrg(slug);
-      if (existing) {
-        console.error(chalk.red(`Organization with slug "${slug}" already exists.`));
-        process.exit(1);
-      }
-
-      if (opts.category && !isValidCategory(opts.category)) {
-        console.error(chalk.red(`Invalid category: "${opts.category}". Valid: ${CATEGORIES.join(", ")}`));
-        process.exit(1);
-      }
-
-      const created = await createOrg(name, { slug, domain: opts.domain, description: opts.description, category: opts.category });
-
-      if (opts.tags) {
-        const tagList = opts.tags.split(",").map((t: string) => t.trim()).filter(Boolean);
-        if (tagList.length > 0) {
-          await addTagsToOrg(created.id, tagList);
+        const existing = await findOrg(slug);
+        if (existing) {
+          console.error(chalk.red(`Organization with slug "${slug}" already exists.`));
+          process.exit(1);
         }
-      }
 
-      if (opts.json) console.log(JSON.stringify(created, null, 2));
-      else console.log(chalk.green(`Organization added: ${name} (${slug})`));
-    });
+        if (opts.category && !isValidCategory(opts.category)) {
+          console.error(
+            chalk.red(`Invalid category: "${opts.category}". Valid: ${CATEGORIES.join(", ")}`),
+          );
+          process.exit(1);
+        }
+
+        const created = await createOrg(name, {
+          slug,
+          domain: opts.domain,
+          description: opts.description,
+          category: opts.category,
+        });
+
+        if (opts.tags) {
+          const tagList = opts.tags
+            .split(",")
+            .map((t: string) => t.trim())
+            .filter(Boolean);
+          if (tagList.length > 0) {
+            await addTagsToOrg(created.id, tagList);
+          }
+        }
+
+        if (opts.json) console.log(JSON.stringify(created, null, 2));
+        else console.log(chalk.green(`Organization added: ${name} (${slug})`));
+      },
+    );
 
   // ── org list ──
   org
@@ -116,15 +148,21 @@ export function registerOrgCommand(program: Command) {
       ]);
 
       if (opts.json) {
-        console.log(JSON.stringify({
-          ...found,
-          accounts,
-          products: orgProducts,
-          sources: linkedSources,
-          tags: orgTags,
-          aliases: aliases.map((a) => a.domain),
-          overview: overview?.content ?? null,
-        }, null, 2));
+        console.log(
+          JSON.stringify(
+            {
+              ...found,
+              accounts,
+              products: orgProducts,
+              sources: linkedSources,
+              tags: orgTags,
+              aliases: aliases.map((a) => a.domain),
+              overview: overview?.content ?? null,
+            },
+            null,
+            2,
+          ),
+        );
         return;
       }
 
@@ -162,7 +200,11 @@ export function registerOrgCommand(program: Command) {
             : s.consecutiveErrors && s.consecutiveErrors > 0
               ? "erroring"
               : "active";
-          const statusColor = s.isHidden ? chalk.red : s.consecutiveErrors ? chalk.yellow : chalk.green;
+          const statusColor = s.isHidden
+            ? chalk.red
+            : s.consecutiveErrors
+              ? chalk.yellow
+              : chalk.green;
           const status = statusColor(statusLabel.padEnd(16));
           const fetched = s.lastFetchedAt
             ? chalk.dim(s.lastFetchedAt.replace("T", " ").replace(/\.\d+Z$/, ""))
@@ -182,7 +224,11 @@ export function registerOrgCommand(program: Command) {
         console.log();
         console.log(`${chalk.bold("Overview")}  ${generatedHint}`);
         if (stale) {
-          console.log(chalk.yellow(`  ⚠ Overview is older than ${OVERVIEW_STALE_DAYS} days — may not reflect recent releases.`));
+          console.log(
+            chalk.yellow(
+              `  ⚠ Overview is older than ${OVERVIEW_STALE_DAYS} days — may not reflect recent releases.`,
+            ),
+          );
         }
         console.log(preview);
         console.log(chalk.dim(`\n  Full overview: releases org overview ${found.slug}`));
@@ -195,10 +241,13 @@ export function registerOrgCommand(program: Command) {
     .description("Print the full AI-generated overview for an organization")
     .argument("<identifier>", "Org slug, domain, name, or account handle")
     .option("--json", "Output as JSON")
-    .addHelpText("after", `
+    .addHelpText(
+      "after",
+      `
 Examples:
   releases org overview acme
-  releases org overview acme --json`)
+  releases org overview acme --json`,
+    )
     .action(async (identifier: string, opts: { json?: boolean }) => {
       const found = await findOrg(identifier);
       if (!found) return orgNotFound(identifier);
@@ -218,26 +267,40 @@ Examples:
       const ageDays = overview.generatedAt ? overviewAgeDays(overview.generatedAt) : null;
 
       if (opts.json) {
-        console.log(JSON.stringify({
-          org: found.slug,
-          name: found.name,
-          generatedAt: overview.generatedAt,
-          updatedAt: overview.updatedAt,
-          lastContributingReleaseAt: overview.lastContributingReleaseAt,
-          releaseCount: overview.releaseCount,
-          stale,
-          ageDays,
-          content: overview.content,
-        }, null, 2));
+        console.log(
+          JSON.stringify(
+            {
+              org: found.slug,
+              name: found.name,
+              generatedAt: overview.generatedAt,
+              updatedAt: overview.updatedAt,
+              lastContributingReleaseAt: overview.lastContributingReleaseAt,
+              releaseCount: overview.releaseCount,
+              stale,
+              ageDays,
+              content: overview.content,
+            },
+            null,
+            2,
+          ),
+        );
         return;
       }
 
       console.log(chalk.bold(`${found.name} — overview`));
       if (overview.generatedAt) {
-        console.log(chalk.dim(`  generated ${timeAgo(overview.generatedAt) ?? "?"} · ${overview.releaseCount} releases`));
+        console.log(
+          chalk.dim(
+            `  generated ${timeAgo(overview.generatedAt) ?? "?"} · ${overview.releaseCount} releases`,
+          ),
+        );
       }
       if (stale) {
-        console.log(chalk.yellow(`  ⚠ Overview is older than ${OVERVIEW_STALE_DAYS} days — may not reflect recent releases.`));
+        console.log(
+          chalk.yellow(
+            `  ⚠ Overview is older than ${OVERVIEW_STALE_DAYS} days — may not reflect recent releases.`,
+          ),
+        );
       }
       console.log();
       console.log(stripAnsi(overview.content));
@@ -257,39 +320,54 @@ Examples:
     .option("--avatar <url>", "Set avatar image URL")
     .option("--no-avatar", "Clear avatar URL")
     .option("--json", "Output as JSON")
-    .action(async (identifier: string, opts: { name?: string; slug?: string; domain?: string; description?: string; category?: string | boolean; avatar?: string | boolean; json?: boolean }) => {
-      const found = await findOrg(identifier);
-      if (!found) return orgNotFound(identifier);
+    .action(
+      async (
+        identifier: string,
+        opts: {
+          name?: string;
+          slug?: string;
+          domain?: string;
+          description?: string;
+          category?: string | boolean;
+          avatar?: string | boolean;
+          json?: boolean;
+        },
+      ) => {
+        const found = await findOrg(identifier);
+        if (!found) return orgNotFound(identifier);
 
-      const updates: Record<string, unknown> = {};
-      if (opts.name !== undefined) updates.name = opts.name;
-      if (opts.slug !== undefined) updates.slug = opts.slug;
-      if (opts.domain !== undefined) updates.domain = opts.domain;
-      if (opts.description !== undefined) updates.description = opts.description;
+        const updates: Record<string, unknown> = {};
+        if (opts.name !== undefined) updates.name = opts.name;
+        if (opts.slug !== undefined) updates.slug = opts.slug;
+        if (opts.domain !== undefined) updates.domain = opts.domain;
+        if (opts.description !== undefined) updates.description = opts.description;
 
-      if (opts.category === false) {
-        updates.category = null;
-      } else if (typeof opts.category === "string") {
-        if (!isValidCategory(opts.category)) {
-          console.error(chalk.red(`Invalid category: "${opts.category}". Valid: ${CATEGORIES.join(", ")}`));
+        if (opts.category === false) {
+          updates.category = null;
+        } else if (typeof opts.category === "string") {
+          if (!isValidCategory(opts.category)) {
+            console.error(
+              chalk.red(`Invalid category: "${opts.category}". Valid: ${CATEGORIES.join(", ")}`),
+            );
+            process.exit(1);
+          }
+          updates.category = opts.category;
+        }
+
+        if (opts.avatar === false) updates.avatarUrl = null;
+        else if (typeof opts.avatar === "string") updates.avatarUrl = opts.avatar;
+
+        if (Object.keys(updates).length === 0) {
+          console.error(chalk.yellow("No fields to update."));
           process.exit(1);
         }
-        updates.category = opts.category;
-      }
 
-      if (opts.avatar === false) updates.avatarUrl = null;
-      else if (typeof opts.avatar === "string") updates.avatarUrl = opts.avatar;
+        const updated = await updateOrg(found.slug, updates);
 
-      if (Object.keys(updates).length === 0) {
-        console.error(chalk.yellow("No fields to update."));
-        process.exit(1);
-      }
-
-      const updated = await updateOrg(found.slug, updates);
-
-      if (opts.json) console.log(JSON.stringify(updated, null, 2));
-      else console.log(chalk.green(`Updated organization: ${updated.name} (${updated.slug})`));
-    });
+        if (opts.json) console.log(JSON.stringify(updated, null, 2));
+        else console.log(chalk.green(`Updated organization: ${updated.name} (${updated.slug})`));
+      },
+    );
 
   // ── org remove ──
   org
@@ -303,8 +381,12 @@ Examples:
       if (!found) return orgNotFound(identifier);
 
       if (opts.dryRun) {
-        if (opts.json) console.log(JSON.stringify({ wouldRemove: found.slug, name: found.name }, null, 2));
-        else console.log(chalk.yellow(`[dry-run] Would remove organization: ${found.name} (${found.slug})`));
+        if (opts.json)
+          console.log(JSON.stringify({ wouldRemove: found.slug, name: found.name }, null, 2));
+        else
+          console.log(
+            chalk.yellow(`[dry-run] Would remove organization: ${found.name} (${found.slug})`),
+          );
         return;
       }
 
@@ -322,15 +404,17 @@ Examples:
     .requiredOption("--platform <platform>", "Platform name (github, x, etc.)")
     .requiredOption("--handle <handle>", "Account handle on the platform")
     .option("--json", "Output as JSON")
-    .action(async (identifier: string, opts: { platform: string; handle: string; json?: boolean }) => {
-      const found = await findOrg(identifier);
-      if (!found) return orgNotFound(identifier);
+    .action(
+      async (identifier: string, opts: { platform: string; handle: string; json?: boolean }) => {
+        const found = await findOrg(identifier);
+        if (!found) return orgNotFound(identifier);
 
-      const created = await linkOrgAccount(found.slug, opts.platform, opts.handle);
+        const created = await linkOrgAccount(found.slug, opts.platform, opts.handle);
 
-      if (opts.json) console.log(JSON.stringify(created, null, 2));
-      else console.log(chalk.green(`Linked ${opts.platform}/${opts.handle} to ${found.name}`));
-    });
+        if (opts.json) console.log(JSON.stringify(created, null, 2));
+        else console.log(chalk.green(`Linked ${opts.platform}/${opts.handle} to ${found.name}`));
+      },
+    );
 
   // ── org unlink ──
   org
@@ -340,15 +424,19 @@ Examples:
     .requiredOption("--platform <platform>", "Platform name")
     .requiredOption("--handle <handle>", "Account handle")
     .option("--json", "Output as JSON")
-    .action(async (identifier: string, opts: { platform: string; handle: string; json?: boolean }) => {
-      const found = await findOrg(identifier);
-      if (!found) return orgNotFound(identifier);
+    .action(
+      async (identifier: string, opts: { platform: string; handle: string; json?: boolean }) => {
+        const found = await findOrg(identifier);
+        if (!found) return orgNotFound(identifier);
 
-      await unlinkOrgAccount(found.slug, opts.platform, opts.handle);
+        await unlinkOrgAccount(found.slug, opts.platform, opts.handle);
 
-      if (opts.json) console.log(JSON.stringify({ unlinked: `${opts.platform}/${opts.handle}` }, null, 2));
-      else console.log(chalk.green(`Unlinked ${opts.platform}/${opts.handle} from ${found.name}`));
-    });
+        if (opts.json)
+          console.log(JSON.stringify({ unlinked: `${opts.platform}/${opts.handle}` }, null, 2));
+        else
+          console.log(chalk.green(`Unlinked ${opts.platform}/${opts.handle} from ${found.name}`));
+      },
+    );
 
   // ── org tag ──
   const tag = org.command("tag").description("Manage organization tags");
@@ -422,12 +510,18 @@ Examples:
           const created = await addDomainAlias(domain, { orgId: found.id });
           results.push(created);
         } catch (err) {
-          logger.error(chalk.red(`Failed to add alias "${domain}": ${err instanceof Error ? err.message : err}`));
+          logger.error(
+            chalk.red(
+              `Failed to add alias "${domain}": ${err instanceof Error ? err.message : err}`,
+            ),
+          );
         }
       }
 
       if (opts.json) console.log(JSON.stringify(results, null, 2));
-      else for (const r of results) console.log(chalk.green(`Added alias: ${r.domain} → ${found.name}`));
+      else
+        for (const r of results)
+          console.log(chalk.green(`Added alias: ${r.domain} → ${found.name}`));
     });
 
   alias
@@ -462,8 +556,16 @@ Examples:
 
       const aliases = await listDomainAliases({ orgId: found.id });
 
-      if (opts.json) console.log(JSON.stringify(aliases.map((a) => a.domain), null, 2));
-      else if (aliases.length === 0) console.log(chalk.yellow(`No domain aliases for ${found.name}`));
+      if (opts.json)
+        console.log(
+          JSON.stringify(
+            aliases.map((a) => a.domain),
+            null,
+            2,
+          ),
+        );
+      else if (aliases.length === 0)
+        console.log(chalk.yellow(`No domain aliases for ${found.name}`));
       else for (const a of aliases) console.log(a.domain);
     });
 }

--- a/src/cli/commands/product.ts
+++ b/src/cli/commands/product.ts
@@ -2,19 +2,29 @@ import { Command } from "commander";
 import chalk from "chalk";
 import Table from "cli-table3";
 import {
-  findOrg, findProduct, getProductsByOrg, createProduct, updateProduct,
-  deleteProduct, getSourcesByOrg, updateSource, removeOrg,
-  getOrgAccountsBySlug, linkOrgAccount,
-  addTagsToProduct, removeTagsFromProduct, getTagsForProduct,
-  listDomainAliases, addDomainAlias, removeDomainAlias,
+  findOrg,
+  findProduct,
+  getProductsByOrg,
+  createProduct,
+  updateProduct,
+  deleteProduct,
+  getSourcesByOrg,
+  updateSource,
+  removeOrg,
+  getOrgAccountsBySlug,
+  linkOrgAccount,
+  addTagsToProduct,
+  removeTagsFromProduct,
+  getTagsForProduct,
+  listDomainAliases,
+  addDomainAlias,
+  removeDomainAlias,
 } from "../../api/client.js";
 import { toSlug } from "@releases/core/slug";
 import { isValidCategory, CATEGORIES } from "@releases/core/categories";
 
 export function registerProductCommand(program: Command) {
-  const product = program
-    .command("product")
-    .description("Manage products");
+  const product = program.command("product").description("Manage products");
 
   product
     .command("list")
@@ -68,46 +78,68 @@ export function registerProductCommand(program: Command) {
     .option("--category <category>", "Category")
     .option("--tags <tags>", "Comma-separated tags")
     .option("--json", "Output as JSON")
-    .action(async (name: string, opts: { org: string; slug?: string; url?: string; description?: string; category?: string; tags?: string; json?: boolean }) => {
-      const org = await findOrg(opts.org);
-      if (!org) {
-        console.error(chalk.red(`Organization not found: ${opts.org}`));
-        process.exit(1);
-      }
-
-      const slug = opts.slug ?? toSlug(name);
-
-      if (opts.category && !isValidCategory(opts.category)) {
-        console.error(chalk.red(`Invalid category: "${opts.category}". Valid: ${CATEGORIES.join(", ")}`));
-        process.exit(1);
-      }
-
-      let created;
-      try {
-        created = await createProduct(org.id, name, {
-          slug,
-          url: opts.url,
-          description: opts.description,
-          category: opts.category,
-        });
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        if (msg.includes("already exists") || msg.includes("UNIQUE constraint") || msg.includes("conflict")) {
-          console.error(chalk.red(`Product with slug "${slug}" already exists.`));
-        } else {
-          console.error(chalk.red(`Failed to create product: ${msg}`));
+    .action(
+      async (
+        name: string,
+        opts: {
+          org: string;
+          slug?: string;
+          url?: string;
+          description?: string;
+          category?: string;
+          tags?: string;
+          json?: boolean;
+        },
+      ) => {
+        const org = await findOrg(opts.org);
+        if (!org) {
+          console.error(chalk.red(`Organization not found: ${opts.org}`));
+          process.exit(1);
         }
-        process.exit(1);
-      }
 
-      if (opts.tags) {
-        const tagList = opts.tags.split(",").map((t: string) => t.trim()).filter(Boolean);
-        if (tagList.length > 0) await addTagsToProduct(created.id, tagList);
-      }
+        const slug = opts.slug ?? toSlug(name);
 
-      if (opts.json) console.log(JSON.stringify(created, null, 2));
-      else console.log(chalk.green(`Product added: ${name} (${slug}) under ${org.name}`));
-    });
+        if (opts.category && !isValidCategory(opts.category)) {
+          console.error(
+            chalk.red(`Invalid category: "${opts.category}". Valid: ${CATEGORIES.join(", ")}`),
+          );
+          process.exit(1);
+        }
+
+        let created;
+        try {
+          created = await createProduct(org.id, name, {
+            slug,
+            url: opts.url,
+            description: opts.description,
+            category: opts.category,
+          });
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          if (
+            msg.includes("already exists") ||
+            msg.includes("UNIQUE constraint") ||
+            msg.includes("conflict")
+          ) {
+            console.error(chalk.red(`Product with slug "${slug}" already exists.`));
+          } else {
+            console.error(chalk.red(`Failed to create product: ${msg}`));
+          }
+          process.exit(1);
+        }
+
+        if (opts.tags) {
+          const tagList = opts.tags
+            .split(",")
+            .map((t: string) => t.trim())
+            .filter(Boolean);
+          if (tagList.length > 0) await addTagsToProduct(created.id, tagList);
+        }
+
+        if (opts.json) console.log(JSON.stringify(created, null, 2));
+        else console.log(chalk.green(`Product added: ${name} (${slug}) under ${org.name}`));
+      },
+    );
 
   product
     .command("edit")
@@ -119,38 +151,51 @@ export function registerProductCommand(program: Command) {
     .option("--category <category>", "Set category")
     .option("--no-category", "Clear category")
     .option("--json", "Output as JSON")
-    .action(async (slug: string, opts: { name?: string; url?: string; description?: string; category?: string | boolean; json?: boolean }) => {
-      const found = await findProduct(slug);
-      if (!found) {
-        console.error(chalk.red(`Product not found: ${slug}`));
-        process.exit(1);
-      }
-
-      const updates: Record<string, unknown> = {};
-      if (opts.name !== undefined) updates.name = opts.name;
-      if (opts.url !== undefined) updates.url = opts.url;
-      if (opts.description !== undefined) updates.description = opts.description;
-
-      if (opts.category === false) {
-        updates.category = null;
-      } else if (typeof opts.category === "string") {
-        if (!isValidCategory(opts.category)) {
-          console.error(chalk.red(`Invalid category: "${opts.category}". Valid: ${CATEGORIES.join(", ")}`));
+    .action(
+      async (
+        slug: string,
+        opts: {
+          name?: string;
+          url?: string;
+          description?: string;
+          category?: string | boolean;
+          json?: boolean;
+        },
+      ) => {
+        const found = await findProduct(slug);
+        if (!found) {
+          console.error(chalk.red(`Product not found: ${slug}`));
           process.exit(1);
         }
-        updates.category = opts.category;
-      }
 
-      if (Object.keys(updates).length === 0) {
-        console.error(chalk.yellow("No fields to update."));
-        process.exit(1);
-      }
+        const updates: Record<string, unknown> = {};
+        if (opts.name !== undefined) updates.name = opts.name;
+        if (opts.url !== undefined) updates.url = opts.url;
+        if (opts.description !== undefined) updates.description = opts.description;
 
-      const updated = await updateProduct(found.slug, updates);
+        if (opts.category === false) {
+          updates.category = null;
+        } else if (typeof opts.category === "string") {
+          if (!isValidCategory(opts.category)) {
+            console.error(
+              chalk.red(`Invalid category: "${opts.category}". Valid: ${CATEGORIES.join(", ")}`),
+            );
+            process.exit(1);
+          }
+          updates.category = opts.category;
+        }
 
-      if (opts.json) console.log(JSON.stringify(updated, null, 2));
-      else console.log(chalk.green(`Product updated: ${updated.name} (${updated.slug})`));
-    });
+        if (Object.keys(updates).length === 0) {
+          console.error(chalk.yellow("No fields to update."));
+          process.exit(1);
+        }
+
+        const updated = await updateProduct(found.slug, updates);
+
+        if (opts.json) console.log(JSON.stringify(updated, null, 2));
+        else console.log(chalk.green(`Product updated: ${updated.name} (${updated.slug})`));
+      },
+    );
 
   product
     .command("remove")
@@ -166,8 +211,12 @@ export function registerProductCommand(program: Command) {
       }
 
       if (opts.dryRun) {
-        if (opts.json) console.log(JSON.stringify({ wouldRemove: found.slug, name: found.name }, null, 2));
-        else console.log(chalk.yellow(`[dry-run] Would remove product: ${found.name} (${found.slug})`));
+        if (opts.json)
+          console.log(JSON.stringify({ wouldRemove: found.slug, name: found.name }, null, 2));
+        else
+          console.log(
+            chalk.yellow(`[dry-run] Would remove product: ${found.name} (${found.slug})`),
+          );
         return;
       }
 
@@ -186,83 +235,106 @@ export function registerProductCommand(program: Command) {
     .option("--url <url>", "URL for the new product")
     .option("--dry-run", "Show what would happen")
     .option("--json", "Output as JSON")
-    .action(async (sourceOrgSlug: string, opts: { into: string; slug?: string; url?: string; dryRun?: boolean; json?: boolean }) => {
-      const sourceOrg = await findOrg(sourceOrgSlug);
-      if (!sourceOrg) {
-        console.error(chalk.red(`Source organization not found: ${sourceOrgSlug}`));
-        process.exit(1);
-      }
+    .action(
+      async (
+        sourceOrgSlug: string,
+        opts: { into: string; slug?: string; url?: string; dryRun?: boolean; json?: boolean },
+      ) => {
+        const sourceOrg = await findOrg(sourceOrgSlug);
+        if (!sourceOrg) {
+          console.error(chalk.red(`Source organization not found: ${sourceOrgSlug}`));
+          process.exit(1);
+        }
 
-      const targetOrg = await findOrg(opts.into);
-      if (!targetOrg) {
-        console.error(chalk.red(`Target organization not found: ${opts.into}`));
-        process.exit(1);
-      }
+        const targetOrg = await findOrg(opts.into);
+        if (!targetOrg) {
+          console.error(chalk.red(`Target organization not found: ${opts.into}`));
+          process.exit(1);
+        }
 
-      if (sourceOrg.id === targetOrg.id) {
-        console.error(chalk.red("Source and target organizations must be different."));
-        process.exit(1);
-      }
+        if (sourceOrg.id === targetOrg.id) {
+          console.error(chalk.red("Source and target organizations must be different."));
+          process.exit(1);
+        }
 
-      const sources = await getSourcesByOrg(sourceOrg.id);
-      const productSlug = opts.slug ?? sourceOrg.slug;
-      const productUrl = opts.url ?? (sourceOrg.domain ? `https://${sourceOrg.domain}` : undefined);
+        const sources = await getSourcesByOrg(sourceOrg.id);
+        const productSlug = opts.slug ?? sourceOrg.slug;
+        const productUrl =
+          opts.url ?? (sourceOrg.domain ? `https://${sourceOrg.domain}` : undefined);
 
-      if (opts.dryRun) {
-        const plan = {
-          action: "adopt",
-          sourceOrg: { slug: sourceOrg.slug, name: sourceOrg.name },
-          targetOrg: { slug: targetOrg.slug, name: targetOrg.name },
-          newProduct: { slug: productSlug, name: sourceOrg.name, url: productUrl ?? null },
-          sourcesToMove: sources.map((s) => s.slug),
-          wouldRemoveOrg: sourceOrg.slug,
-        };
+        if (opts.dryRun) {
+          const plan = {
+            action: "adopt",
+            sourceOrg: { slug: sourceOrg.slug, name: sourceOrg.name },
+            targetOrg: { slug: targetOrg.slug, name: targetOrg.name },
+            newProduct: { slug: productSlug, name: sourceOrg.name, url: productUrl ?? null },
+            sourcesToMove: sources.map((s) => s.slug),
+            wouldRemoveOrg: sourceOrg.slug,
+          };
+
+          if (opts.json) {
+            console.log(JSON.stringify(plan, null, 2));
+          } else {
+            console.log(
+              chalk.yellow(
+                `[dry-run] Would adopt "${sourceOrg.name}" as product under "${targetOrg.name}"`,
+              ),
+            );
+            console.log(`  New product slug: ${productSlug}`);
+            if (productUrl) console.log(`  New product URL:  ${productUrl}`);
+            console.log(
+              `  Sources to move:  ${sources.length > 0 ? sources.map((s) => s.slug).join(", ") : chalk.dim("none")}`,
+            );
+            console.log(`  Would remove org: ${sourceOrg.slug}`);
+          }
+          return;
+        }
+
+        const created = await createProduct(targetOrg.id, sourceOrg.name, {
+          slug: productSlug,
+          url: productUrl,
+          description: sourceOrg.description ?? undefined,
+        });
+
+        for (const source of sources) {
+          await updateSource(source.slug, { orgId: targetOrg.id, productId: created.id });
+        }
+
+        const accounts = await getOrgAccountsBySlug(sourceOrg.slug);
+        for (const acct of accounts) {
+          try {
+            await linkOrgAccount(targetOrg.slug, acct.platform, acct.handle);
+          } catch {
+            /* skip duplicates */
+          }
+        }
+
+        await removeOrg(sourceOrg.slug);
 
         if (opts.json) {
-          console.log(JSON.stringify(plan, null, 2));
+          console.log(
+            JSON.stringify(
+              {
+                adopted: sourceOrg.slug,
+                into: targetOrg.slug,
+                product: created,
+                sourcesMoved: sources.length,
+              },
+              null,
+              2,
+            ),
+          );
         } else {
-          console.log(chalk.yellow(`[dry-run] Would adopt "${sourceOrg.name}" as product under "${targetOrg.name}"`));
-          console.log(`  New product slug: ${productSlug}`);
-          if (productUrl) console.log(`  New product URL:  ${productUrl}`);
-          console.log(`  Sources to move:  ${sources.length > 0 ? sources.map((s) => s.slug).join(", ") : chalk.dim("none")}`);
-          console.log(`  Would remove org: ${sourceOrg.slug}`);
+          console.log(
+            chalk.green(
+              `Adopted "${sourceOrg.name}" as product under "${targetOrg.name}" (${productSlug})`,
+            ),
+          );
+          if (sources.length > 0)
+            console.log(`  Moved ${sources.length} source(s) to ${targetOrg.name}`);
         }
-        return;
-      }
-
-      const created = await createProduct(targetOrg.id, sourceOrg.name, {
-        slug: productSlug,
-        url: productUrl,
-        description: sourceOrg.description ?? undefined,
-      });
-
-      for (const source of sources) {
-        await updateSource(source.slug, { orgId: targetOrg.id, productId: created.id });
-      }
-
-      const accounts = await getOrgAccountsBySlug(sourceOrg.slug);
-      for (const acct of accounts) {
-        try {
-          await linkOrgAccount(targetOrg.slug, acct.platform, acct.handle);
-        } catch {
-          /* skip duplicates */
-        }
-      }
-
-      await removeOrg(sourceOrg.slug);
-
-      if (opts.json) {
-        console.log(JSON.stringify({
-          adopted: sourceOrg.slug,
-          into: targetOrg.slug,
-          product: created,
-          sourcesMoved: sources.length,
-        }, null, 2));
-      } else {
-        console.log(chalk.green(`Adopted "${sourceOrg.name}" as product under "${targetOrg.name}" (${productSlug})`));
-        if (sources.length > 0) console.log(`  Moved ${sources.length} source(s) to ${targetOrg.name}`);
-      }
-    });
+      },
+    );
 
   // ── product tag ──
   const tag = product.command("tag").description("Manage product tags");
@@ -348,12 +420,18 @@ export function registerProductCommand(program: Command) {
           const created = await addDomainAlias(domain, { productId: found.id });
           results.push(created);
         } catch (err) {
-          console.error(chalk.red(`Failed to add alias "${domain}": ${err instanceof Error ? err.message : err}`));
+          console.error(
+            chalk.red(
+              `Failed to add alias "${domain}": ${err instanceof Error ? err.message : err}`,
+            ),
+          );
         }
       }
 
       if (opts.json) console.log(JSON.stringify(results, null, 2));
-      else for (const r of results) console.log(chalk.green(`Added alias: ${r.domain} → ${found.name}`));
+      else
+        for (const r of results)
+          console.log(chalk.green(`Added alias: ${r.domain} → ${found.name}`));
     });
 
   alias
@@ -394,8 +472,16 @@ export function registerProductCommand(program: Command) {
 
       const aliases = await listDomainAliases({ productId: found.id });
 
-      if (opts.json) console.log(JSON.stringify(aliases.map((a) => a.domain), null, 2));
-      else if (aliases.length === 0) console.log(chalk.yellow(`No domain aliases for ${found.name}`));
+      if (opts.json)
+        console.log(
+          JSON.stringify(
+            aliases.map((a) => a.domain),
+            null,
+            2,
+          ),
+        );
+      else if (aliases.length === 0)
+        console.log(chalk.yellow(`No domain aliases for ${found.name}`));
       else for (const a of aliases) console.log(a.domain);
     });
 }

--- a/src/cli/commands/release.ts
+++ b/src/cli/commands/release.ts
@@ -2,8 +2,13 @@ import { Command } from "commander";
 import { createHash } from "crypto";
 import chalk from "chalk";
 import {
-  findSource, suppressRelease, unsuppressRelease,
-  getRelease, deleteRelease, updateRelease, deleteReleasesForSource,
+  findSource,
+  suppressRelease,
+  unsuppressRelease,
+  getRelease,
+  deleteRelease,
+  updateRelease,
+  deleteReleasesForSource,
 } from "../../api/client.js";
 import { stripAnsi } from "../../lib/sanitize.js";
 import { normalizeReleaseId } from "@releases/core/id";
@@ -14,9 +19,7 @@ function releaseNotFound(id: string): never {
 }
 
 export function registerReleaseCommand(program: Command) {
-  const release = program
-    .command("release")
-    .description("Manage releases");
+  const release = program.command("release").description("Manage releases");
 
   release
     .command("show")
@@ -38,10 +41,15 @@ export function registerReleaseCommand(program: Command) {
 
       console.log(chalk.bold(stripAnsi(rel.title)));
       if (rel.version) console.log(`  Version:   ${stripAnsi(rel.version)}`);
-      console.log(`  Source:    ${rel.sourceName ? stripAnsi(rel.sourceName) : chalk.dim("—")} (${rel.sourceSlug ?? chalk.dim("—")})`);
+      console.log(
+        `  Source:    ${rel.sourceName ? stripAnsi(rel.sourceName) : chalk.dim("—")} (${rel.sourceSlug ?? chalk.dim("—")})`,
+      );
       if (rel.publishedAt) console.log(`  Published: ${rel.publishedAt}`);
       console.log(`  Fetched:   ${rel.fetchedAt}`);
-      if (rel.suppressed) console.log(`  ${chalk.yellow("Suppressed")}${rel.suppressedReason ? `: ${stripAnsi(rel.suppressedReason)}` : ""}`);
+      if (rel.suppressed)
+        console.log(
+          `  ${chalk.yellow("Suppressed")}${rel.suppressedReason ? `: ${stripAnsi(rel.suppressedReason)}` : ""}`,
+        );
       if (rel.url) console.log(`  URL:       ${rel.url}`);
 
       if (rel.contentSummary) {
@@ -68,62 +76,80 @@ export function registerReleaseCommand(program: Command) {
     .option("--source <slug>", "Delete all releases for a source")
     .option("--dry-run", "Show what would be deleted without deleting")
     .option("--json", "Output as JSON")
-    .action(async (rawId: string | undefined, opts: { source?: string; json?: boolean; dryRun?: boolean }) => {
-      const id = rawId ? normalizeReleaseId(rawId) : undefined;
-      if (!id && !opts.source) {
-        console.error("Error: provide a release ID or --source\n");
-        process.exit(1);
-      }
-
-      let resolvedSource: Awaited<ReturnType<typeof findSource>> | undefined;
-      if (opts.source) {
-        resolvedSource = await findSource(opts.source);
-        if (!resolvedSource) {
-          console.error(chalk.red(`Source not found: ${opts.source}`));
+    .action(
+      async (
+        rawId: string | undefined,
+        opts: { source?: string; json?: boolean; dryRun?: boolean },
+      ) => {
+        const id = rawId ? normalizeReleaseId(rawId) : undefined;
+        if (!id && !opts.source) {
+          console.error("Error: provide a release ID or --source\n");
           process.exit(1);
         }
-      }
 
-      if (id) {
-        if (opts.dryRun) {
-          const existing = await getRelease(id);
-          if (!existing) releaseNotFound(id);
-          if (opts.json) {
-            console.log(JSON.stringify({ wouldDelete: 1, releases: [{ id, title: existing.title }] }, null, 2));
-          } else {
-            console.log(chalk.yellow(`[dry-run] Would delete 1 release(s)`));
-            console.log(`  ${id}  ${stripAnsi(existing.title)}`);
+        let resolvedSource: Awaited<ReturnType<typeof findSource>> | undefined;
+        if (opts.source) {
+          resolvedSource = await findSource(opts.source);
+          if (!resolvedSource) {
+            console.error(chalk.red(`Source not found: ${opts.source}`));
+            process.exit(1);
           }
+        }
+
+        if (id) {
+          if (opts.dryRun) {
+            const existing = await getRelease(id);
+            if (!existing) releaseNotFound(id);
+            if (opts.json) {
+              console.log(
+                JSON.stringify(
+                  { wouldDelete: 1, releases: [{ id, title: existing.title }] },
+                  null,
+                  2,
+                ),
+              );
+            } else {
+              console.log(chalk.yellow(`[dry-run] Would delete 1 release(s)`));
+              console.log(`  ${id}  ${stripAnsi(existing.title)}`);
+            }
+            return;
+          }
+
+          const deleted = await deleteRelease(id);
+          if (!deleted) {
+            console.error(chalk.red("No matching releases found."));
+            process.exit(1);
+          }
+          if (opts.json) console.log(JSON.stringify({ deleted: 1 }, null, 2));
+          else console.log(chalk.green(`Deleted 1 release.`));
           return;
         }
 
-        const deleted = await deleteRelease(id);
-        if (!deleted) {
-          console.error(chalk.red("No matching releases found."));
-          process.exit(1);
-        }
-        if (opts.json) console.log(JSON.stringify({ deleted: 1 }, null, 2));
-        else console.log(chalk.green(`Deleted 1 release.`));
-        return;
-      }
-
-      if (resolvedSource) {
-        if (opts.dryRun) {
-          console.log(chalk.yellow(`[dry-run] Would delete all releases for source: ${resolvedSource.slug}`));
+        if (resolvedSource) {
+          if (opts.dryRun) {
+            console.log(
+              chalk.yellow(
+                `[dry-run] Would delete all releases for source: ${resolvedSource.slug}`,
+              ),
+            );
+            return;
+          }
+          let result: Awaited<ReturnType<typeof deleteReleasesForSource>>;
+          try {
+            result = await deleteReleasesForSource(resolvedSource.slug);
+          } catch (err) {
+            console.error(chalk.red(err instanceof Error ? err.message : String(err)));
+            process.exit(1);
+          }
+          if (opts.json) console.log(JSON.stringify(result, null, 2));
+          else
+            console.log(
+              chalk.green(`Deleted ${result.deleted} release${result.deleted === 1 ? "" : "s"}.`),
+            );
           return;
         }
-        let result: Awaited<ReturnType<typeof deleteReleasesForSource>>;
-        try {
-          result = await deleteReleasesForSource(resolvedSource.slug);
-        } catch (err) {
-          console.error(chalk.red(err instanceof Error ? err.message : String(err)));
-          process.exit(1);
-        }
-        if (opts.json) console.log(JSON.stringify(result, null, 2));
-        else console.log(chalk.green(`Deleted ${result.deleted} release${result.deleted === 1 ? "" : "s"}.`));
-        return;
-      }
-    });
+      },
+    );
 
   release
     .command("edit")
@@ -133,38 +159,49 @@ export function registerReleaseCommand(program: Command) {
     .option("--version <version>", "Update version")
     .option("--content <content>", "Update content (recomputes contentHash)")
     .option("--json", "Output as JSON")
-    .action(async (rawId: string, opts: { title?: string; version?: string; content?: string; json?: boolean }) => {
-      const id = normalizeReleaseId(rawId);
-      const existing = await getRelease(id);
-      if (!existing) releaseNotFound(id);
+    .action(
+      async (
+        rawId: string,
+        opts: { title?: string; version?: string; content?: string; json?: boolean },
+      ) => {
+        const id = normalizeReleaseId(rawId);
+        const existing = await getRelease(id);
+        if (!existing) releaseNotFound(id);
 
-      const updates: Record<string, unknown> = {};
-      const changes: string[] = [];
+        const updates: Record<string, unknown> = {};
+        const changes: string[] = [];
 
-      if (opts.title) { updates.title = opts.title; changes.push(`title → ${opts.title}`); }
-      if (opts.version) { updates.version = opts.version; changes.push(`version → ${opts.version}`); }
+        if (opts.title) {
+          updates.title = opts.title;
+          changes.push(`title → ${opts.title}`);
+        }
+        if (opts.version) {
+          updates.version = opts.version;
+          changes.push(`version → ${opts.version}`);
+        }
 
-      if (opts.content) {
-        updates.content = opts.content;
-        const hash = createHash("sha256").update(opts.content).digest("hex");
-        updates.contentHash = hash;
-        changes.push(`content → (${opts.content.length} chars)`);
-        changes.push(`contentHash → ${hash.slice(0, 12)}…`);
-      }
+        if (opts.content) {
+          updates.content = opts.content;
+          const hash = createHash("sha256").update(opts.content).digest("hex");
+          updates.contentHash = hash;
+          changes.push(`content → (${opts.content.length} chars)`);
+          changes.push(`contentHash → ${hash.slice(0, 12)}…`);
+        }
 
-      if (changes.length === 0) {
-        console.log(chalk.yellow("No changes specified."));
-        return;
-      }
+        if (changes.length === 0) {
+          console.log(chalk.yellow("No changes specified."));
+          return;
+        }
 
-      const updated = await updateRelease(id, updates);
+        const updated = await updateRelease(id, updates);
 
-      if (opts.json) console.log(JSON.stringify(updated, null, 2));
-      else {
-        console.log(chalk.green(`Updated release ${id}:`));
-        for (const change of changes) console.log(`  ${change}`);
-      }
-    });
+        if (opts.json) console.log(JSON.stringify(updated, null, 2));
+        else {
+          console.log(chalk.green(`Updated release ${id}:`));
+          for (const change of changes) console.log(`  ${change}`);
+        }
+      },
+    );
 
   release
     .command("suppress")
@@ -176,16 +213,28 @@ export function registerReleaseCommand(program: Command) {
     .action(async (rawId: string, opts: { reason?: string; dryRun?: boolean; json?: boolean }) => {
       const id = normalizeReleaseId(rawId);
       if (opts.dryRun) {
-        if (opts.json) console.log(JSON.stringify({ id, suppressed: true, reason: opts.reason ?? null, dryRun: true }));
-        else console.log(chalk.yellow(`[dry-run] Would suppress release ${id}${opts.reason ? ` (${opts.reason})` : ""}`));
+        if (opts.json)
+          console.log(
+            JSON.stringify({ id, suppressed: true, reason: opts.reason ?? null, dryRun: true }),
+          );
+        else
+          console.log(
+            chalk.yellow(
+              `[dry-run] Would suppress release ${id}${opts.reason ? ` (${opts.reason})` : ""}`,
+            ),
+          );
         return;
       }
 
       const found = await suppressRelease(id, opts.reason);
       if (!found) releaseNotFound(id);
 
-      if (opts.json) console.log(JSON.stringify({ id, suppressed: true, reason: opts.reason ?? null }));
-      else console.log(chalk.green(`Suppressed release ${id}${opts.reason ? ` (${opts.reason})` : ""}`));
+      if (opts.json)
+        console.log(JSON.stringify({ id, suppressed: true, reason: opts.reason ?? null }));
+      else
+        console.log(
+          chalk.green(`Suppressed release ${id}${opts.reason ? ` (${opts.reason})` : ""}`),
+        );
     });
 
   release

--- a/src/cli/commands/remove.ts
+++ b/src/cli/commands/remove.ts
@@ -12,76 +12,93 @@ export function registerRemoveCommand(program: Command) {
     .option("--reason <reason>", "Reason for ignoring (used with --ignore)")
     .option("--dry-run", "Show what would be removed without deleting")
     .option("--json", "Output as JSON")
-    .action(async (slugs: string[], opts: { ignore?: boolean; reason?: string; json?: boolean; dryRun?: boolean }) => {
-      const existing = await findSourcesBySlugs(slugs);
+    .action(
+      async (
+        slugs: string[],
+        opts: { ignore?: boolean; reason?: string; json?: boolean; dryRun?: boolean },
+      ) => {
+        const existing = await findSourcesBySlugs(slugs);
 
-      const foundSlugs = new Set(existing.map((s) => s.slug));
-      const results: { slug: string; name?: string; url?: string; status: "removed" | "not_found"; ignored?: boolean }[] = [];
-      let hasError = false;
+        const foundSlugs = new Set(existing.map((s) => s.slug));
+        const results: {
+          slug: string;
+          name?: string;
+          url?: string;
+          status: "removed" | "not_found";
+          ignored?: boolean;
+        }[] = [];
+        let hasError = false;
 
-      if (opts.dryRun) {
-        const dryResults = slugs.map((slug) => {
-          const found = existing.find((s) => s.slug === slug);
-          return found
-            ? { slug, name: found.name, url: found.url, status: "would_remove" as const }
-            : { slug, status: "not_found" as const };
-        });
-
-        if (opts.json) {
-          console.log(JSON.stringify(dryResults, null, 2));
-        } else {
-          for (const r of dryResults) {
-            if (r.status === "not_found") console.error(chalk.red(`Source not found: ${r.slug}`));
-            else console.log(chalk.yellow(`[dry-run] Would remove: ${r.name} (${r.slug})`));
-          }
-        }
-
-        if (dryResults.some((r) => r.status === "not_found")) process.exit(1);
-        return;
-      }
-
-      for (const slug of slugs) {
-        if (!foundSlugs.has(slug)) {
-          results.push({ slug, status: "not_found" });
-          logger.error(`Source not found: ${slug}`);
-          hasError = true;
-        }
-      }
-
-      if (opts.ignore && existing.length > 0) {
-        for (const source of existing) {
-          if (!source.orgId) {
-            if (!opts.json) {
-              logger.warn(chalk.yellow(`Cannot ignore ${source.url} — source has no organization. Use 'block add' for global blocking.`));
-            }
-            continue;
-          }
-          await addIgnoredUrl(source.url, source.orgId, opts.reason);
-          if (!opts.json) {
-            logger.info(chalk.yellow(`Ignored URL: ${source.url}${opts.reason ? ` (${opts.reason})` : ""}`));
-          }
-        }
-      }
-
-      if (existing.length > 0) {
-        const foundSlugList = existing.map((s) => s.slug);
-        await deleteSources(foundSlugList);
-
-        for (const source of existing) {
-          results.push({
-            slug: source.slug,
-            name: source.name,
-            url: source.url,
-            status: "removed",
-            ...(opts.ignore ? { ignored: true } : {}),
+        if (opts.dryRun) {
+          const dryResults = slugs.map((slug) => {
+            const found = existing.find((s) => s.slug === slug);
+            return found
+              ? { slug, name: found.name, url: found.url, status: "would_remove" as const }
+              : { slug, status: "not_found" as const };
           });
-          if (!opts.json) {
-            logger.info(chalk.green(`Removed source: ${source.name} (${source.slug})`));
+
+          if (opts.json) {
+            console.log(JSON.stringify(dryResults, null, 2));
+          } else {
+            for (const r of dryResults) {
+              if (r.status === "not_found") console.error(chalk.red(`Source not found: ${r.slug}`));
+              else console.log(chalk.yellow(`[dry-run] Would remove: ${r.name} (${r.slug})`));
+            }
+          }
+
+          if (dryResults.some((r) => r.status === "not_found")) process.exit(1);
+          return;
+        }
+
+        for (const slug of slugs) {
+          if (!foundSlugs.has(slug)) {
+            results.push({ slug, status: "not_found" });
+            logger.error(`Source not found: ${slug}`);
+            hasError = true;
           }
         }
-      }
 
-      if (opts.json) console.log(JSON.stringify(results, null, 2));
-      if (hasError) process.exit(1);
-    });
+        if (opts.ignore && existing.length > 0) {
+          for (const source of existing) {
+            if (!source.orgId) {
+              if (!opts.json) {
+                logger.warn(
+                  chalk.yellow(
+                    `Cannot ignore ${source.url} — source has no organization. Use 'block add' for global blocking.`,
+                  ),
+                );
+              }
+              continue;
+            }
+            await addIgnoredUrl(source.url, source.orgId, opts.reason);
+            if (!opts.json) {
+              logger.info(
+                chalk.yellow(`Ignored URL: ${source.url}${opts.reason ? ` (${opts.reason})` : ""}`),
+              );
+            }
+          }
+        }
+
+        if (existing.length > 0) {
+          const foundSlugList = existing.map((s) => s.slug);
+          await deleteSources(foundSlugList);
+
+          for (const source of existing) {
+            results.push({
+              slug: source.slug,
+              name: source.name,
+              url: source.url,
+              status: "removed",
+              ...(opts.ignore ? { ignored: true } : {}),
+            });
+            if (!opts.json) {
+              logger.info(chalk.green(`Removed source: ${source.name} (${source.slug})`));
+            }
+          }
+        }
+
+        if (opts.json) console.log(JSON.stringify(results, null, 2));
+        if (hasError) process.exit(1);
+      },
+    );
 }

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -23,78 +23,88 @@ export function registerSearchCommand(program: Command) {
     .option("--type <type>", "Limit to a result type: orgs, products, releases")
     .option("--mode <mode>", `Search mode: ${SEARCH_MODES.join(" | ")}`)
     .option("--json", "Output as JSON")
-    .action(async (query: string, opts: { limit: string; type?: string; mode?: string; json?: boolean }) => {
-      const limit = parseInt(opts.limit, 10);
+    .action(
+      async (
+        query: string,
+        opts: { limit: string; type?: string; mode?: string; json?: boolean },
+      ) => {
+        const limit = parseInt(opts.limit, 10);
 
-      let mode: SearchMode | undefined;
-      try {
-        mode = parseMode(opts.mode);
-      } catch (err) {
-        logger.error(err instanceof Error ? err.message : String(err));
-        process.exit(1);
-      }
-
-      const response = await unifiedSearch(
-        query,
-        limit,
-        mode ? { mode } : undefined,
-      );
-
-      const types = opts.type
-        ? [opts.type as keyof Omit<UnifiedSearchResponse, "query">]
-        : (["orgs", "products", "releases"] as const);
-
-      if (opts.json) {
-        const filtered: Record<string, unknown> = { query: response.query };
-        for (const t of types) filtered[t] = response[t];
-        if (response.mode !== undefined) filtered.mode = response.mode;
-        if (response.degraded !== undefined) filtered.degraded = response.degraded;
-        if (response.degradedReason !== undefined) filtered.degradedReason = response.degradedReason;
-        console.log(JSON.stringify(filtered, null, 2));
-        return;
-      }
-
-      if (response.degraded) {
-        logger.warn(`Search degraded to lexical${response.degradedReason ? `: ${response.degradedReason}` : ""}.`);
-      }
-
-      let totalResults = 0;
-
-      if (types.includes("orgs") && response.orgs.length > 0) {
-        console.log(chalk.bold.underline("Organizations"));
-        for (const org of response.orgs) {
-          const meta = [org.category, org.domain].filter(Boolean).join(" | ");
-          console.log(`  ${chalk.cyan.bold(stripAnsi(org.name))} ${chalk.dim(`(${org.slug})`)}`);
-          if (meta) console.log(`  ${chalk.dim(meta)}`);
+        let mode: SearchMode | undefined;
+        try {
+          mode = parseMode(opts.mode);
+        } catch (err) {
+          logger.error(err instanceof Error ? err.message : String(err));
+          process.exit(1);
         }
-        console.log();
-        totalResults += response.orgs.length;
-      }
 
-      if (types.includes("products") && response.products.length > 0) {
-        console.log(chalk.bold.underline("Products"));
-        for (const p of response.products) {
-          const org = p.orgName ? ` ${chalk.dim(`by ${stripAnsi(p.orgName)}`)}` : "";
-          console.log(`  ${chalk.cyan.bold(stripAnsi(p.name))} ${chalk.dim(`(${p.slug})`)}${org}`);
+        const response = await unifiedSearch(query, limit, mode ? { mode } : undefined);
+
+        const types = opts.type
+          ? [opts.type as keyof Omit<UnifiedSearchResponse, "query">]
+          : (["orgs", "products", "releases"] as const);
+
+        if (opts.json) {
+          const filtered: Record<string, unknown> = { query: response.query };
+          for (const t of types) filtered[t] = response[t];
+          if (response.mode !== undefined) filtered.mode = response.mode;
+          if (response.degraded !== undefined) filtered.degraded = response.degraded;
+          if (response.degradedReason !== undefined)
+            filtered.degradedReason = response.degradedReason;
+          console.log(JSON.stringify(filtered, null, 2));
+          return;
         }
-        console.log();
-        totalResults += response.products.length;
-      }
 
-      if (types.includes("releases") && response.releases.length > 0) {
-        console.log(chalk.bold.underline("Releases"));
-        for (const r of response.releases) {
-          const idLabel = r.id ? ` ${chalk.dim(r.id.slice(0, 12))}` : "";
-          console.log(`  ${chalk.cyan.bold(stripAnsi(r.title))}${idLabel}`);
-          console.log(chalk.dim(`  Source: ${stripAnsi(r.sourceName)} (${r.sourceSlug})  |  Published: ${r.publishedAt ?? "No date"}`));
-          const summary = stripAnsi(r.summary);
-          console.log(`  ${summary}${summary.length >= 150 ? "..." : ""}`);
+        if (response.degraded) {
+          logger.warn(
+            `Search degraded to lexical${response.degradedReason ? `: ${response.degradedReason}` : ""}.`,
+          );
+        }
+
+        let totalResults = 0;
+
+        if (types.includes("orgs") && response.orgs.length > 0) {
+          console.log(chalk.bold.underline("Organizations"));
+          for (const org of response.orgs) {
+            const meta = [org.category, org.domain].filter(Boolean).join(" | ");
+            console.log(`  ${chalk.cyan.bold(stripAnsi(org.name))} ${chalk.dim(`(${org.slug})`)}`);
+            if (meta) console.log(`  ${chalk.dim(meta)}`);
+          }
           console.log();
+          totalResults += response.orgs.length;
         }
-        totalResults += response.releases.length;
-      }
 
-      if (totalResults === 0) console.log(chalk.yellow("No results found."));
-      else console.log(chalk.dim(`${totalResults} result(s) found.`));
-    });
+        if (types.includes("products") && response.products.length > 0) {
+          console.log(chalk.bold.underline("Products"));
+          for (const p of response.products) {
+            const org = p.orgName ? ` ${chalk.dim(`by ${stripAnsi(p.orgName)}`)}` : "";
+            console.log(
+              `  ${chalk.cyan.bold(stripAnsi(p.name))} ${chalk.dim(`(${p.slug})`)}${org}`,
+            );
+          }
+          console.log();
+          totalResults += response.products.length;
+        }
+
+        if (types.includes("releases") && response.releases.length > 0) {
+          console.log(chalk.bold.underline("Releases"));
+          for (const r of response.releases) {
+            const idLabel = r.id ? ` ${chalk.dim(r.id.slice(0, 12))}` : "";
+            console.log(`  ${chalk.cyan.bold(stripAnsi(r.title))}${idLabel}`);
+            console.log(
+              chalk.dim(
+                `  Source: ${stripAnsi(r.sourceName)} (${r.sourceSlug})  |  Published: ${r.publishedAt ?? "No date"}`,
+              ),
+            );
+            const summary = stripAnsi(r.summary);
+            console.log(`  ${summary}${summary.length >= 150 ? "..." : ""}`);
+            console.log();
+          }
+          totalResults += response.releases.length;
+        }
+
+        if (totalResults === 0) console.log(chalk.yellow("No results found."));
+        else console.log(chalk.dim(`${totalResults} result(s) found.`));
+      },
+    );
 }

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -1,10 +1,7 @@
 import { Command } from "commander";
 import { startMcpServer } from "../../mcp/server.js";
 
-export function registerServeCommand(
-  program: Command,
-  opts?: { commandName?: string },
-) {
+export function registerServeCommand(program: Command, opts?: { commandName?: string }) {
   program
     .command(opts?.commandName ?? "serve")
     .description("Start the MCP server on stdio for AI agent integration")

--- a/src/cli/commands/show.ts
+++ b/src/cli/commands/show.ts
@@ -1,6 +1,12 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { findSource, findOrg, findProduct, getRelease, getLatestReleases } from "../../api/client.js";
+import {
+  findSource,
+  findOrg,
+  findProduct,
+  getRelease,
+  getLatestReleases,
+} from "../../api/client.js";
 import { stripAnsi } from "../../lib/sanitize.js";
 import { renderLatestReleasesTable } from "../render/releases-table.js";
 import { getEntityType, normalizeReleaseId, isLikelyBareId } from "@releases/core/id";
@@ -48,11 +54,15 @@ async function showRelease(id: string, opts: { json?: boolean }) {
   console.log(chalk.bold(stripAnsi(rel.title)));
   console.log(`  ID:        ${rel.id}`);
   if (rel.version) console.log(`  Version:   ${stripAnsi(rel.version)}`);
-  console.log(`  Source:    ${rel.sourceName ? stripAnsi(rel.sourceName) : chalk.dim("—")} (${rel.sourceSlug ?? chalk.dim("—")})`);
+  console.log(
+    `  Source:    ${rel.sourceName ? stripAnsi(rel.sourceName) : chalk.dim("—")} (${rel.sourceSlug ?? chalk.dim("—")})`,
+  );
   if (rel.publishedAt) console.log(`  Published: ${rel.publishedAt}`);
   if (rel.url) console.log(`  URL:       ${rel.url}`);
   if (rel.suppressed) {
-    console.log(`  ${chalk.yellow("Suppressed")}${rel.suppressedReason ? `: ${stripAnsi(rel.suppressedReason)}` : ""}`);
+    console.log(
+      `  ${chalk.yellow("Suppressed")}${rel.suppressedReason ? `: ${stripAnsi(rel.suppressedReason)}` : ""}`,
+    );
   }
   if (rel.contentSummary) {
     console.log("");
@@ -87,7 +97,18 @@ async function showProduct(identifier: string, opts: { json?: boolean }) {
   await renderProduct(product, opts);
 }
 
-function renderSource(source: { id: string; name: string; slug: string; type: string; url: string; orgId: string | null; productId: string | null }, opts: { json?: boolean }) {
+function renderSource(
+  source: {
+    id: string;
+    name: string;
+    slug: string;
+    type: string;
+    url: string;
+    orgId: string | null;
+    productId: string | null;
+  },
+  opts: { json?: boolean },
+) {
   if (opts.json) {
     console.log(JSON.stringify(source, null, 2));
     return;
@@ -127,7 +148,17 @@ async function renderOrg(
   }
 }
 
-async function renderProduct(product: { id: string; name: string; slug: string; orgId: string; url: string | null; category: string | null }, opts: { json?: boolean }) {
+async function renderProduct(
+  product: {
+    id: string;
+    name: string;
+    slug: string;
+    orgId: string;
+    url: string | null;
+    category: string | null;
+  },
+  opts: { json?: boolean },
+) {
   const org = await findOrg(product.orgId);
   if (opts.json) {
     console.log(JSON.stringify({ ...product, orgSlug: org?.slug ?? null }, null, 2));

--- a/src/cli/commands/stats.ts
+++ b/src/cli/commands/stats.ts
@@ -16,21 +16,27 @@ export function registerStatsCommand(program: Command) {
       const data = await getStatsSummary(days);
 
       if (opts.json) {
-        console.log(JSON.stringify({
-          period: data.period,
-          totals: data.totals,
-          sourceHealth: data.sourceHealth,
-          sources: data.sources.map((s) => ({
-            name: s.sourceName,
-            slug: s.sourceSlug,
-            type: s.sourceType,
-            org: s.orgName,
-            lastFetched: s.lastFetchedAt,
-            totalReleases: s.totalReleases,
-            recentReleases: s.recentReleases,
-          })),
-          recentActivity: data.recentActivity,
-        }, null, 2));
+        console.log(
+          JSON.stringify(
+            {
+              period: data.period,
+              totals: data.totals,
+              sourceHealth: data.sourceHealth,
+              sources: data.sources.map((s) => ({
+                name: s.sourceName,
+                slug: s.sourceSlug,
+                type: s.sourceType,
+                org: s.orgName,
+                lastFetched: s.lastFetchedAt,
+                totalReleases: s.totalReleases,
+                recentReleases: s.recentReleases,
+              })),
+              recentActivity: data.recentActivity,
+            },
+            null,
+            2,
+          ),
+        );
         return;
       }
 
@@ -41,9 +47,13 @@ export function registerStatsCommand(program: Command) {
       console.log(`  Last ${days} days:   ${data.totals.releasesInPeriod} releases\n`);
 
       console.log(chalk.bold("Source Health\n"));
-      console.log(`  ${chalk.green(`${data.sourceHealth.upToDate} up to date`)} (fetched in last ${days} days)`);
+      console.log(
+        `  ${chalk.green(`${data.sourceHealth.upToDate} up to date`)} (fetched in last ${days} days)`,
+      );
       if (data.sourceHealth.stale > 0) {
-        console.log(`  ${chalk.yellow(`${data.sourceHealth.stale} stale`)} (fetched, but not recently)`);
+        console.log(
+          `  ${chalk.yellow(`${data.sourceHealth.stale} stale`)} (fetched, but not recently)`,
+        );
       }
       if (data.sourceHealth.neverFetched > 0) {
         console.log(`  ${chalk.red(`${data.sourceHealth.neverFetched} never fetched`)}`);
@@ -90,13 +100,14 @@ export function registerStatsCommand(program: Command) {
           ],
         });
         for (const f of data.recentActivity) {
-          const statusLabel = f.status === "dry_run"
-            ? chalk.magenta("dry run")
-            : f.status === "success"
-              ? chalk.green("success")
-              : f.status === "error"
-                ? chalk.red("error")
-                : chalk.dim("no change");
+          const statusLabel =
+            f.status === "dry_run"
+              ? chalk.magenta("dry run")
+              : f.status === "success"
+                ? chalk.green("success")
+                : f.status === "error"
+                  ? chalk.red("error")
+                  : chalk.dim("no change");
           activityTable.push([
             stripAnsi(f.sourceName),
             f.orgName ? stripAnsi(f.orgName) : chalk.dim("—"),

--- a/src/cli/commands/tail.ts
+++ b/src/cli/commands/tail.ts
@@ -41,11 +41,16 @@ export function registerTailCommand(program: Command) {
     .argument("[slug]", "Source slug to filter by")
     .option("-c, --count <n>", "Number of releases to show", "10")
     .option("--org <identifier>", "Filter to an organization")
-    .option("--include-coverage", "Include releases that are coverage of another (hidden by default)")
+    .option(
+      "--include-coverage",
+      "Include releases that are coverage of another (hidden by default)",
+    )
     .option("-f, --follow", "Poll for new releases and stream them as they arrive")
     .option("--interval <seconds>", "Poll interval in seconds when following (min 5)", "60")
     .option("--json", "Output as JSON")
-    .addHelpText("after", `
+    .addHelpText(
+      "after",
+      `
 Examples:
   releases tail                         Latest releases across all sources
   releases tail my-source               Latest releases from one source
@@ -53,77 +58,84 @@ Examples:
   releases tail -f                      Follow new releases as they arrive (60s interval)
   releases tail -f --interval 30        Follow with a 30s poll interval
   releases tail --json                  Output as JSON
-  releases latest                       Alias for the one-shot listing`)
-    .action(async (
-      slug: string | undefined,
-      opts: {
-        count: string;
-        org?: string;
-        includeCoverage?: boolean;
-        follow?: boolean;
-        interval: string;
-        json?: boolean;
-      },
-    ) => {
-      const count = parseInt(opts.count, 10);
-      const intervalSeconds = Math.max(5, parseInt(opts.interval, 10) || 60);
+  releases latest                       Alias for the one-shot listing`,
+    )
+    .action(
+      async (
+        slug: string | undefined,
+        opts: {
+          count: string;
+          org?: string;
+          includeCoverage?: boolean;
+          follow?: boolean;
+          interval: string;
+          json?: boolean;
+        },
+      ) => {
+        const count = parseInt(opts.count, 10);
+        const intervalSeconds = Math.max(5, parseInt(opts.interval, 10) || 60);
 
-      if (slug) {
-        const source = await findSource(slug);
-        if (!source) return sourceNotFound(slug);
-      }
-
-      let orgSlug: string | undefined;
-      if (opts.org) {
-        const org = await findOrg(opts.org);
-        if (!org) return orgNotFound(opts.org);
-        orgSlug = org.slug;
-      }
-
-      const fetchOpts = { slug, orgSlug, count, includeCoverage: opts.includeCoverage };
-      const rows = await getLatestReleases(fetchOpts);
-
-      if (opts.json) {
-        console.log(JSON.stringify(rows, null, 2));
-      } else if (rows.length === 0) {
-        console.log(chalk.yellow("No releases found."));
-      } else if (opts.follow) {
-        for (const row of rows.slice().reverse()) {
-          console.log(renderStreamLine(row));
+        if (slug) {
+          const source = await findSource(slug);
+          if (!source) return sourceNotFound(slug);
         }
-      } else {
-        console.log(renderLatestReleasesTable(rows, { withSummary: true }));
-        console.log(
-          chalk.dim(
-            `\n  More: "releases show <rel_id>" for full content · "releases tail <source-slug>" to filter by source`,
-          ),
-        );
-      }
 
-      if (!opts.follow) return;
+        let orgSlug: string | undefined;
+        if (opts.org) {
+          const org = await findOrg(opts.org);
+          if (!org) return orgNotFound(opts.org);
+          orgSlug = org.slug;
+        }
 
-      // Follow mode polls the same unfiltered request each tick so the response
-      // collapses onto the shared KV cache key — a server-side `since` filter
-      // would fork the cache and defeat the point. De-dupe via seen-id set.
-      const seen = new Set<string>();
-      rememberSeen(seen, rows.map((r) => r.id));
-      console.error(
-        chalk.dim(`\n  Following (every ${intervalSeconds}s). Ctrl-C to stop.`),
-      );
+        const fetchOpts = { slug, orgSlug, count, includeCoverage: opts.includeCoverage };
+        const rows = await getLatestReleases(fetchOpts);
 
-      while (true) {
-        await sleep(intervalSeconds * 1000);
-        const fresh = await getLatestReleases(fetchOpts);
-        const novel = fresh.filter((r) => !seen.has(r.id));
-        if (novel.length === 0) continue;
-
-        rememberSeen(seen, novel.map((r) => r.id));
-        const ordered = novel.slice().reverse();
         if (opts.json) {
-          for (const row of ordered) console.log(JSON.stringify(row));
+          console.log(JSON.stringify(rows, null, 2));
+        } else if (rows.length === 0) {
+          console.log(chalk.yellow("No releases found."));
+        } else if (opts.follow) {
+          for (const row of rows.slice().reverse()) {
+            console.log(renderStreamLine(row));
+          }
         } else {
-          for (const row of ordered) console.log(renderStreamLine(row));
+          console.log(renderLatestReleasesTable(rows, { withSummary: true }));
+          console.log(
+            chalk.dim(
+              `\n  More: "releases show <rel_id>" for full content · "releases tail <source-slug>" to filter by source`,
+            ),
+          );
         }
-      }
-    });
+
+        if (!opts.follow) return;
+
+        // Follow mode polls the same unfiltered request each tick so the response
+        // collapses onto the shared KV cache key — a server-side `since` filter
+        // would fork the cache and defeat the point. De-dupe via seen-id set.
+        const seen = new Set<string>();
+        rememberSeen(
+          seen,
+          rows.map((r) => r.id),
+        );
+        console.error(chalk.dim(`\n  Following (every ${intervalSeconds}s). Ctrl-C to stop.`));
+
+        while (true) {
+          await sleep(intervalSeconds * 1000);
+          const fresh = await getLatestReleases(fetchOpts);
+          const novel = fresh.filter((r) => !seen.has(r.id));
+          if (novel.length === 0) continue;
+
+          rememberSeen(
+            seen,
+            novel.map((r) => r.id),
+          );
+          const ordered = novel.slice().reverse();
+          if (opts.json) {
+            for (const row of ordered) console.log(JSON.stringify(row));
+          } else {
+            for (const row of ordered) console.log(renderStreamLine(row));
+          }
+        }
+      },
+    );
 }

--- a/src/cli/commands/task.ts
+++ b/src/cli/commands/task.ts
@@ -3,9 +3,7 @@ import chalk from "chalk";
 import * as apiClient from "../../api/client.js";
 
 export function registerTaskCommand(program: Command) {
-  const task = program
-    .command("task")
-    .description("Manage remote fetch and discovery sessions");
+  const task = program.command("task").description("Manage remote fetch and discovery sessions");
 
   task
     .command("list")
@@ -26,15 +24,24 @@ export function registerTaskCommand(program: Command) {
 
       for (const s of sessions) {
         const age = Math.round((Date.now() - s.startedAt) / 1000);
-        const statusColor = s.status === "running" ? chalk.yellow
-          : s.status === "complete" ? chalk.green
-          : s.status === "cancelled" ? chalk.gray
-          : chalk.red;
+        const statusColor =
+          s.status === "running"
+            ? chalk.yellow
+            : s.status === "complete"
+              ? chalk.green
+              : s.status === "cancelled"
+                ? chalk.gray
+                : chalk.red;
         const sources = s.totalSources ? `${s.sourcesFetched ?? 0}/${s.totalSources} sources` : "";
         const releases = s.releasesInserted ? `${s.releasesInserted} new` : "";
         const details = [sources, releases].filter(Boolean).join(", ");
         const detailStr = details ? chalk.gray(` (${details})`) : "";
-        const ageStr = age < 60 ? `${age}s` : age < 3600 ? `${Math.round(age / 60)}m` : `${Math.round(age / 3600)}h`;
+        const ageStr =
+          age < 60
+            ? `${age}s`
+            : age < 3600
+              ? `${Math.round(age / 60)}m`
+              : `${Math.round(age / 3600)}h`;
 
         console.log(
           `  ${statusColor(s.status.padEnd(10))} ${s.company.padEnd(30)} ${chalk.gray(s.sessionId.slice(0, 8))}  ${chalk.gray(ageStr + " ago")}${detailStr}`,

--- a/src/cli/commands/telemetry.ts
+++ b/src/cli/commands/telemetry.ts
@@ -3,9 +3,7 @@ import chalk from "chalk";
 import { setTelemetryEnabled, telemetryStatus } from "../../lib/telemetry.js";
 
 export function registerTelemetryCommand(parent: Command): void {
-  const cmd = parent
-    .command("telemetry")
-    .description("Manage anonymous usage telemetry");
+  const cmd = parent.command("telemetry").description("Manage anonymous usage telemetry");
 
   cmd
     .command("status")
@@ -24,7 +22,9 @@ export function registerTelemetryCommand(parent: Command): void {
       console.log(`${chalk.dim("Kind:")}    ${s.clientKind}`);
       console.log(`${chalk.dim("Endpoint:")}${" "}${s.endpoint}/v1/telemetry`);
       console.log("");
-      console.log(chalk.dim("Collected: command name, CLI version, OS/arch, runtime, exit code, duration."));
+      console.log(
+        chalk.dim("Collected: command name, CLI version, OS/arch, runtime, exit code, duration."),
+      );
       console.log(chalk.dim("Never collected: arguments, flag values, paths, slugs, or content."));
     });
 

--- a/src/cli/commands/usage.ts
+++ b/src/cli/commands/usage.ts
@@ -19,10 +19,13 @@ export function registerUsageCommand(program: Command) {
     .command("usage")
     .description("Show API token usage summary")
     .option("--days <n>", "Number of days to look back", "7")
-    .addHelpText("after", `
+    .addHelpText(
+      "after",
+      `
 Examples:
   releases admin stats usage
-  releases admin stats usage --days 30`)
+  releases admin stats usage --days 30`,
+    )
     .action(async (opts: { days: string }) => {
       const days = parseInt(opts.days, 10) || 7;
       const stats = await getUsageStats(days);

--- a/src/cli/commands/whoami.ts
+++ b/src/cli/commands/whoami.ts
@@ -73,15 +73,21 @@ export function registerWhoamiCommand(parent: Command): void {
       const urlSuffix = status.apiUrlSource === "default" ? " (default)" : " (RELEASED_API_URL)";
       row("API URL", `${status.apiUrl}${chalk.dim(urlSuffix)}`);
       row("Mode", status.mode === "admin" ? chalk.green("admin") : chalk.cyan("public"));
-      row("Auth", status.apiKey.set
-        ? `${chalk.green("✓")} RELEASED_API_KEY set ${chalk.dim(`(${status.apiKey.hint})`)}`
-        : `${chalk.dim("—")} RELEASED_API_KEY not set`);
+      row(
+        "Auth",
+        status.apiKey.set
+          ? `${chalk.green("✓")} RELEASED_API_KEY set ${chalk.dim(`(${status.apiKey.hint})`)}`
+          : `${chalk.dim("—")} RELEASED_API_KEY not set`,
+      );
 
       if (status.check) {
         const probeLabel = status.mode === "admin" ? "API + auth" : "API";
-        row("Probe", status.check.ok
-          ? `${chalk.green("✓")} ${probeLabel} reachable`
-          : `${chalk.red("✗")} ${status.check.message}`);
+        row(
+          "Probe",
+          status.check.ok
+            ? `${chalk.green("✓")} ${probeLabel} reachable`
+            : `${chalk.red("✗")} ${status.check.message}`,
+        );
       } else {
         console.log("");
         console.log(chalk.dim('Run "releases whoami --check" to verify connectivity.'));

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -83,7 +83,9 @@ function printStyledHelp(): string {
   lines.push("The most common commands are:");
   lines.push("");
   lines.push(`  - releases search     : ${chalk.dim("Full-text search across releases")}`);
-  lines.push(`  - releases tail       : ${chalk.dim("Show the most recent releases (add -f to follow)")}`);
+  lines.push(
+    `  - releases tail       : ${chalk.dim("Show the most recent releases (add -f to follow)")}`,
+  );
   lines.push(`  - releases list       : ${chalk.dim("List and inspect sources")}`);
   lines.push("");
 
@@ -104,7 +106,11 @@ function printStyledHelp(): string {
   lines.push(row("-v, --version", "Print version number"));
   lines.push("");
 
-  lines.push(chalk.dim(`Use ${chalk.white('"releases <command> --help"')} for more information about a command.`));
+  lines.push(
+    chalk.dim(
+      `Use ${chalk.white('"releases <command> --help"')} for more information about a command.`,
+    ),
+  );
 
   return lines.join("\n");
 }
@@ -127,7 +133,9 @@ export const program = new Command()
   .configureOutput({
     outputError: (str, write) => {
       write(str);
-      const hint = chalk.dim('\nRun "releases --help" for available commands, or "releases <command> --help" for details.');
+      const hint = chalk.dim(
+        '\nRun "releases --help" for available commands, or "releases <command> --help" for details.',
+      );
       write(hint + "\n");
     },
   })
@@ -183,22 +191,16 @@ const discoveryAdmin = admin
 registerOnboardCommand(discoveryAdmin);
 registerTaskCommand(discoveryAdmin);
 
-const policyAdmin = admin
-  .command("policy")
-  .description("Manage ignored URLs and blocked URLs");
+const policyAdmin = admin.command("policy").description("Manage ignored URLs and blocked URLs");
 registerIgnoreCommand(policyAdmin);
 registerBlockCommand(policyAdmin);
 
-const statsAdmin = admin
-  .command("stats")
-  .description("Inspect operator metrics and usage");
+const statsAdmin = admin.command("stats").description("Inspect operator metrics and usage");
 registerUsageCommand(statsAdmin);
 
 registerEmbedCommand(admin);
 
-const mcpAdmin = admin
-  .command("mcp")
-  .description("MCP server management");
+const mcpAdmin = admin.command("mcp").description("MCP server management");
 registerServeCommand(mcpAdmin);
 
 gateAdminSubtree(admin);
@@ -215,7 +217,9 @@ program
         sub.help();
       } else {
         console.error(chalk.red(`Unknown command: ${command}`));
-        console.log(chalk.dim(`\nRun ${chalk.white('"releases --help"')} to see all available commands.`));
+        console.log(
+          chalk.dim(`\nRun ${chalk.white('"releases --help"')} to see all available commands.`),
+        );
         process.exit(1);
       }
     } else {

--- a/src/cli/render/releases-table.ts
+++ b/src/cli/render/releases-table.ts
@@ -12,10 +12,7 @@ export interface RenderOptions {
   withSummary?: boolean;
 }
 
-export function renderLatestReleasesTable(
-  rows: LatestRelease[],
-  opts: RenderOptions = {},
-): string {
+export function renderLatestReleasesTable(rows: LatestRelease[], opts: RenderOptions = {}): string {
   const table = new Table({
     head: [
       chalk.cyan("ID"),
@@ -28,19 +25,18 @@ export function renderLatestReleasesTable(
 
   for (const row of rows) {
     const titleCell = opts.withSummary
-      ? stripAnsi(row.title) + (row.contentSummary
-          ? `\n${chalk.dim(truncate(row.contentSummary, 120))}`
-          : "")
+      ? stripAnsi(row.title) +
+        (row.contentSummary ? `\n${chalk.dim(truncate(row.contentSummary, 120))}` : "")
       : truncate(stripAnsi(row.title), 50);
     const publishedCell = opts.withSummary
-      ? row.publishedAt ?? "-"
+      ? (row.publishedAt ?? "-")
       : (row.publishedAt?.slice(0, 10) ?? chalk.dim("—"));
 
     table.push([
       chalk.dim(row.id.slice(0, 12)),
       `${stripAnsi(row.sourceName)} ${chalk.dim(`(${row.sourceSlug})`)}`,
       titleCell,
-      row.version ? stripAnsi(row.version) : (opts.withSummary ? "-" : chalk.dim("—")),
+      row.version ? stripAnsi(row.version) : opts.withSummary ? "-" : chalk.dim("—"),
       publishedCell,
     ]);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,10 +45,7 @@ function gateAdminArgv(argv: string[]): void {
   if (process.env.RELEASED_API_KEY) return;
 
   const isHelpInvocation =
-    args.length === 1 ||
-    args.includes("--help") ||
-    args.includes("-h") ||
-    args[1] === "help";
+    args.length === 1 || args.includes("--help") || args.includes("-h") || args[1] === "help";
 
   if (!isHelpInvocation) {
     logger.error('"admin" requires an API key. Set RELEASED_API_KEY to enable it.');

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -69,9 +69,7 @@ export function sourceToMarkdown(source: SourceDetail, opts: FormatOptions = {})
   const lines: string[] = [];
 
   // ── Frontmatter ──
-  const sourcePath = source.org
-    ? `/${source.org.slug}/${source.slug}`
-    : `/source/${source.slug}`;
+  const sourcePath = source.org ? `/${source.org.slug}/${source.slug}` : `/source/${source.slug}`;
 
   lines.push("---");
   lines.push(yamlLine("name", source.name));
@@ -108,17 +106,25 @@ export function sourceToMarkdown(source: SourceDetail, opts: FormatOptions = {})
 
   // ── Summaries ──
   if (source.summaries?.rolling) {
-    lines.push(`<Summary type="rolling" window-days="${source.summaries.rolling.windowDays}" release-count="${source.summaries.rolling.releaseCount}">`);
+    lines.push(
+      `<Summary type="rolling" window-days="${source.summaries.rolling.windowDays}" release-count="${source.summaries.rolling.releaseCount}">`,
+    );
     lines.push(source.summaries.rolling.summary);
     lines.push("</Summary>");
     lines.push("");
   }
 
   for (const monthly of source.summaries?.monthly ?? []) {
-    const monthName = monthly.month != null && monthly.year != null
-      ? new Date(monthly.year, monthly.month - 1).toLocaleDateString("en-US", { month: "long", year: "numeric" })
-      : "";
-    lines.push(`<Summary type="monthly"${attr("period", monthName)}${attr("release-count", monthly.releaseCount)}>`);
+    const monthName =
+      monthly.month != null && monthly.year != null
+        ? new Date(monthly.year, monthly.month - 1).toLocaleDateString("en-US", {
+            month: "long",
+            year: "numeric",
+          })
+        : "";
+    lines.push(
+      `<Summary type="monthly"${attr("period", monthName)}${attr("release-count", monthly.releaseCount)}>`,
+    );
     lines.push(monthly.summary);
     lines.push("</Summary>");
     lines.push("");
@@ -128,7 +134,7 @@ export function sourceToMarkdown(source: SourceDetail, opts: FormatOptions = {})
   for (const release of source.releases) {
     const dateStr = formatIsoDate(release.publishedAt);
     lines.push(
-      `<Release${attr("version", release.version)}${attr("date", dateStr)}${attr("published", release.publishedAt)}${attr("url", release.url)}>`
+      `<Release${attr("version", release.version)}${attr("date", dateStr)}${attr("published", release.publishedAt)}${attr("url", release.url)}>`,
     );
 
     // Title as heading if it differs from version
@@ -155,7 +161,9 @@ export function sourceToMarkdown(source: SourceDetail, opts: FormatOptions = {})
       `total-items="${source.pagination.totalItems}"`,
     ];
     if (opts.baseUrl) {
-      paginationAttrs.push(`next="${opts.baseUrl}${sourcePath}.md?page=${source.pagination.page + 1}"`);
+      paginationAttrs.push(
+        `next="${opts.baseUrl}${sourcePath}.md?page=${source.pagination.page + 1}"`,
+      );
     }
     lines.push(`<Pagination ${paginationAttrs.join(" ")} />`);
     lines.push("");
@@ -227,7 +235,7 @@ export function orgToMarkdown(org: OrgDetail, opts: FormatOptions = {}): string 
   if (org.products.length > 0) {
     for (const product of org.products) {
       lines.push(
-        `<Product${attr("name", product.name)}${attr("slug", product.slug)}${attr("sources", product.sourceCount)}${product.url ? attr("url", product.url) : ""} />`
+        `<Product${attr("name", product.name)}${attr("slug", product.slug)}${attr("sources", product.sourceCount)}${product.url ? attr("url", product.url) : ""} />`,
       );
     }
     lines.push("");
@@ -237,7 +245,7 @@ export function orgToMarkdown(org: OrgDetail, opts: FormatOptions = {}): string 
   for (const source of org.sources) {
     const sourceUrl = opts.baseUrl ? ` url="${opts.baseUrl}/${org.slug}/${source.slug}"` : "";
     lines.push(
-      `<Source${attr("name", source.name)}${attr("slug", source.slug)}${attr("type", source.type)}${attr("releases", source.releaseCount)}${attr("latest-version", source.latestVersion)}${attr("latest-date", source.latestDate)}${source.isPrimary ? ' primary="true"' : ""}${sourceUrl} />`
+      `<Source${attr("name", source.name)}${attr("slug", source.slug)}${attr("type", source.type)}${attr("releases", source.releaseCount)}${attr("latest-version", source.latestVersion)}${attr("latest-date", source.latestDate)}${source.isPrimary ? ' primary="true"' : ""}${sourceUrl} />`,
     );
   }
 
@@ -248,16 +256,11 @@ export function orgToMarkdown(org: OrgDetail, opts: FormatOptions = {}): string 
 
 // ── Release Detail → Markdown ──────────────────────────────────────
 
-export function releaseToMarkdown(
-  release: ReleaseDetail,
-  opts: FormatOptions = {},
-): string {
+export function releaseToMarkdown(release: ReleaseDetail, opts: FormatOptions = {}): string {
   const lines: string[] = [];
 
   const orgPath = release.org ? `/${release.org.slug}` : "";
-  const sourcePath = orgPath
-    ? `${orgPath}/${release.sourceSlug}`
-    : `/source/${release.sourceSlug}`;
+  const sourcePath = orgPath ? `${orgPath}/${release.sourceSlug}` : `/source/${release.sourceSlug}`;
 
   lines.push("---");
   lines.push(yamlLine("title", release.title));
@@ -317,7 +320,7 @@ export function orgReleaseFeedToMarkdown(
   for (const release of releases) {
     const dateStr = formatIsoDate(release.publishedAt);
     lines.push(
-      `<Release${attr("version", release.version)}${attr("date", dateStr)}${attr("published", release.publishedAt)}${attr("url", release.url)}${attr("source", release.source.slug)}>`
+      `<Release${attr("version", release.version)}${attr("date", dateStr)}${attr("published", release.publishedAt)}${attr("url", release.url)}${attr("source", release.source.slug)}>`,
     );
 
     if (release.title && release.title !== release.version) {
@@ -337,7 +340,9 @@ export function orgReleaseFeedToMarkdown(
   if (pagination.nextCursor) {
     const cursorAttrs = [`cursor="${pagination.nextCursor}"`];
     if (opts.baseUrl) {
-      cursorAttrs.push(`next="${opts.baseUrl}/${orgSlug}/releases?cursor=${encodeURIComponent(pagination.nextCursor)}&limit=${pagination.limit}"`);
+      cursorAttrs.push(
+        `next="${opts.baseUrl}/${orgSlug}/releases?cursor=${encodeURIComponent(pagination.nextCursor)}&limit=${pagination.limit}"`,
+      );
     }
     lines.push(`<Pagination ${cursorAttrs.join(" ")} />`);
     lines.push("");
@@ -348,10 +353,7 @@ export function orgReleaseFeedToMarkdown(
 
 // ── Search Results → Markdown ──────────────────────────────────────
 
-export function searchToMarkdown(
-  results: UnifiedSearchResponse,
-  opts: FormatOptions = {},
-): string {
+export function searchToMarkdown(results: UnifiedSearchResponse, opts: FormatOptions = {}): string {
   const lines: string[] = [];
 
   lines.push("---");
@@ -364,7 +366,9 @@ export function searchToMarkdown(
     lines.push("");
     for (const org of results.orgs) {
       const url = opts.baseUrl ? ` — [view](${opts.baseUrl}/${org.slug})` : "";
-      lines.push(`- **${org.name}** (\`${org.slug}\`)${org.category ? ` [${org.category}]` : ""}${url}`);
+      lines.push(
+        `- **${org.name}** (\`${org.slug}\`)${org.category ? ` [${org.category}]` : ""}${url}`,
+      );
     }
     lines.push("");
   }
@@ -375,10 +379,11 @@ export function searchToMarkdown(
     for (const p of results.products) {
       const orgInfo = p.orgSlug ? ` (${p.orgName})` : "";
       const viewSlug = p.kind === "source" && p.sourceSlug ? p.sourceSlug : `product/${p.slug}`;
-      const url = opts.baseUrl && p.orgSlug
-        ? ` — [view](${opts.baseUrl}/${p.orgSlug}/${viewSlug})`
-        : "";
-      lines.push(`- **${p.name}** (\`${p.slug}\`)${orgInfo}${p.category ? ` [${p.category}]` : ""}${url}`);
+      const url =
+        opts.baseUrl && p.orgSlug ? ` — [view](${opts.baseUrl}/${p.orgSlug}/${viewSlug})` : "";
+      lines.push(
+        `- **${p.name}** (\`${p.slug}\`)${orgInfo}${p.category ? ` [${p.category}]` : ""}${url}`,
+      );
     }
     lines.push("");
   }
@@ -397,8 +402,7 @@ export function searchToMarkdown(
     lines.push("");
   }
 
-  if (results.orgs.length === 0 && results.products.length === 0 &&
-      results.releases.length === 0) {
+  if (results.orgs.length === 0 && results.products.length === 0 && results.releases.length === 0) {
     lines.push("No results found.");
     lines.push("");
   }

--- a/src/lib/mode.ts
+++ b/src/lib/mode.ts
@@ -36,7 +36,9 @@ export function getApiKey(): string {
 export function validateConfig(): void {
   if (process.env.RELEASED_API_URL && !process.env.RELEASED_API_KEY) {
     logger.error("RELEASED_API_URL is set but RELEASED_API_KEY is missing.");
-    logger.error("Set RELEASED_API_KEY to authenticate with the remote API, or unset RELEASED_API_URL for public access.");
+    logger.error(
+      "Set RELEASED_API_KEY to authenticate with the remote API, or unset RELEASED_API_URL for public access.",
+    );
     process.exit(1);
   }
 }

--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -1,10 +1,10 @@
+/* oxlint-disable no-control-regex -- intentional: matches ANSI escape sequences */
 /**
  * Strip ANSI escape sequences from a string.
  * Prevents terminal escape injection when displaying external content
  * (e.g., release titles, content from changelogs).
  */
-const ANSI_RE =
-  /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g;
+const ANSI_RE = /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g;
 
 export function stripAnsi(str: string): string {
   return str.replace(ANSI_RE, "");

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -61,7 +61,12 @@ export function setTelemetryEnabled(enabled: boolean): void {
   }
 }
 
-function detectClientKind(): { kind: TelemetryClientKind; sessionId?: string; agentName?: string; model?: string } {
+function detectClientKind(): {
+  kind: TelemetryClientKind;
+  sessionId?: string;
+  agentName?: string;
+  model?: string;
+} {
   const envKind = process.env.RELEASED_CLIENT_KIND as TelemetryClientKind | undefined;
   if (envKind) {
     return {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -2,10 +2,19 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import * as z from "zod/v4";
 import {
-  findSource, getSourcesByOrg, findOrg, listOrgs,
-  getLatestReleases, unifiedSearch, sourceChangelog,
-  listDomainAliases, getTagsForOrg, getOrgAccountsBySlug,
-  getProductsByOrg, findProduct, listSourcesWithOrg,
+  findSource,
+  getSourcesByOrg,
+  findOrg,
+  listOrgs,
+  getLatestReleases,
+  unifiedSearch,
+  sourceChangelog,
+  listDomainAliases,
+  getTagsForOrg,
+  getOrgAccountsBySlug,
+  getProductsByOrg,
+  findProduct,
+  listSourcesWithOrg,
 } from "../api/client.js";
 import { logger } from "@releases/lib/logger";
 import { recordEvent } from "../lib/telemetry.js";
@@ -24,7 +33,11 @@ const server = new McpServer({
 {
   const original = server.registerTool.bind(server);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (server as any).registerTool = (name: string, config: unknown, handler: (...args: unknown[]) => unknown) => {
+  (server as any).registerTool = (
+    name: string,
+    config: unknown,
+    handler: (...args: unknown[]) => unknown,
+  ) => {
     const wrapped = async (...args: unknown[]) => {
       const start = Date.now();
       let exitCode = 0;
@@ -48,325 +61,416 @@ const server = new McpServer({
 }
 
 // ── search_releases ──────────────────────────────────────────────────
-server.registerTool("search_releases", {
-  description: "Search indexed release notes. Proxies to api.releases.sh — supports hybrid lexical + semantic search.",
-  inputSchema: {
-    query: z.string().describe("Search query"),
-    organization: z.string().optional().describe("Filter to sources belonging to this organization"),
-    type: z.enum(["feature", "rollup"]).optional().describe("Filter by release type: 'feature' for individual releases, 'rollup' for seasonal/quarterly catch-all posts. Omit to include both."),
-    limit: z.number().optional().describe("Max results to return (default 20)"),
-    mode: z.enum(["lexical", "semantic", "hybrid"]).optional().describe("Retrieval strategy (default: hybrid)."),
+server.registerTool(
+  "search_releases",
+  {
+    description:
+      "Search indexed release notes. Proxies to api.releases.sh — supports hybrid lexical + semantic search.",
+    inputSchema: {
+      query: z.string().describe("Search query"),
+      organization: z
+        .string()
+        .optional()
+        .describe("Filter to sources belonging to this organization"),
+      type: z
+        .enum(["feature", "rollup"])
+        .optional()
+        .describe(
+          "Filter by release type: 'feature' for individual releases, 'rollup' for seasonal/quarterly catch-all posts. Omit to include both.",
+        ),
+      limit: z.number().optional().describe("Max results to return (default 20)"),
+      mode: z
+        .enum(["lexical", "semantic", "hybrid"])
+        .optional()
+        .describe("Retrieval strategy (default: hybrid)."),
+    },
   },
-}, async ({ query, organization, limit, mode }) => {
-  const maxResults = limit ?? 20;
+  async ({ query, organization, limit, mode }) => {
+    const maxResults = limit ?? 20;
 
-  const searchResult = await unifiedSearch(query, maxResults, {
-    org: organization,
-    mode: mode ?? "hybrid",
-  });
+    const searchResult = await unifiedSearch(query, maxResults, {
+      org: organization,
+      mode: mode ?? "hybrid",
+    });
 
-  let results = searchResult.releases ?? [];
-  // type filter: SearchReleaseHit doesn't expose a type field in this API shape.
-  // The remote MCP worker at mcp.releases.sh handles type filtering natively.
+    let results = searchResult.releases ?? [];
+    // type filter: SearchReleaseHit doesn't expose a type field in this API shape.
+    // The remote MCP worker at mcp.releases.sh handles type filtering natively.
 
-  results = results.slice(0, maxResults);
+    results = results.slice(0, maxResults);
 
-  if (results.length === 0) {
-    return textResult("No releases found matching the query.");
-  }
+    if (results.length === 0) {
+      return textResult("No releases found matching the query.");
+    }
 
-  const text = results
-    .map((r) => {
-      const preview = (r.summary || r.content || "").slice(0, 300);
-      return `**${r.title}**\n${preview}`;
-    })
-    .join("\n\n---\n\n");
+    const text = results
+      .map((r) => {
+        const preview = (r.summary || r.content || "").slice(0, 300);
+        return `**${r.title}**\n${preview}`;
+      })
+      .join("\n\n---\n\n");
 
-  return textResult(text);
-});
+    return textResult(text);
+  },
+);
 
 // ── get_latest_releases ──────────────────────────────────────────────
-server.registerTool("get_latest_releases", {
-  description: "Get the most recent releases, optionally filtered by product or organization",
-  inputSchema: {
-    product: z.string().optional().describe("Filter to a specific product slug"),
-    organization: z.string().optional().describe("Filter to sources belonging to this organization"),
-    type: z.enum(["feature", "rollup"]).optional().describe("Filter by release type: 'feature' for individual releases, 'rollup' for seasonal/quarterly catch-all posts. Omit to include both."),
-    count: z.number().optional().describe("Number of releases to return (default 10)"),
+server.registerTool(
+  "get_latest_releases",
+  {
+    description: "Get the most recent releases, optionally filtered by product or organization",
+    inputSchema: {
+      product: z.string().optional().describe("Filter to a specific product slug"),
+      organization: z
+        .string()
+        .optional()
+        .describe("Filter to sources belonging to this organization"),
+      type: z
+        .enum(["feature", "rollup"])
+        .optional()
+        .describe(
+          "Filter by release type: 'feature' for individual releases, 'rollup' for seasonal/quarterly catch-all posts. Omit to include both.",
+        ),
+      count: z.number().optional().describe("Number of releases to return (default 10)"),
+    },
   },
-}, async ({ product, organization, count }) => {
-  const maxCount = count ?? 10;
+  async ({ product, organization, count }) => {
+    const maxCount = count ?? 10;
 
-  let releases = await getLatestReleases({
-    slug: product,
-    orgSlug: organization,
-    count: maxCount,
-  });
+    let releases = await getLatestReleases({
+      slug: product,
+      orgSlug: organization,
+      count: maxCount,
+    });
 
-  // type filter: LatestRelease doesn't carry a type field — the remote MCP worker
-  // handles this natively. Silently ignored when proxying.
+    // type filter: LatestRelease doesn't carry a type field — the remote MCP worker
+    // handles this natively. Silently ignored when proxying.
 
-  releases = releases.slice(0, maxCount);
+    releases = releases.slice(0, maxCount);
 
-  if (releases.length === 0) {
-    return textResult("No releases found.");
-  }
+    if (releases.length === 0) {
+      return textResult("No releases found.");
+    }
 
-  const text = releases
-    .map((r) => {
-      const preview = (r.contentSummary || "").slice(0, 500);
-      return [
-        `**${r.title}**`,
-        `Source: ${r.sourceName} | Version: ${r.version ?? "N/A"} | Date: ${r.publishedAt ?? "N/A"}`,
-        preview,
-      ].join("\n");
-    })
-    .join("\n\n---\n\n");
+    const text = releases
+      .map((r) => {
+        const preview = (r.contentSummary || "").slice(0, 500);
+        return [
+          `**${r.title}**`,
+          `Source: ${r.sourceName} | Version: ${r.version ?? "N/A"} | Date: ${r.publishedAt ?? "N/A"}`,
+          preview,
+        ].join("\n");
+      })
+      .join("\n\n---\n\n");
 
-  return textResult(text);
-});
+    return textResult(text);
+  },
+);
 
 // ── list_sources ─────────────────────────────────────────────────────
-server.registerTool("list_sources", {
-  description: "List all indexed changelog sources",
-  inputSchema: {
-    organization: z.string().optional().describe("Filter to sources belonging to this organization"),
+server.registerTool(
+  "list_sources",
+  {
+    description: "List all indexed changelog sources",
+    inputSchema: {
+      organization: z
+        .string()
+        .optional()
+        .describe("Filter to sources belonging to this organization"),
+    },
   },
-}, async ({ organization }) => {
-  let allSources;
+  async ({ organization }) => {
+    let allSources;
 
-  if (organization) {
+    if (organization) {
+      const org = await findOrg(organization);
+      if (!org) {
+        return textResult(`No organization found matching "${organization}"`);
+      }
+      allSources = await getSourcesByOrg(org.id);
+    } else {
+      allSources = await listSourcesWithOrg();
+    }
+
+    if (allSources.length === 0) {
+      return textResult("No products indexed yet.");
+    }
+
+    const text = allSources
+      .map((s) =>
+        [
+          `**${s.name}**`,
+          `  Slug: ${s.slug}`,
+          `  Type: ${s.type}`,
+          `  URL: ${s.url}`,
+          `  Last fetched: ${s.lastFetchedAt ?? "Never"}`,
+        ].join("\n"),
+      )
+      .join("\n\n");
+
+    return textResult(text);
+  },
+);
+
+// ── get_source ───────────────────────────────────────────────────────
+server.registerTool(
+  "get_source",
+  {
+    description: "Get detailed information about a single changelog source",
+    inputSchema: {
+      identifier: z.string().describe("Source slug or ID"),
+    },
+  },
+  async ({ identifier }) => {
+    const source = await findSource(identifier);
+    if (!source) {
+      return textResult(`No source found matching "${identifier}"`);
+    }
+
+    const lines: string[] = [
+      `**Source: ${source.name}**`,
+      `Slug: ${source.slug} | Type: ${source.type}`,
+      `URL: ${source.url}`,
+      `Last fetched: ${source.lastFetchedAt ?? "Never"}`,
+    ];
+
+    return textResult(lines.join("\n"));
+  },
+);
+
+// ── get_source_changelog ─────────────────────────────────────────────
+server.registerTool(
+  "get_source_changelog",
+  {
+    description:
+      "Read a tracked CHANGELOG file for a GitHub source. Supports heading-aligned slicing by chars (`limit`) or tokens (`tokens`, cl100k_base). Chain successive calls via `nextOffset` to page through large files.",
+    inputSchema: {
+      source: z.string().describe("Source slug or ID (e.g. 'apollo-client' or 'src_...')"),
+      path: z
+        .string()
+        .optional()
+        .describe(
+          "Specific file path to read (e.g. 'packages/next/CHANGELOG.md'). Defaults to the root CHANGELOG.",
+        ),
+      offset: z
+        .number()
+        .optional()
+        .describe(
+          "Character offset into the selected file. Snapped forward to the next heading unless 0.",
+        ),
+      limit: z
+        .number()
+        .optional()
+        .describe(
+          "Target slice size in characters. Defaults to 40000 when slicing without a token budget.",
+        ),
+      tokens: z
+        .number()
+        .optional()
+        .describe(
+          "Target slice size in tokens (cl100k_base). Takes precedence over `limit`. Recommended brackets: 2000, 5000, 10000, 20000.",
+        ),
+    },
+  },
+  async ({ source: identifier, path: requestedPath, offset, limit, tokens }) => {
+    const response = await sourceChangelog(identifier, {
+      path: requestedPath,
+      offset,
+      limit,
+      tokens,
+    });
+
+    if (!response) {
+      return textResult(
+        `No CHANGELOG file is tracked for "${identifier}". Only GitHub sources expose this.`,
+      );
+    }
+
+    const lines: string[] = [
+      `**${response.path}**`,
+      `Source: ${response.url ?? ""}`,
+      `Offset: ${response.offset} | Total chars: ${response.totalChars} | Total tokens: ${response.totalTokens ?? "N/A"}`,
+    ];
+
+    if (response.truncated) {
+      lines.push(`WARNING: File truncated at 1MB cap.`);
+    }
+
+    if (response.nextOffset != null && response.nextOffset < response.totalChars) {
+      lines.push(`Next offset: ${response.nextOffset} (pass as offset to continue)`);
+    }
+
+    lines.push("");
+    lines.push(response.content);
+
+    return textResult(lines.join("\n"));
+  },
+);
+
+// ── list_organizations ───────────────────────────────────────────────
+server.registerTool(
+  "list_organizations",
+  {
+    description: "List all indexed organizations, optionally filtered",
+    inputSchema: {
+      query: z
+        .string()
+        .optional()
+        .describe("Search across org name, slug, domain, and account handles"),
+      platform: z.string().optional().describe("Filter to orgs with an account on this platform"),
+    },
+  },
+  async ({ query, platform }) => {
+    const allOrgs = await listOrgs({ query, platform });
+
+    if (allOrgs.length === 0) {
+      return textResult("No organizations found.");
+    }
+
+    const text = allOrgs
+      .map((o) =>
+        [`**${o.name}**`, `  Slug: ${o.slug}`, `  Domain: ${o.domain ?? "N/A"}`].join("\n"),
+      )
+      .join("\n\n");
+
+    return textResult(text);
+  },
+);
+
+// ── get_organization ─────────────────────────────────────────────────
+server.registerTool(
+  "get_organization",
+  {
+    description:
+      "Get detailed information about a single organization including accounts, tags, sources, products, and aliases",
+    inputSchema: {
+      identifier: z.string().describe("Organization slug, domain, name, or account handle"),
+    },
+  },
+  async ({ identifier }) => {
+    const org = await findOrg(identifier);
+    if (!org) {
+      return textResult(`No organization found matching "${identifier}"`);
+    }
+
+    const [accounts, tagRows, orgSources, orgProducts, aliases] = await Promise.all([
+      getOrgAccountsBySlug(org.slug),
+      getTagsForOrg(org.id),
+      getSourcesByOrg(org.id),
+      getProductsByOrg(org.id),
+      listDomainAliases({ orgId: org.id }),
+    ]);
+
+    const lines: string[] = [];
+    lines.push(`**Organization: ${org.name}**`);
+    lines.push(
+      `Slug: ${org.slug} | Domain: ${org.domain ?? "N/A"} | Category: ${org.category ?? "N/A"}`,
+    );
+    if (org.description) lines.push(`Description: ${org.description}`);
+    lines.push("");
+    lines.push(
+      accounts.length > 0
+        ? `Accounts: ${accounts.map((a) => `${a.platform}/${a.handle}`).join(", ")}`
+        : "Accounts: none",
+    );
+    lines.push(tagRows.length > 0 ? `Tags: ${tagRows.join(", ")}` : "Tags: none");
+    lines.push(
+      aliases.length > 0 ? `Aliases: ${aliases.map((a) => a.domain).join(", ")}` : "Aliases: none",
+    );
+
+    if (orgProducts.length > 0) {
+      lines.push("");
+      lines.push("Products:");
+      for (const p of orgProducts) {
+        const urlPart = p.url ? ` — ${p.url}` : "";
+        const descPart = p.description ? ` — ${p.description}` : "";
+        lines.push(`- ${p.name} (${p.slug})${urlPart}${descPart}`);
+      }
+    }
+
+    if (orgSources.length > 0) {
+      lines.push("");
+      lines.push("Sources:");
+      for (const s of orgSources) {
+        lines.push(`- **${s.name}** (${s.slug})`);
+        lines.push(`  Type: ${s.type} | URL: ${s.url}`);
+        lines.push(`  Last fetched: ${s.lastFetchedAt ?? "Never"}`);
+      }
+    } else {
+      lines.push("");
+      lines.push("Sources: none");
+    }
+
+    return textResult(lines.join("\n"));
+  },
+);
+
+// ── list_products ─────────────────────────────────────────────────────
+server.registerTool(
+  "list_products",
+  {
+    description: "List products, optionally scoped to one organization",
+    inputSchema: {
+      organization: z.string().optional().describe("Organization slug to filter by"),
+    },
+  },
+  async ({ organization }) => {
+    if (!organization) {
+      return textResult("Please provide an organization slug to list products.");
+    }
+
     const org = await findOrg(organization);
     if (!org) {
       return textResult(`No organization found matching "${organization}"`);
     }
-    allSources = await getSourcesByOrg(org.id);
-  } else {
-    allSources = await listSourcesWithOrg();
-  }
 
-  if (allSources.length === 0) {
-    return textResult("No products indexed yet.");
-  }
+    const products = await getProductsByOrg(org.id);
 
-  const text = allSources
-    .map((s) =>
-      [
-        `**${s.name}**`,
-        `  Slug: ${s.slug}`,
-        `  Type: ${s.type}`,
-        `  URL: ${s.url}`,
-        `  Last fetched: ${s.lastFetchedAt ?? "Never"}`,
-      ].join("\n"),
-    )
-    .join("\n\n");
-
-  return textResult(text);
-});
-
-// ── get_source ───────────────────────────────────────────────────────
-server.registerTool("get_source", {
-  description: "Get detailed information about a single changelog source",
-  inputSchema: {
-    identifier: z.string().describe("Source slug or ID"),
-  },
-}, async ({ identifier }) => {
-  const source = await findSource(identifier);
-  if (!source) {
-    return textResult(`No source found matching "${identifier}"`);
-  }
-
-  const lines: string[] = [
-    `**Source: ${source.name}**`,
-    `Slug: ${source.slug} | Type: ${source.type}`,
-    `URL: ${source.url}`,
-    `Last fetched: ${source.lastFetchedAt ?? "Never"}`,
-  ];
-
-  return textResult(lines.join("\n"));
-});
-
-// ── get_source_changelog ─────────────────────────────────────────────
-server.registerTool("get_source_changelog", {
-  description: "Read a tracked CHANGELOG file for a GitHub source. Supports heading-aligned slicing by chars (`limit`) or tokens (`tokens`, cl100k_base). Chain successive calls via `nextOffset` to page through large files.",
-  inputSchema: {
-    source: z.string().describe("Source slug or ID (e.g. 'apollo-client' or 'src_...')"),
-    path: z.string().optional().describe("Specific file path to read (e.g. 'packages/next/CHANGELOG.md'). Defaults to the root CHANGELOG."),
-    offset: z.number().optional().describe("Character offset into the selected file. Snapped forward to the next heading unless 0."),
-    limit: z.number().optional().describe("Target slice size in characters. Defaults to 40000 when slicing without a token budget."),
-    tokens: z.number().optional().describe("Target slice size in tokens (cl100k_base). Takes precedence over `limit`. Recommended brackets: 2000, 5000, 10000, 20000."),
-  },
-}, async ({ source: identifier, path: requestedPath, offset, limit, tokens }) => {
-  const response = await sourceChangelog(identifier, { path: requestedPath, offset, limit, tokens });
-
-  if (!response) {
-    return textResult(`No CHANGELOG file is tracked for "${identifier}". Only GitHub sources expose this.`);
-  }
-
-  const lines: string[] = [
-    `**${response.path}**`,
-    `Source: ${response.url ?? ""}`,
-    `Offset: ${response.offset} | Total chars: ${response.totalChars} | Total tokens: ${response.totalTokens ?? "N/A"}`,
-  ];
-
-  if (response.truncated) {
-    lines.push(`WARNING: File truncated at 1MB cap.`);
-  }
-
-  if (response.nextOffset != null && response.nextOffset < response.totalChars) {
-    lines.push(`Next offset: ${response.nextOffset} (pass as offset to continue)`);
-  }
-
-  lines.push("");
-  lines.push(response.content);
-
-  return textResult(lines.join("\n"));
-});
-
-// ── list_organizations ───────────────────────────────────────────────
-server.registerTool("list_organizations", {
-  description: "List all indexed organizations, optionally filtered",
-  inputSchema: {
-    query: z.string().optional().describe("Search across org name, slug, domain, and account handles"),
-    platform: z.string().optional().describe("Filter to orgs with an account on this platform"),
-  },
-}, async ({ query, platform }) => {
-  const allOrgs = await listOrgs({ query, platform });
-
-  if (allOrgs.length === 0) {
-    return textResult("No organizations found.");
-  }
-
-  const text = allOrgs
-    .map((o) => [
-      `**${o.name}**`,
-      `  Slug: ${o.slug}`,
-      `  Domain: ${o.domain ?? "N/A"}`,
-    ].join("\n"))
-    .join("\n\n");
-
-  return textResult(text);
-});
-
-// ── get_organization ─────────────────────────────────────────────────
-server.registerTool("get_organization", {
-  description: "Get detailed information about a single organization including accounts, tags, sources, products, and aliases",
-  inputSchema: {
-    identifier: z.string().describe("Organization slug, domain, name, or account handle"),
-  },
-}, async ({ identifier }) => {
-  const org = await findOrg(identifier);
-  if (!org) {
-    return textResult(`No organization found matching "${identifier}"`);
-  }
-
-  const [accounts, tagRows, orgSources, orgProducts, aliases] = await Promise.all([
-    getOrgAccountsBySlug(org.slug),
-    getTagsForOrg(org.id),
-    getSourcesByOrg(org.id),
-    getProductsByOrg(org.id),
-    listDomainAliases({ orgId: org.id }),
-  ]);
-
-  const lines: string[] = [];
-  lines.push(`**Organization: ${org.name}**`);
-  lines.push(
-    `Slug: ${org.slug} | Domain: ${org.domain ?? "N/A"} | Category: ${org.category ?? "N/A"}`,
-  );
-  if (org.description) lines.push(`Description: ${org.description}`);
-  lines.push("");
-  lines.push(
-    accounts.length > 0
-      ? `Accounts: ${accounts.map((a) => `${a.platform}/${a.handle}`).join(", ")}`
-      : "Accounts: none",
-  );
-  lines.push(tagRows.length > 0 ? `Tags: ${tagRows.join(", ")}` : "Tags: none");
-  lines.push(
-    aliases.length > 0
-      ? `Aliases: ${aliases.map((a) => a.domain).join(", ")}`
-      : "Aliases: none",
-  );
-
-  if (orgProducts.length > 0) {
-    lines.push("");
-    lines.push("Products:");
-    for (const p of orgProducts) {
-      const urlPart = p.url ? ` — ${p.url}` : "";
-      const descPart = p.description ? ` — ${p.description}` : "";
-      lines.push(`- ${p.name} (${p.slug})${urlPart}${descPart}`);
+    if (products.length === 0) {
+      return textResult(`No products found for ${org.name}.`);
     }
-  }
 
-  if (orgSources.length > 0) {
-    lines.push("");
-    lines.push("Sources:");
-    for (const s of orgSources) {
-      lines.push(`- **${s.name}** (${s.slug})`);
-      lines.push(`  Type: ${s.type} | URL: ${s.url}`);
-      lines.push(`  Last fetched: ${s.lastFetchedAt ?? "Never"}`);
-    }
-  } else {
-    lines.push("");
-    lines.push("Sources: none");
-  }
+    const text = products
+      .map((p) =>
+        [
+          `**${p.name}** (${p.slug})`,
+          p.description ? `  ${p.description}` : null,
+          `  Category: ${p.category ?? "N/A"} | Sources: ${p.sourceCount ?? 0}`,
+        ]
+          .filter(Boolean)
+          .join("\n"),
+      )
+      .join("\n\n");
 
-  return textResult(lines.join("\n"));
-});
-
-// ── list_products ─────────────────────────────────────────────────────
-server.registerTool("list_products", {
-  description: "List products, optionally scoped to one organization",
-  inputSchema: {
-    organization: z.string().optional().describe("Organization slug to filter by"),
+    return textResult(text);
   },
-}, async ({ organization }) => {
-  if (!organization) {
-    return textResult("Please provide an organization slug to list products.");
-  }
-
-  const org = await findOrg(organization);
-  if (!org) {
-    return textResult(`No organization found matching "${organization}"`);
-  }
-
-  const products = await getProductsByOrg(org.id);
-
-  if (products.length === 0) {
-    return textResult(`No products found for ${org.name}.`);
-  }
-
-  const text = products
-    .map((p) => [
-      `**${p.name}** (${p.slug})`,
-      p.description ? `  ${p.description}` : null,
-      `  Category: ${p.category ?? "N/A"} | Sources: ${p.sourceCount ?? 0}`,
-    ].filter(Boolean).join("\n"))
-    .join("\n\n");
-
-  return textResult(text);
-});
+);
 
 // ── get_product ───────────────────────────────────────────────────────
-server.registerTool("get_product", {
-  description: "Get detailed information about a single product",
-  inputSchema: {
-    identifier: z.string().describe("Product slug or ID"),
+server.registerTool(
+  "get_product",
+  {
+    description: "Get detailed information about a single product",
+    inputSchema: {
+      identifier: z.string().describe("Product slug or ID"),
+    },
   },
-}, async ({ identifier }) => {
-  const product = await findProduct(identifier);
-  if (!product) {
-    return textResult(`No product found matching "${identifier}"`);
-  }
+  async ({ identifier }) => {
+    const product = await findProduct(identifier);
+    if (!product) {
+      return textResult(`No product found matching "${identifier}"`);
+    }
 
-  const lines: string[] = [
-    `**Product: ${product.name}**`,
-    `Slug: ${product.slug} | Category: ${product.category ?? "N/A"}`,
-  ];
-  if (product.description) lines.push(`Description: ${product.description}`);
-  if (product.url) lines.push(`URL: ${product.url}`);
+    const lines: string[] = [
+      `**Product: ${product.name}**`,
+      `Slug: ${product.slug} | Category: ${product.category ?? "N/A"}`,
+    ];
+    if (product.description) lines.push(`Description: ${product.description}`);
+    if (product.url) lines.push(`URL: ${product.url}`);
 
-  return textResult(lines.join("\n"));
-});
+    return textResult(lines.join("\n"));
+  },
+);
 
 // ── Start function ───────────────────────────────────────────────────
 export async function startMcpServer() {

--- a/tests/unit/api-client.test.ts
+++ b/tests/unit/api-client.test.ts
@@ -47,23 +47,19 @@ describe("apiFetch 404 handling", () => {
 
   it("throws on POST 404 (addIgnoredUrl)", async () => {
     mockFetch(404, { message: "Not Found" });
-    await expect(
-      client.addIgnoredUrl("https://example.com", "org_123"),
-    ).rejects.toThrow(/API error \(404\) on POST/);
+    await expect(client.addIgnoredUrl("https://example.com", "org_123")).rejects.toThrow(
+      /API error \(404\) on POST/,
+    );
   });
 
   it("throws on DELETE 404 (deleteRelease)", async () => {
     mockFetch(404, { message: "Not Found" });
-    await expect(client.deleteRelease("rel_123")).rejects.toThrow(
-      /API error \(404\) on DELETE/,
-    );
+    await expect(client.deleteRelease("rel_123")).rejects.toThrow(/API error \(404\) on DELETE/);
   });
 
   it("throws on non-404 errors for GET", async () => {
     mockFetch(500, { message: "Internal Server Error" });
-    await expect(client.findSource("test")).rejects.toThrow(
-      /API error \(500\)/,
-    );
+    await expect(client.findSource("test")).rejects.toThrow(/API error \(500\)/);
   });
 });
 
@@ -153,8 +149,12 @@ describe("listSourcesWithOrg", () => {
         JSON.stringify({
           items: [apiRow],
           pagination: {
-            page: 2, pageSize: 50, returned: 1,
-            totalItems: 233, totalPages: 5, hasMore: true,
+            page: 2,
+            pageSize: 50,
+            returned: 1,
+            totalItems: 233,
+            totalPages: 5,
+            hasMore: true,
           },
         }),
         { status: 200, headers: { "Content-Type": "application/json" } },

--- a/tests/unit/changelog-slice.test.ts
+++ b/tests/unit/changelog-slice.test.ts
@@ -129,8 +129,20 @@ describe("buildChangelogResponse truncation + files", () => {
 
   it("flags truncated=false by default and includes files index", () => {
     const res = buildChangelogResponse(row, { offset: null, limit: null }, [
-      { path: "CHANGELOG.md", filename: "CHANGELOG.md", url: row.url, bytes: 18, fetchedAt: row.fetchedAt },
-      { path: "packages/a/CHANGELOG.md", filename: "CHANGELOG.md", url: row.url, bytes: 9, fetchedAt: row.fetchedAt },
+      {
+        path: "CHANGELOG.md",
+        filename: "CHANGELOG.md",
+        url: row.url,
+        bytes: 18,
+        fetchedAt: row.fetchedAt,
+      },
+      {
+        path: "packages/a/CHANGELOG.md",
+        filename: "CHANGELOG.md",
+        url: row.url,
+        bytes: 9,
+        fetchedAt: row.fetchedAt,
+      },
     ]);
     expect(res.truncated).toBe(false);
     expect(res.truncatedAt).toBeNull();

--- a/tests/unit/formatters-markdown.test.ts
+++ b/tests/unit/formatters-markdown.test.ts
@@ -50,12 +50,18 @@ const feedReleases: OrgReleaseItem[] = [
 
 const searchResults: UnifiedSearchResponse = {
   query: "react",
-  orgs: [
-    { slug: "meta", name: "Meta", domain: "meta.com", avatarUrl: null, category: "ai" },
-  ],
+  orgs: [{ slug: "meta", name: "Meta", domain: "meta.com", avatarUrl: null, category: "ai" }],
   products: [
     { slug: "react", name: "React", orgSlug: "meta", orgName: "Meta", category: "frontend" },
-    { slug: "react-native", name: "React Native", orgSlug: "meta", orgName: "Meta", category: null, kind: "source", sourceSlug: "react-native" },
+    {
+      slug: "react-native",
+      name: "React Native",
+      orgSlug: "meta",
+      orgName: "Meta",
+      category: null,
+      kind: "source",
+      sourceSlug: "react-native",
+    },
   ],
   sources: [],
   releases: [
@@ -186,14 +192,22 @@ describe("orgReleaseFeedToMarkdown", () => {
   });
 
   it("includes has_more in frontmatter when cursor is present", () => {
-    const md = orgReleaseFeedToMarkdown("vercel", feedReleases, { nextCursor: "cursor", limit: 20 });
+    const md = orgReleaseFeedToMarkdown("vercel", feedReleases, {
+      nextCursor: "cursor",
+      limit: 20,
+    });
     expect(md).toContain("has_more: true");
   });
 
   it("includes next URL in Pagination when baseUrl is provided", () => {
     const cursor = "2024-06-10|rel_002";
-    const md = orgReleaseFeedToMarkdown("vercel", feedReleases, { nextCursor: cursor, limit: 20 }, { baseUrl: "https://releases.sh" });
-    expect(md).toContain("next=\"https://releases.sh/vercel/releases?cursor=");
+    const md = orgReleaseFeedToMarkdown(
+      "vercel",
+      feedReleases,
+      { nextCursor: cursor, limit: 20 },
+      { baseUrl: "https://releases.sh" },
+    );
+    expect(md).toContain('next="https://releases.sh/vercel/releases?cursor=');
   });
 
   it("handles empty releases array", () => {

--- a/tests/unit/formatters.test.ts
+++ b/tests/unit/formatters.test.ts
@@ -382,7 +382,7 @@ describe("orgToMarkdown", () => {
     expect(md).toContain('latest-date="2024-06-15"');
   });
 
-  it("Source tags include primary=\"true\" for primary sources", () => {
+  it('Source tags include primary="true" for primary sources', () => {
     const md = orgToMarkdown(fullOrg);
     // Next.js is primary
     expect(md).toContain('primary="true"');

--- a/tests/unit/id.test.ts
+++ b/tests/unit/id.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "bun:test";
-import { newSourceId, newReleaseId, newOrgId, newProductId, newTagId } from "@buildinternet/releases-core/id";
+import {
+  newSourceId,
+  newReleaseId,
+  newOrgId,
+  newProductId,
+  newTagId,
+} from "@buildinternet/releases-core/id";
 
 describe("ID generators", () => {
   it("newSourceId has correct prefix", () => {

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -11,7 +11,7 @@ export function runCli(
   // OSS CLI is remote-only — a real-looking URL must be set so the CLI starts.
   // Commands that don't hit the API (e.g. `categories`) succeed without it.
   const safeEnv: Record<string, string> = {
-    ...process.env as Record<string, string>,
+    ...(process.env as Record<string, string>),
     RELEASED_API_URL: "https://test.example.com",
     RELEASED_API_KEY: "test",
     ...options?.env,


### PR DESCRIPTION
## Summary
- Brings this repo in line with the lint/format toolchain recently introduced in the `releases` repo.
- Adds `.oxlintrc.json`, `.prettierrc.json`, `.prettierignore`, and matching `lint` / `format` package scripts.
- Adds a `Lint & Format` job to the CI workflow so PRs fail fast on style or correctness regressions.

## Changes
- **Config**: `.oxlintrc.json` (correctness/suspicious/perf categories, unicorn + typescript + oxc plugins), `.prettierrc.json`, `.prettierignore`. Ignore patterns adapted for this repo's layout (`packages/*/dist`, `npm/*/bin`, `skills`, `plugins/claude/releases/skills`).
- **Scripts**: `lint`, `lint:fix`, `format`, `format:check`. Added `oxlint@^1.60.0` and `prettier@^3.8.3` as devDeps.
- **CI**: new `Lint & Format` job in `.github/workflows/test.yml` running alongside the existing type-check/test job.
- **Formatting pass**: ran `bun run format`; 52 files got whitespace/quote normalization (no behavior changes).
- **One targeted fix**: `src/lib/sanitize.ts` gets an `oxlint-disable no-control-regex` directive — the ANSI escape regex is intentional.

## Notes for the reviewer
- Diff looks large because of the one-time prettier pass. The only logic-affecting change is the sanitize.ts disable comment; everything else is whitespace/quotes.
- 34 oxlint warnings remain (mostly `no-await-in-loop`). Non-blocking by design, matching the posture in the `releases` repo.

## Test plan
- [x] `bun run lint` passes
- [x] `bun run format:check` passes
- [x] `bun run typecheck` passes
- [ ] CI `Lint & Format` and `Type-check and test` jobs both green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)