### PR TITLE
fix(changeset): drop -core from fix-list-json-contract

### DIFF
--- a/.changeset/fix-list-json-contract.md
+++ b/.changeset/fix-list-json-contract.md
@@ -4,7 +4,6 @@
 "@buildinternet/releases-darwin-x64": minor
 "@buildinternet/releases-linux-arm64": minor
 "@buildinternet/releases-linux-x64": minor
-"@buildinternet/releases-core": minor
 "@buildinternet/releases-lib": minor
 "@buildinternet/releases-skills": minor
 ---


### PR DESCRIPTION
After #30 removed `@buildinternet/releases-core` from the workspace, the Changesets release workflow fails with `Found changeset fix-list-json-contract for package @buildinternet/releases-core which is not in the workspace` — which is why #26 is stuck with merge conflicts.

Remove the dead line from the changeset. The core-side of that change was published independently as `@buildinternet/releases-core@0.16.0` when #393 landed on the monorepo, so nothing is actually left to bump here.

Unblocks #26 — merging this will let the changesets bot rebuild the version PR cleanly.