### PR TITLE
fix(#33): await stdout drain in --json output to prevent pipe truncation

### DIFF
--- a/.changeset/json-output-drain.md
+++ b/.changeset/json-output-drain.md
@@ -1,0 +1,11 @@
+---
+"@buildinternet/releases": patch
+"@buildinternet/releases-darwin-arm64": patch
+"@buildinternet/releases-darwin-x64": patch
+"@buildinternet/releases-linux-arm64": patch
+"@buildinternet/releases-linux-x64": patch
+"@buildinternet/releases-lib": patch
+"@buildinternet/releases-skills": patch
+---
+
+Fix `--json` output being truncated at ~96 KB when piped to another process. All JSON output now awaits stdout `drain` before the CLI exits, so piping `releases admin source list --json | jq ...` works correctly on large datasets.

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ npm/releases/README.md
 # scratch / local work
 .context
 .superpowers
+.worktrees

--- a/src/cli/commands/add.ts
+++ b/src/cli/commands/add.ts
@@ -4,6 +4,7 @@ import { findOrg, createOrg, createSource, isUrlExcluded, findProduct } from "..
 import { toSlug } from "@buildinternet/releases-core/slug";
 import { logger } from "@releases/lib/logger";
 import { readFileSync } from "fs";
+import { writeJson } from "../../lib/output.js";
 
 const VALID_TYPES = ["github", "scrape", "feed", "agent"] as const;
 type SourceType = (typeof VALID_TYPES)[number];
@@ -253,7 +254,7 @@ Examples:
             }
           }
 
-          if (opts.json) console.log(JSON.stringify(results, null, 2));
+          if (opts.json) await writeJson(results);
           if (hasError) process.exit(1);
           return;
         }
@@ -282,18 +283,18 @@ Examples:
         });
 
         if (result.status === "error") {
-          if (opts.json) console.log(JSON.stringify(result, null, 2));
+          if (opts.json) await writeJson(result);
           else logger.error(chalk.red(result.error!));
           process.exit(1);
         }
 
         if (result.status === "ignored") {
-          if (opts.json) console.log(JSON.stringify(result, null, 2));
+          if (opts.json) await writeJson(result);
           return;
         }
 
         if (opts.json) {
-          console.log(JSON.stringify(result, null, 2));
+          await writeJson(result);
         } else {
           const orgLabel = result.org ? ` [org: ${result.org}]` : "";
           const typeLabel = !opts.type ? ` (auto-detected: ${result.type})` : "";

--- a/src/cli/commands/admin/embed.ts
+++ b/src/cli/commands/admin/embed.ts
@@ -17,6 +17,7 @@ import {
   getEmbedStatus,
 } from "../../../api/client.js";
 import type { EmbedBackfillResponse } from "../../../api/types.js";
+import { writeJson } from "../../../lib/output.js";
 
 /** Worker batch cap — must stay in sync with BATCH_CAP on the API worker. */
 const ENDPOINT_BATCH_CAP = 50;
@@ -68,7 +69,7 @@ async function runBackfillLoop(
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       if (opts.json) {
-        console.log(JSON.stringify({ ok: false, label, error: msg, ...summary }, null, 2));
+        await writeJson({ ok: false, label, error: msg, ...summary });
       } else {
         logger.error(`  Batch ${summary.batches + 1} failed: ${msg}`);
       }
@@ -95,9 +96,9 @@ async function runBackfillLoop(
   return summary;
 }
 
-function printSummary(label: string, summary: LoopSummary, json: boolean): void {
+async function printSummary(label: string, summary: LoopSummary, json: boolean): Promise<void> {
   if (json) {
-    console.log(JSON.stringify({ ok: true, label, ...summary }, null, 2));
+    await writeJson({ ok: true, label, ...summary });
     return;
   }
   console.log(`Done. Total: ${summary.totalProcessed} processed, ${summary.totalFailed} failed.`);
@@ -128,7 +129,7 @@ export function registerEmbedCommand(parent: Command): void {
         (limit) => embedReleases({ since: opts.since, limit, dryRun: opts.dryRun }),
         opts,
       );
-      printSummary("releases", summary, opts.json === true);
+      await printSummary("releases", summary, opts.json === true);
     });
 
   embed
@@ -155,7 +156,7 @@ export function registerEmbedCommand(parent: Command): void {
           (limit) => embedEntities({ kind: opts.kind, limit, dryRun: opts.dryRun }),
           opts,
         );
-        printSummary(label, summary, opts.json === true);
+        await printSummary(label, summary, opts.json === true);
       },
     );
 
@@ -172,7 +173,7 @@ export function registerEmbedCommand(parent: Command): void {
         (limit) => embedChangelogs({ sourceSlug: opts.source, limit, dryRun: opts.dryRun }),
         opts,
       );
-      printSummary("changelogs", summary, opts.json === true);
+      await printSummary("changelogs", summary, opts.json === true);
     });
 
   embed
@@ -190,7 +191,7 @@ export function registerEmbedCommand(parent: Command): void {
       }
 
       if (opts.json) {
-        console.log(JSON.stringify(status, null, 2));
+        await writeJson(status);
         return;
       }
 

--- a/src/cli/commands/block.ts
+++ b/src/cli/commands/block.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { listBlockedUrls, addBlockedUrl, removeBlockedUrl } from "../../api/client.js";
 import { logger } from "@releases/lib/logger";
+import { writeJson } from "../../lib/output.js";
 
 export function registerBlockCommand(program: Command) {
   const block = program.command("block").description("Manage globally blocked URLs and domains");
@@ -21,7 +22,7 @@ Examples:
       const rows = await listBlockedUrls();
 
       if (opts.json) {
-        console.log(JSON.stringify(rows, null, 2));
+        await writeJson(rows);
         return;
       }
 
@@ -108,7 +109,7 @@ Examples:
     .action(async (pattern: string, opts: { json?: boolean }) => {
       await removeBlockedUrl(pattern);
       if (opts.json) {
-        console.log(JSON.stringify({ pattern, status: "unblocked" }, null, 2));
+        await writeJson({ pattern, status: "unblocked" });
       } else {
         logger.info(chalk.green(`Unblocked: ${pattern}`));
       }

--- a/src/cli/commands/changelog.ts
+++ b/src/cli/commands/changelog.ts
@@ -4,6 +4,7 @@ import { findSource, sourceChangelog } from "../../api/client.js";
 import { formatChangelogSliceLine } from "@buildinternet/releases-core/changelog-slice";
 import { sourceNotFound } from "../suggest.js";
 import { logger } from "@releases/lib/logger";
+import { writeJson } from "../../lib/output.js";
 
 export function registerChangelogCommand(program: Command) {
   program
@@ -43,7 +44,7 @@ export function registerChangelogCommand(program: Command) {
         }
 
         if (opts.json) {
-          console.log(JSON.stringify(response, null, 2));
+          await writeJson(response);
           return;
         }
 

--- a/src/cli/commands/check.ts
+++ b/src/cli/commands/check.ts
@@ -4,6 +4,7 @@ import Table from "cli-table3";
 import { findSource, listSourcesWithOrg } from "../../api/client.js";
 import { timeAgo } from "@buildinternet/releases-core/dates";
 import { stripAnsi } from "../../lib/sanitize.js";
+import { writeJson } from "../../lib/output.js";
 
 interface SourceLite {
   name: string;
@@ -132,7 +133,7 @@ export function registerCheckCommand(program: Command) {
           lastFetchedAt: r.lastFetchedAt,
         }));
         if (sourcesToCheck.length === 0) {
-          if (opts.json) console.log(JSON.stringify([], null, 2));
+          if (opts.json) await writeJson([]);
           else console.log("No sources configured.");
           return;
         }
@@ -141,7 +142,7 @@ export function registerCheckCommand(program: Command) {
       const results = await Promise.all(sourcesToCheck.map(checkSource));
 
       if (opts.json) {
-        console.log(JSON.stringify(results, null, 2));
+        await writeJson(results);
         return;
       }
 

--- a/src/cli/commands/edit.ts
+++ b/src/cli/commands/edit.ts
@@ -11,6 +11,7 @@ import {
 import { sourceNotFound } from "../suggest.js";
 import { toSlug } from "@buildinternet/releases-core/slug";
 import { logger } from "@releases/lib/logger";
+import { writeJson } from "../../lib/output.js";
 
 const VALID_TYPES = ["github", "scrape", "feed", "agent"] as const;
 
@@ -253,7 +254,7 @@ export function registerEditCommand(program: Command) {
 
         if (opts.json) {
           const refreshed = await findSource(displaySlug);
-          console.log(JSON.stringify(refreshed, null, 2));
+          await writeJson(refreshed);
         } else {
           console.log(chalk.green(`Updated ${source.name} (${displaySlug}):`));
           for (const change of changes) console.log(`  ${change}`);

--- a/src/cli/commands/fetch-log.ts
+++ b/src/cli/commands/fetch-log.ts
@@ -4,6 +4,7 @@ import Table from "cli-table3";
 import { getFetchLogs } from "../../api/client.js";
 import { timeAgo } from "@buildinternet/releases-core/dates";
 import { stripAnsi } from "../../lib/sanitize.js";
+import { writeJson } from "../../lib/output.js";
 
 export function registerFetchLogCommand(program: Command) {
   program
@@ -26,7 +27,7 @@ Examples:
 
       if (logs.length === 0) {
         if (opts.json) {
-          console.log(JSON.stringify([], null, 2));
+          await writeJson([]);
         } else {
           console.log("No fetch logs found.");
         }
@@ -34,7 +35,7 @@ Examples:
       }
 
       if (opts.json) {
-        console.log(JSON.stringify(logs, null, 2));
+        await writeJson(logs);
         return;
       }
 

--- a/src/cli/commands/fetch.ts
+++ b/src/cli/commands/fetch.ts
@@ -12,6 +12,7 @@ import {
 } from "../../api/client.js";
 import { newCorrelationId } from "@buildinternet/releases-core/id";
 import { orgNotFound, sourceNotFound } from "../suggest.js";
+import { writeJson, writeJsonLine } from "../../lib/output.js";
 
 export function registerFetchCommand(program: Command) {
   program
@@ -67,7 +68,7 @@ Examples:
           );
           if (activeSources.length === 0) {
             if (opts.json)
-              console.log(JSON.stringify({ sessionId: null, message: "No active sources" }));
+              await writeJsonLine({ sessionId: null, message: "No active sources" });
             else logger.info(`No active sources for ${org.name}.`);
             return;
           }
@@ -109,7 +110,7 @@ Examples:
 
         if (entries.length === 0) {
           if (opts.json)
-            console.log(JSON.stringify({ sessionId: null, message: "No matching sources" }));
+            await writeJsonLine({ sessionId: null, message: "No matching sources" });
           else logger.info("No matching sources to fetch.");
           return;
         }
@@ -162,7 +163,7 @@ Examples:
           process.exit(1);
         }
         if (opts.json) {
-          console.log(JSON.stringify(result, null, 2));
+          await writeJson(result);
         } else {
           logger.info(`Update session started: ${result.sessionId}`);
           logger.info(`Fetching ${sourceIdentifiers.length} source(s).`);

--- a/src/cli/commands/fetch.ts
+++ b/src/cli/commands/fetch.ts
@@ -67,8 +67,7 @@ Examples:
             (s) => !s.isHidden && s.fetchPriority !== "paused",
           );
           if (activeSources.length === 0) {
-            if (opts.json)
-              await writeJsonLine({ sessionId: null, message: "No active sources" });
+            if (opts.json) await writeJsonLine({ sessionId: null, message: "No active sources" });
             else logger.info(`No active sources for ${org.name}.`);
             return;
           }
@@ -109,8 +108,7 @@ Examples:
         }
 
         if (entries.length === 0) {
-          if (opts.json)
-            await writeJsonLine({ sessionId: null, message: "No matching sources" });
+          if (opts.json) await writeJsonLine({ sessionId: null, message: "No matching sources" });
           else logger.info("No matching sources to fetch.");
           return;
         }

--- a/src/cli/commands/ignore.ts
+++ b/src/cli/commands/ignore.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { findOrg, listIgnoredUrls, addIgnoredUrl, removeIgnoredUrl } from "../../api/client.js";
 import { logger } from "@releases/lib/logger";
+import { writeJson } from "../../lib/output.js";
 
 export function registerIgnoreCommand(program: Command) {
   const ignore = program
@@ -30,7 +31,7 @@ Examples:
       const rows = await listIgnoredUrls(org.id);
 
       if (opts.json) {
-        console.log(JSON.stringify(rows, null, 2));
+        await writeJson(rows);
         return;
       }
 
@@ -101,7 +102,7 @@ Examples:
 
       await removeIgnoredUrl(url, org.id);
       if (opts.json) {
-        console.log(JSON.stringify({ url, org: org.slug, status: "unignored" }, null, 2));
+        await writeJson({ url, org: org.slug, status: "unignored" });
       } else {
         logger.info(chalk.green(`Un-ignored for ${org.name}: ${url}`));
       }

--- a/src/cli/commands/import.ts
+++ b/src/cli/commands/import.ts
@@ -6,6 +6,7 @@ import { toSlug } from "@buildinternet/releases-core/slug";
 import { logger } from "@releases/lib/logger";
 import { isGitHubUrl } from "./add.js";
 import { isValidCategory } from "@buildinternet/releases-core/categories";
+import { writeJson } from "../../lib/output.js";
 import {
   findOrg,
   createOrg,
@@ -526,7 +527,7 @@ export function registerImportCommand(program: Command) {
         }
 
         if (opts.json) {
-          console.log(JSON.stringify(report, null, 2));
+          await writeJson(report);
         } else {
           console.log("");
           const prefix = opts.dryRun ? "[dry-run] " : "";

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -4,6 +4,7 @@ import Table from "cli-table3";
 import { listSourcesWithOrg, findSource } from "../../api/client.js";
 import { sourceNotFound } from "../suggest.js";
 import { stripAnsi } from "../../lib/sanitize.js";
+import { writeJson } from "../../lib/output.js";
 import {
   DEFAULT_PAGE_SIZE,
   parseMetadataObject,
@@ -67,7 +68,7 @@ export function registerListCommand(program: Command) {
               method,
               metadata: parsedMeta ?? source.metadata,
             };
-            console.log(JSON.stringify(parsed, null, 2));
+            await writeJson(parsed);
             return;
           }
           const label = (key: string, val: string | null | undefined) =>
@@ -136,13 +137,13 @@ export function registerListCommand(program: Command) {
           const warnTruncated = !explicitLimit && apiPagination.hasMore;
 
           if (opts.flat) {
-            console.log(JSON.stringify(items, null, 2));
+            await writeJson(items);
           } else {
             const response: ListResponse<Record<string, unknown>> = {
               items,
               pagination: apiPagination,
             };
-            console.log(JSON.stringify(response, null, 2));
+            await writeJson(response);
           }
 
           if (warnTruncated) {

--- a/src/cli/commands/onboard-apply.ts
+++ b/src/cli/commands/onboard-apply.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { logger } from "@releases/lib/logger";
 import { addIgnoredUrl, findOrg, createSource } from "../../api/client.js";
+import { writeJson } from "../../lib/output.js";
 
 interface AgentDiscoveredSource {
   slug: string;
@@ -119,7 +120,7 @@ export function registerOnboardApplyCommand(onboardCmd: Command) {
       }
 
       if (opts.json) {
-        console.log(JSON.stringify(results, null, 2));
+        await writeJson(results);
       } else {
         let added = 0,
           ignored = 0,

--- a/src/cli/commands/onboard.ts
+++ b/src/cli/commands/onboard.ts
@@ -4,6 +4,7 @@ import { logger } from "@releases/lib/logger";
 import { registerOnboardApplyCommand } from "./onboard-apply.js";
 import { apiFetch } from "../../api/client.js";
 import { getApiUrl } from "../../lib/mode.js";
+import { writeJson } from "../../lib/output.js";
 
 interface OnboardOpts {
   domain?: string;
@@ -126,7 +127,7 @@ async function runRemoteDiscovery(
 
       if (status.result) {
         if (opts.json) {
-          console.log(JSON.stringify(status.result, null, 2));
+          await writeJson(status.result);
           return;
         }
 

--- a/src/cli/commands/org.ts
+++ b/src/cli/commands/org.ts
@@ -382,8 +382,7 @@ Examples:
       if (!found) return orgNotFound(identifier);
 
       if (opts.dryRun) {
-        if (opts.json)
-          await writeJson({ wouldRemove: found.slug, name: found.name });
+        if (opts.json) await writeJson({ wouldRemove: found.slug, name: found.name });
         else
           console.log(
             chalk.yellow(`[dry-run] Would remove organization: ${found.name} (${found.slug})`),
@@ -432,8 +431,7 @@ Examples:
 
         await unlinkOrgAccount(found.slug, opts.platform, opts.handle);
 
-        if (opts.json)
-          await writeJson({ unlinked: `${opts.platform}/${opts.handle}` });
+        if (opts.json) await writeJson({ unlinked: `${opts.platform}/${opts.handle}` });
         else
           console.log(chalk.green(`Unlinked ${opts.platform}/${opts.handle} from ${found.name}`));
       },

--- a/src/cli/commands/org.ts
+++ b/src/cli/commands/org.ts
@@ -26,6 +26,7 @@ import { orgNotFound } from "../suggest.js";
 import { toSlug } from "@buildinternet/releases-core/slug";
 import { isValidCategory, CATEGORIES } from "@buildinternet/releases-core/categories";
 import { timeAgo } from "@buildinternet/releases-core/dates";
+import { writeJson } from "../../lib/output.js";
 import {
   OVERVIEW_STALE_DAYS,
   overviewAgeDays,
@@ -91,7 +92,7 @@ export function registerOrgCommand(program: Command) {
           }
         }
 
-        if (opts.json) console.log(JSON.stringify(created, null, 2));
+        if (opts.json) await writeJson(created);
         else console.log(chalk.green(`Organization added: ${name} (${slug})`));
       },
     );
@@ -107,13 +108,13 @@ export function registerOrgCommand(program: Command) {
       const allOrgs = await listOrgs({ query: opts.query, platform: opts.platform });
 
       if (allOrgs.length === 0) {
-        if (opts.json) console.log(JSON.stringify([], null, 2));
+        if (opts.json) await writeJson([]);
         else console.log(chalk.yellow("No organizations found."));
         return;
       }
 
       if (opts.json) {
-        console.log(JSON.stringify(allOrgs, null, 2));
+        await writeJson(allOrgs);
         return;
       }
 
@@ -256,7 +257,7 @@ Examples:
 
       if (!overview?.content) {
         if (opts.json) {
-          console.log(JSON.stringify({ org: found.slug, overview: null }, null, 2));
+          await writeJson({ org: found.slug, overview: null });
         } else {
           console.log(chalk.yellow(`No overview available for ${found.name}.`));
         }
@@ -364,7 +365,7 @@ Examples:
 
         const updated = await updateOrg(found.slug, updates);
 
-        if (opts.json) console.log(JSON.stringify(updated, null, 2));
+        if (opts.json) await writeJson(updated);
         else console.log(chalk.green(`Updated organization: ${updated.name} (${updated.slug})`));
       },
     );
@@ -382,7 +383,7 @@ Examples:
 
       if (opts.dryRun) {
         if (opts.json)
-          console.log(JSON.stringify({ wouldRemove: found.slug, name: found.name }, null, 2));
+          await writeJson({ wouldRemove: found.slug, name: found.name });
         else
           console.log(
             chalk.yellow(`[dry-run] Would remove organization: ${found.name} (${found.slug})`),
@@ -392,7 +393,7 @@ Examples:
 
       await removeOrg(found.slug);
 
-      if (opts.json) console.log(JSON.stringify({ removed: found.slug }, null, 2));
+      if (opts.json) await writeJson({ removed: found.slug });
       else console.log(chalk.green(`Removed organization: ${found.name} (${found.slug})`));
     });
 
@@ -411,7 +412,7 @@ Examples:
 
         const created = await linkOrgAccount(found.slug, opts.platform, opts.handle);
 
-        if (opts.json) console.log(JSON.stringify(created, null, 2));
+        if (opts.json) await writeJson(created);
         else console.log(chalk.green(`Linked ${opts.platform}/${opts.handle} to ${found.name}`));
       },
     );
@@ -432,7 +433,7 @@ Examples:
         await unlinkOrgAccount(found.slug, opts.platform, opts.handle);
 
         if (opts.json)
-          console.log(JSON.stringify({ unlinked: `${opts.platform}/${opts.handle}` }, null, 2));
+          await writeJson({ unlinked: `${opts.platform}/${opts.handle}` });
         else
           console.log(chalk.green(`Unlinked ${opts.platform}/${opts.handle} from ${found.name}`));
       },
@@ -453,7 +454,7 @@ Examples:
       await addTagsToOrg(found.id, tagNames);
       if (opts.json) {
         const allTags = await getTagsForOrg(found.id);
-        console.log(JSON.stringify({ tags: allTags }, null, 2));
+        await writeJson({ tags: allTags });
       } else {
         console.log(chalk.green(`Added tags to ${found.name}: ${tagNames.join(", ")}`));
       }
@@ -471,7 +472,7 @@ Examples:
       await removeTagsFromOrg(found.id, tagNames);
       if (opts.json) {
         const allTags = await getTagsForOrg(found.id);
-        console.log(JSON.stringify({ tags: allTags }, null, 2));
+        await writeJson({ tags: allTags });
       } else {
         console.log(chalk.green(`Removed tags from ${found.name}: ${tagNames.join(", ")}`));
       }
@@ -486,7 +487,7 @@ Examples:
       const found = await findOrg(identifier);
       if (!found) return orgNotFound(identifier);
       const allTags = await getTagsForOrg(found.id);
-      if (opts.json) console.log(JSON.stringify(allTags, null, 2));
+      if (opts.json) await writeJson(allTags);
       else if (allTags.length === 0) console.log(chalk.yellow(`No tags for ${found.name}`));
       else console.log(allTags.join(", "));
     });
@@ -518,7 +519,7 @@ Examples:
         }
       }
 
-      if (opts.json) console.log(JSON.stringify(results, null, 2));
+      if (opts.json) await writeJson(results);
       else
         for (const r of results)
           console.log(chalk.green(`Added alias: ${r.domain} → ${found.name}`));
@@ -541,7 +542,7 @@ Examples:
         else console.error(chalk.yellow(`Alias "${domain}" not found.`));
       }
 
-      if (opts.json) console.log(JSON.stringify({ removed }, null, 2));
+      if (opts.json) await writeJson({ removed });
       else for (const d of removed) console.log(chalk.green(`Removed alias: ${d}`));
     });
 

--- a/src/cli/commands/product.ts
+++ b/src/cli/commands/product.ts
@@ -22,6 +22,7 @@ import {
 } from "../../api/client.js";
 import { toSlug } from "@buildinternet/releases-core/slug";
 import { isValidCategory, CATEGORIES } from "@buildinternet/releases-core/categories";
+import { writeJson } from "../../lib/output.js";
 
 export function registerProductCommand(program: Command) {
   const product = program.command("product").description("Manage products");
@@ -46,13 +47,13 @@ export function registerProductCommand(program: Command) {
       const productList = await getProductsByOrg(org.id);
 
       if (productList.length === 0) {
-        if (opts.json) console.log(JSON.stringify([], null, 2));
+        if (opts.json) await writeJson([]);
         else console.log(chalk.yellow(`No products found for organization: ${org.name}`));
         return;
       }
 
       if (opts.json) {
-        console.log(JSON.stringify(productList, null, 2));
+        await writeJson(productList);
         return;
       }
 
@@ -136,7 +137,7 @@ export function registerProductCommand(program: Command) {
           if (tagList.length > 0) await addTagsToProduct(created.id, tagList);
         }
 
-        if (opts.json) console.log(JSON.stringify(created, null, 2));
+        if (opts.json) await writeJson(created);
         else console.log(chalk.green(`Product added: ${name} (${slug}) under ${org.name}`));
       },
     );
@@ -192,7 +193,7 @@ export function registerProductCommand(program: Command) {
 
         const updated = await updateProduct(found.slug, updates);
 
-        if (opts.json) console.log(JSON.stringify(updated, null, 2));
+        if (opts.json) await writeJson(updated);
         else console.log(chalk.green(`Product updated: ${updated.name} (${updated.slug})`));
       },
     );
@@ -212,7 +213,7 @@ export function registerProductCommand(program: Command) {
 
       if (opts.dryRun) {
         if (opts.json)
-          console.log(JSON.stringify({ wouldRemove: found.slug, name: found.name }, null, 2));
+          await writeJson({ wouldRemove: found.slug, name: found.name });
         else
           console.log(
             chalk.yellow(`[dry-run] Would remove product: ${found.name} (${found.slug})`),
@@ -222,7 +223,7 @@ export function registerProductCommand(program: Command) {
 
       await deleteProduct(found.id);
 
-      if (opts.json) console.log(JSON.stringify({ removed: found.slug }, null, 2));
+      if (opts.json) await writeJson({ removed: found.slug });
       else console.log(chalk.green(`Removed product: ${found.name} (${found.slug})`));
     });
 
@@ -273,7 +274,7 @@ export function registerProductCommand(program: Command) {
           };
 
           if (opts.json) {
-            console.log(JSON.stringify(plan, null, 2));
+            await writeJson(plan);
           } else {
             console.log(
               chalk.yellow(
@@ -354,7 +355,7 @@ export function registerProductCommand(program: Command) {
       await addTagsToProduct(found.id, tagNames);
       if (opts.json) {
         const allTags = await getTagsForProduct(found.id);
-        console.log(JSON.stringify({ tags: allTags }, null, 2));
+        await writeJson({ tags: allTags });
       } else {
         console.log(chalk.green(`Added tags to ${found.name}: ${tagNames.join(", ")}`));
       }
@@ -375,7 +376,7 @@ export function registerProductCommand(program: Command) {
       await removeTagsFromProduct(found.id, tagNames);
       if (opts.json) {
         const allTags = await getTagsForProduct(found.id);
-        console.log(JSON.stringify({ tags: allTags }, null, 2));
+        await writeJson({ tags: allTags });
       } else {
         console.log(chalk.green(`Removed tags from ${found.name}: ${tagNames.join(", ")}`));
       }
@@ -393,7 +394,7 @@ export function registerProductCommand(program: Command) {
         process.exit(1);
       }
       const allTags = await getTagsForProduct(found.id);
-      if (opts.json) console.log(JSON.stringify(allTags, null, 2));
+      if (opts.json) await writeJson(allTags);
       else if (allTags.length === 0) console.log(chalk.yellow(`No tags for ${found.name}`));
       else console.log(allTags.join(", "));
     });
@@ -428,7 +429,7 @@ export function registerProductCommand(program: Command) {
         }
       }
 
-      if (opts.json) console.log(JSON.stringify(results, null, 2));
+      if (opts.json) await writeJson(results);
       else
         for (const r of results)
           console.log(chalk.green(`Added alias: ${r.domain} → ${found.name}`));
@@ -454,7 +455,7 @@ export function registerProductCommand(program: Command) {
         else console.error(chalk.yellow(`Alias "${domain}" not found.`));
       }
 
-      if (opts.json) console.log(JSON.stringify({ removed }, null, 2));
+      if (opts.json) await writeJson({ removed });
       else for (const d of removed) console.log(chalk.green(`Removed alias: ${d}`));
     });
 

--- a/src/cli/commands/product.ts
+++ b/src/cli/commands/product.ts
@@ -212,8 +212,7 @@ export function registerProductCommand(program: Command) {
       }
 
       if (opts.dryRun) {
-        if (opts.json)
-          await writeJson({ wouldRemove: found.slug, name: found.name });
+        if (opts.json) await writeJson({ wouldRemove: found.slug, name: found.name });
         else
           console.log(
             chalk.yellow(`[dry-run] Would remove product: ${found.name} (${found.slug})`),

--- a/src/cli/commands/release.ts
+++ b/src/cli/commands/release.ts
@@ -12,6 +12,7 @@ import {
 } from "../../api/client.js";
 import { stripAnsi } from "../../lib/sanitize.js";
 import { normalizeReleaseId } from "@buildinternet/releases-core/id";
+import { writeJson, writeJsonLine } from "../../lib/output.js";
 
 function releaseNotFound(id: string): never {
   console.error(chalk.red(`Release not found: ${id}`));
@@ -35,7 +36,7 @@ export function registerReleaseCommand(program: Command) {
       const rel = result;
 
       if (opts.json) {
-        console.log(JSON.stringify(rel, null, 2));
+        await writeJson(rel);
         return;
       }
 
@@ -120,7 +121,7 @@ export function registerReleaseCommand(program: Command) {
             console.error(chalk.red("No matching releases found."));
             process.exit(1);
           }
-          if (opts.json) console.log(JSON.stringify({ deleted: 1 }, null, 2));
+          if (opts.json) await writeJson({ deleted: 1 });
           else console.log(chalk.green(`Deleted 1 release.`));
           return;
         }
@@ -141,7 +142,7 @@ export function registerReleaseCommand(program: Command) {
             console.error(chalk.red(err instanceof Error ? err.message : String(err)));
             process.exit(1);
           }
-          if (opts.json) console.log(JSON.stringify(result, null, 2));
+          if (opts.json) await writeJson(result);
           else
             console.log(
               chalk.green(`Deleted ${result.deleted} release${result.deleted === 1 ? "" : "s"}.`),
@@ -195,7 +196,7 @@ export function registerReleaseCommand(program: Command) {
 
         const updated = await updateRelease(id, updates);
 
-        if (opts.json) console.log(JSON.stringify(updated, null, 2));
+        if (opts.json) await writeJson(updated);
         else {
           console.log(chalk.green(`Updated release ${id}:`));
           for (const change of changes) console.log(`  ${change}`);
@@ -230,7 +231,7 @@ export function registerReleaseCommand(program: Command) {
       if (!found) releaseNotFound(id);
 
       if (opts.json)
-        console.log(JSON.stringify({ id, suppressed: true, reason: opts.reason ?? null }));
+        await writeJsonLine({ id, suppressed: true, reason: opts.reason ?? null });
       else
         console.log(
           chalk.green(`Suppressed release ${id}${opts.reason ? ` (${opts.reason})` : ""}`),
@@ -247,7 +248,7 @@ export function registerReleaseCommand(program: Command) {
       const found = await unsuppressRelease(id);
       if (!found) releaseNotFound(id);
 
-      if (opts.json) console.log(JSON.stringify({ id, suppressed: false }));
+      if (opts.json) await writeJsonLine({ id, suppressed: false });
       else console.log(chalk.green(`Unsuppressed release ${id}`));
     });
 }

--- a/src/cli/commands/release.ts
+++ b/src/cli/commands/release.ts
@@ -230,8 +230,7 @@ export function registerReleaseCommand(program: Command) {
       const found = await suppressRelease(id, opts.reason);
       if (!found) releaseNotFound(id);
 
-      if (opts.json)
-        await writeJsonLine({ id, suppressed: true, reason: opts.reason ?? null });
+      if (opts.json) await writeJsonLine({ id, suppressed: true, reason: opts.reason ?? null });
       else
         console.log(
           chalk.green(`Suppressed release ${id}${opts.reason ? ` (${opts.reason})` : ""}`),

--- a/src/cli/commands/remove.ts
+++ b/src/cli/commands/remove.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { findSourcesBySlugs, deleteSources, addIgnoredUrl } from "../../api/client.js";
 import { logger } from "@releases/lib/logger";
+import { writeJson } from "../../lib/output.js";
 
 export function registerRemoveCommand(program: Command) {
   program
@@ -38,7 +39,7 @@ export function registerRemoveCommand(program: Command) {
           });
 
           if (opts.json) {
-            console.log(JSON.stringify(dryResults, null, 2));
+            await writeJson(dryResults);
           } else {
             for (const r of dryResults) {
               if (r.status === "not_found") console.error(chalk.red(`Source not found: ${r.slug}`));
@@ -97,7 +98,7 @@ export function registerRemoveCommand(program: Command) {
           }
         }
 
-        if (opts.json) console.log(JSON.stringify(results, null, 2));
+        if (opts.json) await writeJson(results);
         if (hasError) process.exit(1);
       },
     );

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -4,6 +4,7 @@ import { unifiedSearch } from "../../api/client.js";
 import { stripAnsi } from "../../lib/sanitize.js";
 import { logger } from "@releases/lib/logger";
 import type { UnifiedSearchResponse } from "../../api/types.js";
+import { writeJson } from "../../lib/output.js";
 
 const SEARCH_MODES = ["lexical", "semantic", "hybrid"] as const;
 type SearchMode = (typeof SEARCH_MODES)[number];
@@ -51,7 +52,7 @@ export function registerSearchCommand(program: Command) {
           if (response.degraded !== undefined) filtered.degraded = response.degraded;
           if (response.degradedReason !== undefined)
             filtered.degradedReason = response.degradedReason;
-          console.log(JSON.stringify(filtered, null, 2));
+          await writeJson(filtered);
           return;
         }
 

--- a/src/cli/commands/show.ts
+++ b/src/cli/commands/show.ts
@@ -10,6 +10,7 @@ import {
 import { stripAnsi } from "../../lib/sanitize.js";
 import { renderLatestReleasesTable } from "../render/releases-table.js";
 import { getEntityType, normalizeReleaseId, isLikelyBareId } from "@buildinternet/releases-core/id";
+import { writeJson } from "../../lib/output.js";
 
 export function registerShowCommand(program: Command) {
   program
@@ -32,7 +33,7 @@ export function registerShowCommand(program: Command) {
       const product = await findProduct(identifier);
       if (product) return await renderProduct(product, opts);
       const source = await findSource(identifier);
-      if (source) return renderSource(source, opts);
+      if (source) return await renderSource(source, opts);
 
       console.error(chalk.red(`Not found: ${identifier}`));
       process.exit(1);
@@ -47,7 +48,7 @@ async function showRelease(id: string, opts: { json?: boolean }) {
   }
   const rel = result;
   if (opts.json) {
-    console.log(JSON.stringify(rel, null, 2));
+    await writeJson(rel);
     return;
   }
   console.log(chalk.dim("Release"));
@@ -76,7 +77,7 @@ async function showSource(identifier: string, opts: { json?: boolean }) {
     console.error(chalk.red(`Source not found: ${identifier}`));
     process.exit(1);
   }
-  renderSource(source, opts);
+  await renderSource(source, opts);
 }
 
 async function showOrg(identifier: string, opts: { json?: boolean }) {
@@ -97,7 +98,7 @@ async function showProduct(identifier: string, opts: { json?: boolean }) {
   await renderProduct(product, opts);
 }
 
-function renderSource(
+async function renderSource(
   source: {
     id: string;
     name: string;
@@ -110,7 +111,7 @@ function renderSource(
   opts: { json?: boolean },
 ) {
   if (opts.json) {
-    console.log(JSON.stringify(source, null, 2));
+    await writeJson(source);
     return;
   }
   console.log(chalk.dim("Source"));
@@ -128,7 +129,7 @@ async function renderOrg(
   const releases = await getLatestReleases({ orgSlug: org.slug, count: 10 });
 
   if (opts.json) {
-    console.log(JSON.stringify({ ...org, releases }, null, 2));
+    await writeJson({ ...org, releases });
     return;
   }
 
@@ -161,7 +162,7 @@ async function renderProduct(
 ) {
   const org = await findOrg(product.orgId);
   if (opts.json) {
-    console.log(JSON.stringify({ ...product, orgSlug: org?.slug ?? null }, null, 2));
+    await writeJson({ ...product, orgSlug: org?.slug ?? null });
     return;
   }
   console.log(chalk.dim("Product"));

--- a/src/cli/commands/tail.ts
+++ b/src/cli/commands/tail.ts
@@ -5,6 +5,7 @@ import type { LatestRelease } from "../../api/types.js";
 import { orgNotFound, sourceNotFound } from "../suggest.js";
 import { stripAnsi } from "../../lib/sanitize.js";
 import { renderLatestReleasesTable } from "../render/releases-table.js";
+import { writeJson, writeJsonLine } from "../../lib/output.js";
 
 function renderStreamLine(row: LatestRelease): string {
   const version = row.version ? chalk.yellow(stripAnsi(row.version)) : "";
@@ -91,7 +92,7 @@ Examples:
         const rows = await getLatestReleases(fetchOpts);
 
         if (opts.json) {
-          console.log(JSON.stringify(rows, null, 2));
+          await writeJson(rows);
         } else if (rows.length === 0) {
           console.log(chalk.yellow("No releases found."));
         } else if (opts.follow) {
@@ -131,7 +132,7 @@ Examples:
           );
           const ordered = novel.slice().reverse();
           if (opts.json) {
-            for (const row of ordered) console.log(JSON.stringify(row));
+            for (const row of ordered) await writeJsonLine(row);
           } else {
             for (const row of ordered) console.log(renderStreamLine(row));
           }

--- a/src/cli/commands/task.ts
+++ b/src/cli/commands/task.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import * as apiClient from "../../api/client.js";
+import { writeJson } from "../../lib/output.js";
 
 export function registerTaskCommand(program: Command) {
   const task = program.command("task").description("Manage remote fetch and discovery sessions");
@@ -13,7 +14,7 @@ export function registerTaskCommand(program: Command) {
       const sessions = await apiClient.listSessions();
 
       if (opts.json) {
-        console.log(JSON.stringify(sessions, null, 2));
+        await writeJson(sessions);
         return;
       }
 

--- a/src/cli/commands/telemetry.ts
+++ b/src/cli/commands/telemetry.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import { setTelemetryEnabled, telemetryStatus } from "../../lib/telemetry.js";
+import { writeJson } from "../../lib/output.js";
 
 export function registerTelemetryCommand(parent: Command): void {
   const cmd = parent.command("telemetry").description("Manage anonymous usage telemetry");
@@ -9,10 +10,10 @@ export function registerTelemetryCommand(parent: Command): void {
     .command("status")
     .description("Show current telemetry configuration")
     .option("--json", "Output as JSON")
-    .action((opts: { json?: boolean }) => {
+    .action(async (opts: { json?: boolean }) => {
       const s = telemetryStatus();
       if (opts.json) {
-        console.log(JSON.stringify(s, null, 2));
+        await writeJson(s);
         return;
       }
       const state = s.enabled ? chalk.green("enabled") : chalk.red("disabled");

--- a/src/cli/commands/whoami.ts
+++ b/src/cli/commands/whoami.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { getApiKey, getApiUrl, isAdminMode } from "../../lib/mode.js";
 import { VERSION } from "../version.js";
+import { writeJson } from "../../lib/output.js";
 
 export type WhoamiStatus = {
   version: string;
@@ -62,7 +63,7 @@ export function registerWhoamiCommand(parent: Command): void {
       if (opts.check) status.check = await probeApi(status.mode);
 
       if (opts.json) {
-        console.log(JSON.stringify(status, null, 2));
+        await writeJson(status);
         return;
       }
 

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -28,6 +28,7 @@ import { registerWhoamiCommand } from "./commands/whoami.js";
 import { CATEGORIES } from "@buildinternet/releases-core/categories";
 import { isAdminMode } from "../lib/mode.js";
 import { VERSION } from "./version.js";
+import { writeJson } from "../lib/output.js";
 
 export { VERSION };
 
@@ -232,9 +233,9 @@ program
   .command("categories")
   .description("List valid category values")
   .option("--json", "Output as JSON")
-  .action((opts: { json?: boolean }) => {
+  .action(async (opts: { json?: boolean }) => {
     if (opts.json) {
-      console.log(JSON.stringify(CATEGORIES, null, 2));
+      await writeJson(CATEGORIES);
     } else {
       for (const cat of CATEGORIES) {
         console.log(cat);

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -1,0 +1,27 @@
+/**
+ * Write a value as pretty-printed JSON to stdout, awaiting drain when the
+ * write buffer is full.
+ *
+ * When stdout is a pipe, Node/Bun's `process.stdout.write` is non-blocking
+ * and returns `false` once the internal buffer (~96 KB) fills. `console.log`
+ * doesn't await drain, so if the CLI process exits before the kernel pipe
+ * buffer has drained, tail bytes are silently dropped. This manifests as
+ * truncated JSON when a caller pipes `--json` output into `jq`, `cat`, etc.
+ *
+ * Always use this helper instead of `console.log(JSON.stringify(...))` for
+ * machine-readable output.
+ */
+export async function writeJson(value: unknown): Promise<void> {
+  const out = JSON.stringify(value, null, 2) + "\n";
+  if (!process.stdout.write(out)) {
+    await new Promise<void>((resolve) => process.stdout.once("drain", resolve));
+  }
+}
+
+/** Compact single-line JSON (for streaming NDJSON-style output). */
+export async function writeJsonLine(value: unknown): Promise<void> {
+  const out = JSON.stringify(value) + "\n";
+  if (!process.stdout.write(out)) {
+    await new Promise<void>((resolve) => process.stdout.once("drain", resolve));
+  }
+}

--- a/tests/unit/output.test.ts
+++ b/tests/unit/output.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, mock } from "bun:test";
+import { writeJson, writeJsonLine } from "../../src/lib/output";
+
+type WriteFn = typeof process.stdout.write;
+type OnceFn = typeof process.stdout.once;
+
+/**
+ * Mock `process.stdout.write` to simulate pipe backpressure:
+ * first call returns false to signal buffer is full, then emit 'drain'
+ * when `once('drain', cb)` is registered.
+ */
+function mockBackpressure() {
+  const chunks: string[] = [];
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  const originalOnce = process.stdout.once.bind(process.stdout);
+
+  let drainHandler: (() => void) | null = null;
+  let drained = false;
+
+  process.stdout.write = mock((chunk: string | Uint8Array) => {
+    chunks.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+    return false;
+  }) as unknown as WriteFn;
+
+  process.stdout.once = mock((event: string, cb: () => void) => {
+    if (event === "drain") {
+      drainHandler = cb;
+      setImmediate(() => {
+        drained = true;
+        drainHandler?.();
+      });
+    }
+    return process.stdout;
+  }) as unknown as OnceFn;
+
+  return {
+    chunks,
+    get drained() {
+      return drained;
+    },
+    restore: () => {
+      process.stdout.write = originalWrite;
+      process.stdout.once = originalOnce;
+    },
+  };
+}
+
+describe("writeJson", () => {
+  it("writes pretty-printed JSON with a trailing newline", async () => {
+    const bp = mockBackpressure();
+    try {
+      await writeJson({ a: 1, b: [2, 3] });
+      expect(bp.chunks.join("")).toBe('{\n  "a": 1,\n  "b": [\n    2,\n    3\n  ]\n}\n');
+    } finally {
+      bp.restore();
+    }
+  });
+
+  it("awaits drain when stdout signals backpressure", async () => {
+    const bp = mockBackpressure();
+    try {
+      await writeJson({ big: "x".repeat(100) });
+      expect(bp.drained).toBe(true);
+    } finally {
+      bp.restore();
+    }
+  });
+});
+
+describe("writeJsonLine", () => {
+  it("writes compact JSON with a trailing newline", async () => {
+    const bp = mockBackpressure();
+    try {
+      await writeJsonLine({ a: 1, b: 2 });
+      expect(bp.chunks.join("")).toBe('{"a":1,"b":2}\n');
+    } finally {
+      bp.restore();
+    }
+  });
+
+  it("awaits drain when stdout signals backpressure", async () => {
+    const bp = mockBackpressure();
+    try {
+      await writeJsonLine({ big: "x".repeat(100) });
+      expect(bp.drained).toBe(true);
+    } finally {
+      bp.restore();
+    }
+  });
+});
+
+describe("integration: large payloads write completely", () => {
+  it("emits ~300 KB of JSON without truncation when stdout applies backpressure", async () => {
+    const bp = mockBackpressure();
+    try {
+      // Build a ~200 KB fixture — larger than the 96 KB pipe buffer that causes
+      // the real-world truncation, ensuring the drain path is exercised.
+      const payload = Array.from({ length: 800 }, (_, i) => ({
+        id: `rel_${i.toString().padStart(6, "0")}`,
+        title: `Release ${i}`,
+        body: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. ".repeat(4),
+      }));
+      const expected = JSON.stringify(payload, null, 2) + "\n";
+      expect(expected.length).toBeGreaterThan(150_000);
+
+      await writeJson(payload);
+      const written = bp.chunks.join("");
+      expect(written.length).toBe(expected.length);
+      expect(written).toBe(expected);
+    } finally {
+      bp.restore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Large `--json` outputs were being truncated at ~96 KB when piped to another process (`jq`, `cat`, `grep`, etc.). Writing to a file worked. This made every JSON-piped workflow randomly fail once a dataset grew, forcing callers (agents especially) to reroute through temp files.

## Root cause

Node/Bun's `process.stdout.write` is non-blocking when connected to a pipe, and returns `false` once the internal buffer (~96 KB) fills. `console.log` doesn't await `drain`, so if the CLI process exited before the kernel pipe buffer had drained, tail bytes were silently dropped. This manifested as cryptic `Unfinished JSON term at EOF` errors from `jq`.

Every `--json` branch in the CLI used `console.log(JSON.stringify(..., null, 2))` — so every one of them had the bug.

## Fix

- New `src/lib/output.ts` with:
  - `writeJson(value)` — pretty-printed JSON + newline; awaits `drain` when `write` returns `false`
  - `writeJsonLine(value)` — compact single-line JSON + newline (for NDJSON streaming in `tail --follow`)
- Swept all 75 call sites across 20 command files to use the helpers.
- Four Commander `action` callbacks and two helper functions that newly use `await` were made `async`.
- Added `.worktrees/` to `.gitignore` so agent worktrees don't leak into git status.

## Test plan

- [x] New unit tests (`tests/unit/output.test.ts`): 5 cases covering content correctness, `drain` await behavior under simulated backpressure, and a ~200 KB fixture to verify no truncation.
- [x] Full suite: `bun test` — 196 pass.
- [x] Typecheck clean: `bun run typecheck`.
- [x] Lint: `bun run lint` — 0 errors (3 new `no-await-in-loop` warnings are intentional — stdout ordering and backpressure require sequential writes in the NDJSON `tail --follow` path).

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)
