### PR TITLE
docs(changesets): update README for core-split

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -2,4 +2,4 @@
 
 This folder holds pending version bumps. Each PR with user-visible behavior should add a new `.md` file via `bun run changeset`.
 
-The five `@buildinternet/releases*` binary packages are in a `fixed` group so they always bump together. The three shared packages (`releases-core`, `releases-lib`, `releases-skills`) version independently.
+Seven `@buildinternet/releases*` packages (`releases`, 4 platform binaries, `releases-lib`, `releases-skills`) are in a `fixed` group so they always bump together. `@buildinternet/releases-core` is published from the private monorepo and is not versioned here — bump its pin in `package.json` when adopting a new schema.


### PR DESCRIPTION
Follow-up to #30. `.changeset/README.md` still described the old layout (3 shared packages versioned independently). Core is now the only externally-versioned one; the other two stay fixed with the binaries.