### PR TITLE
Clean up oxlint warnings

### DIFF
--- a/scripts/sync-plugin-skills.ts
+++ b/scripts/sync-plugin-skills.ts
@@ -113,8 +113,8 @@ function refsEqual(sourceDir: string, destDir: string): boolean {
   if (!hasSource && !hasDest) return true;
   if (hasSource !== hasDest) return false;
 
-  const sourceFiles = readdirSync(sourceDir).sort();
-  const destFiles = readdirSync(destDir).sort();
+  const sourceFiles = readdirSync(sourceDir).toSorted();
+  const destFiles = readdirSync(destDir).toSorted();
   if (sourceFiles.length !== destFiles.length) return false;
 
   for (let i = 0; i < sourceFiles.length; i++) {

--- a/src/cli/commands/add.ts
+++ b/src/cli/commands/add.ts
@@ -229,7 +229,10 @@ Examples:
           const results: AddSourceResult[] = [];
           let hasError = false;
 
+          // Sequential to avoid racing on shared org lookup-or-create for entries
+          // referencing the same org.
           for (const entry of entries) {
+            // eslint-disable-next-line no-await-in-loop
             const result = await addSingleSource({ ...entry, batch: true });
             results.push(result);
 

--- a/src/cli/commands/admin/embed.ts
+++ b/src/cli/commands/admin/embed.ts
@@ -22,6 +22,11 @@ import { writeJson } from "../../../lib/output.js";
 /** Worker batch cap — must stay in sync with BATCH_CAP on the API worker. */
 const ENDPOINT_BATCH_CAP = 50;
 
+function fmt(embedded: number, total: number): string {
+  const pct = total === 0 ? 100 : Math.round((embedded / total) * 100);
+  return `${embedded}/${total} (${pct}%)`;
+}
+
 interface LoopOptions {
   json?: boolean;
   dryRun?: boolean;
@@ -59,16 +64,19 @@ async function runBackfillLoop(
     dryRun,
   };
 
+  // Paginated batches — each call depends on `remaining` from the previous response.
   while (summary.totalProcessed < userLimit) {
     const remainingUserBudget = userLimit - summary.totalProcessed;
     const perCallLimit = Math.min(ENDPOINT_BATCH_CAP, remainingUserBudget);
 
     let result: EmbedBackfillResponse;
     try {
+      // eslint-disable-next-line no-await-in-loop
       result = await callEndpoint(perCallLimit);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       if (opts.json) {
+        // eslint-disable-next-line no-await-in-loop
         await writeJson({ ok: false, label, error: msg, ...summary });
       } else {
         logger.error(`  Batch ${summary.batches + 1} failed: ${msg}`);
@@ -194,11 +202,6 @@ export function registerEmbedCommand(parent: Command): void {
         await writeJson(status);
         return;
       }
-
-      const fmt = (embedded: number, total: number) => {
-        const pct = total === 0 ? 100 : Math.round((embedded / total) * 100);
-        return `${embedded}/${total} (${pct}%)`;
-      };
 
       console.log(chalk.bold("Semantic search backfill status"));
       console.log("");

--- a/src/cli/commands/import.ts
+++ b/src/cli/commands/import.ts
@@ -217,6 +217,7 @@ export function registerImportCommand(program: Command) {
             const orgSlug = orgEntry.slug ?? toSlug(orgEntry.name);
 
             if (opts.dryRun) {
+              // eslint-disable-next-line no-await-in-loop
               const existing = await findOrg(orgSlug);
               if (existing) {
                 if (!opts.json)
@@ -299,12 +300,15 @@ export function registerImportCommand(program: Command) {
               continue;
             }
 
+            // Org creation gates subsequent product/source creation — sequential by design.
+            // eslint-disable-next-line no-await-in-loop
             let org = await findOrg(orgSlug);
             if (org) {
               if (!opts.json)
                 logger.info(chalk.yellow(`Org already exists: ${org.name} (${org.slug})`));
             } else {
               try {
+                // eslint-disable-next-line no-await-in-loop
                 org = await createOrg(orgEntry.name, {
                   slug: orgSlug,
                   domain: orgEntry.domain,
@@ -320,12 +324,14 @@ export function registerImportCommand(program: Command) {
                 continue;
               }
               if (orgEntry.tags && orgEntry.tags.length > 0) {
+                // eslint-disable-next-line no-await-in-loop
                 await addTagsToOrg(org.id, orgEntry.tags);
               }
             }
 
             if (orgEntry.accounts) {
               for (const acc of orgEntry.accounts) {
+                // eslint-disable-next-line no-await-in-loop
                 const existing = await getOrgAccountByPlatform(org.id, acc.platform);
                 if (existing) {
                   if (!opts.json)
@@ -334,6 +340,7 @@ export function registerImportCommand(program: Command) {
                     );
                 } else {
                   try {
+                    // eslint-disable-next-line no-await-in-loop
                     await linkOrgAccount(org.slug, acc.platform, acc.handle);
                     report.created.accounts++;
                     if (!opts.json)
@@ -352,6 +359,8 @@ export function registerImportCommand(program: Command) {
             if (orgEntry.products) {
               for (const prodEntry of orgEntry.products) {
                 const prodSlug = prodEntry.slug ?? toSlug(prodEntry.name);
+                // Product creation gates child source creation — sequential by design.
+                // eslint-disable-next-line no-await-in-loop
                 let prod = await findProduct(prodSlug);
 
                 if (prod) {
@@ -361,6 +370,7 @@ export function registerImportCommand(program: Command) {
                     );
                 } else {
                   try {
+                    // eslint-disable-next-line no-await-in-loop
                     prod = await createProduct(org.id, prodEntry.name, {
                       slug: prodSlug,
                       url: prodEntry.url,
@@ -379,6 +389,7 @@ export function registerImportCommand(program: Command) {
                     continue;
                   }
                   if (prodEntry.tags && prodEntry.tags.length > 0) {
+                    // eslint-disable-next-line no-await-in-loop
                     await addTagsToProduct(prod.id, prodEntry.tags);
                   }
                 }
@@ -402,6 +413,7 @@ export function registerImportCommand(program: Command) {
                     const srcType = resolveSourceType(srcEntry);
 
                     try {
+                      // eslint-disable-next-line no-await-in-loop
                       await createSource({
                         name: srcEntry.name,
                         slug: srcSlug,
@@ -446,6 +458,7 @@ export function registerImportCommand(program: Command) {
                 const srcType = resolveSourceType(srcEntry);
 
                 try {
+                  // eslint-disable-next-line no-await-in-loop
                   await createSource({
                     name: srcEntry.name,
                     slug: srcSlug,
@@ -507,6 +520,7 @@ export function registerImportCommand(program: Command) {
             }
 
             try {
+              // eslint-disable-next-line no-await-in-loop
               await createSource({
                 name: srcEntry.name,
                 slug: srcSlug,

--- a/src/cli/commands/onboard-apply.ts
+++ b/src/cli/commands/onboard-apply.ts
@@ -97,7 +97,10 @@ export function registerOnboardApplyCommand(onboardCmd: Command) {
 
       const results: ApplyResult[] = [];
 
+      // Sequential to avoid racing on shared org/product lookup-or-create
+      // across sources that belong to the same parent entity.
       for (const source of state.sources) {
+        // eslint-disable-next-line no-await-in-loop
         const result = await applySource(source, orgId);
         results.push(result);
 

--- a/src/cli/commands/onboard.ts
+++ b/src/cli/commands/onboard.ts
@@ -101,7 +101,9 @@ async function runRemoteDiscovery(
   const startTime = Date.now();
   let lastStep = "";
 
+  // Polling loop — each tick depends on the prior sleep + status fetch.
   while (Date.now() - startTime < MAX_POLL_TIME) {
+    // eslint-disable-next-line no-await-in-loop
     await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL));
 
     let status: {
@@ -116,6 +118,7 @@ async function runRemoteDiscovery(
       error?: string;
     };
     try {
+      // eslint-disable-next-line no-await-in-loop
       status = await apiFetch(`/v1/discover/${sessionId}`);
     } catch (err) {
       logger.error(`Failed to poll status: ${err instanceof Error ? err.message : String(err)}`);
@@ -127,6 +130,7 @@ async function runRemoteDiscovery(
 
       if (status.result) {
         if (opts.json) {
+          // eslint-disable-next-line no-await-in-loop
           await writeJson(status.result);
           return;
         }
@@ -168,9 +172,12 @@ async function runRemoteDiscovery(
   process.exit(1);
 }
 
+function write(s: string): void {
+  process.stderr.write(s + "\n");
+}
+
 function printSummary(state: DiscoveryState): void {
   const { sources } = state;
-  const write = (s: string) => process.stderr.write(s + "\n");
 
   write("");
   write(chalk.bold(`Discovery results for ${state.product}`));

--- a/src/cli/commands/org.ts
+++ b/src/cli/commands/org.ts
@@ -503,19 +503,21 @@ Examples:
       const found = await findOrg(identifier);
       if (!found) return orgNotFound(identifier);
 
-      const results = [];
-      for (const domain of domains) {
-        try {
-          const created = await addDomainAlias(domain, { orgId: found.id });
-          results.push(created);
-        } catch (err) {
-          logger.error(
-            chalk.red(
-              `Failed to add alias "${domain}": ${err instanceof Error ? err.message : err}`,
-            ),
-          );
-        }
-      }
+      const settled = await Promise.all(
+        domains.map(async (domain) => {
+          try {
+            return await addDomainAlias(domain, { orgId: found.id });
+          } catch (err) {
+            logger.error(
+              chalk.red(
+                `Failed to add alias "${domain}": ${err instanceof Error ? err.message : err}`,
+              ),
+            );
+            return null;
+          }
+        }),
+      );
+      const results = settled.filter((r): r is NonNullable<typeof r> => r !== null);
 
       if (opts.json) await writeJson(results);
       else
@@ -533,9 +535,11 @@ Examples:
       const found = await findOrg(identifier);
       if (!found) return orgNotFound(identifier);
 
-      const removed = [];
-      for (const domain of domains) {
-        const ok = await removeDomainAlias(domain);
+      const results = await Promise.all(
+        domains.map(async (domain) => ({ domain, ok: await removeDomainAlias(domain) })),
+      );
+      const removed: string[] = [];
+      for (const { domain, ok } of results) {
         if (ok) removed.push(domain);
         else console.error(chalk.yellow(`Alias "${domain}" not found.`));
       }

--- a/src/cli/commands/product.ts
+++ b/src/cli/commands/product.ts
@@ -296,18 +296,22 @@ export function registerProductCommand(program: Command) {
           description: sourceOrg.description ?? undefined,
         });
 
-        for (const source of sources) {
-          await updateSource(source.slug, { orgId: targetOrg.id, productId: created.id });
-        }
+        await Promise.all(
+          sources.map((source) =>
+            updateSource(source.slug, { orgId: targetOrg.id, productId: created.id }),
+          ),
+        );
 
         const accounts = await getOrgAccountsBySlug(sourceOrg.slug);
-        for (const acct of accounts) {
-          try {
-            await linkOrgAccount(targetOrg.slug, acct.platform, acct.handle);
-          } catch {
-            /* skip duplicates */
-          }
-        }
+        await Promise.all(
+          accounts.map(async (acct) => {
+            try {
+              await linkOrgAccount(targetOrg.slug, acct.platform, acct.handle);
+            } catch {
+              /* skip duplicates */
+            }
+          }),
+        );
 
         await removeOrg(sourceOrg.slug);
 
@@ -414,19 +418,21 @@ export function registerProductCommand(program: Command) {
         process.exit(1);
       }
 
-      const results = [];
-      for (const domain of domains) {
-        try {
-          const created = await addDomainAlias(domain, { productId: found.id });
-          results.push(created);
-        } catch (err) {
-          console.error(
-            chalk.red(
-              `Failed to add alias "${domain}": ${err instanceof Error ? err.message : err}`,
-            ),
-          );
-        }
-      }
+      const settled = await Promise.all(
+        domains.map(async (domain) => {
+          try {
+            return await addDomainAlias(domain, { productId: found.id });
+          } catch (err) {
+            console.error(
+              chalk.red(
+                `Failed to add alias "${domain}": ${err instanceof Error ? err.message : err}`,
+              ),
+            );
+            return null;
+          }
+        }),
+      );
+      const results = settled.filter((r): r is NonNullable<typeof r> => r !== null);
 
       if (opts.json) await writeJson(results);
       else
@@ -447,9 +453,11 @@ export function registerProductCommand(program: Command) {
         process.exit(1);
       }
 
-      const removed = [];
-      for (const domain of domains) {
-        const ok = await removeDomainAlias(domain);
+      const results = await Promise.all(
+        domains.map(async (domain) => ({ domain, ok: await removeDomainAlias(domain) })),
+      );
+      const removed: string[] = [];
+      for (const { domain, ok } of results) {
         if (ok) removed.push(domain);
         else console.error(chalk.yellow(`Alias "${domain}" not found.`));
       }

--- a/src/cli/commands/remove.ts
+++ b/src/cli/commands/remove.ts
@@ -60,19 +60,22 @@ export function registerRemoveCommand(program: Command) {
         }
 
         if (opts.ignore && existing.length > 0) {
-          for (const source of existing) {
-            if (!source.orgId) {
-              if (!opts.json) {
-                logger.warn(
-                  chalk.yellow(
-                    `Cannot ignore ${source.url} — source has no organization. Use 'block add' for global blocking.`,
-                  ),
-                );
-              }
-              continue;
-            }
-            await addIgnoredUrl(source.url, source.orgId, opts.reason);
+          const ignorable = existing.filter((source) => {
+            if (source.orgId) return true;
             if (!opts.json) {
+              logger.warn(
+                chalk.yellow(
+                  `Cannot ignore ${source.url} — source has no organization. Use 'block add' for global blocking.`,
+                ),
+              );
+            }
+            return false;
+          });
+          await Promise.all(
+            ignorable.map((source) => addIgnoredUrl(source.url, source.orgId!, opts.reason)),
+          );
+          if (!opts.json) {
+            for (const source of ignorable) {
               logger.info(
                 chalk.yellow(`Ignored URL: ${source.url}${opts.reason ? ` (${opts.reason})` : ""}`),
               );

--- a/src/cli/commands/tail.ts
+++ b/src/cli/commands/tail.ts
@@ -96,7 +96,7 @@ Examples:
         } else if (rows.length === 0) {
           console.log(chalk.yellow("No releases found."));
         } else if (opts.follow) {
-          for (const row of rows.slice().reverse()) {
+          for (const row of rows.toReversed()) {
             console.log(renderStreamLine(row));
           }
         } else {
@@ -120,8 +120,11 @@ Examples:
         );
         console.error(chalk.dim(`\n  Following (every ${intervalSeconds}s). Ctrl-C to stop.`));
 
+        // Polling loop — each tick depends on the previous sleep + fetch.
         while (true) {
+          // eslint-disable-next-line no-await-in-loop
           await sleep(intervalSeconds * 1000);
+          // eslint-disable-next-line no-await-in-loop
           const fresh = await getLatestReleases(fetchOpts);
           const novel = fresh.filter((r) => !seen.has(r.id));
           if (novel.length === 0) continue;
@@ -130,8 +133,10 @@ Examples:
             seen,
             novel.map((r) => r.id),
           );
-          const ordered = novel.slice().reverse();
+          const ordered = novel.toReversed();
           if (opts.json) {
+            // Preserve stream ordering; writes must land in order.
+            // eslint-disable-next-line no-await-in-loop
             for (const row of ordered) await writeJsonLine(row);
           } else {
             for (const row of ordered) console.log(renderStreamLine(row));

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,9 +58,9 @@ gateAdminArgv(argv);
 
 validateConfig();
 
-function telemetryCommandName(argv: string[]): string {
-  const args = argv.slice(2).filter((a) => !a.startsWith("-"));
-  const name = args.slice(0, 3).join(" ");
+function telemetryCommandName(args: string[]): string {
+  const positional = args.slice(2).filter((a) => !a.startsWith("-"));
+  const name = positional.slice(0, 3).join(" ");
   return name || "(root)";
 }
 

--- a/tests/unit/api-client.test.ts
+++ b/tests/unit/api-client.test.ts
@@ -10,6 +10,14 @@ mock.module("../../src/lib/mode.js", () => ({
 
 const client = await import("../../src/api/client.js");
 
+function mockFetch(status: number, body: unknown = null) {
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    })) as any;
+}
+
 // ---------------------------------------------------------------------------
 // apiFetch 404 behavior — GET vs mutating methods
 // ---------------------------------------------------------------------------
@@ -24,14 +32,6 @@ describe("apiFetch 404 handling", () => {
   afterEach(() => {
     globalThis.fetch = originalFetch;
   });
-
-  function mockFetch(status: number, body: unknown = null) {
-    globalThis.fetch = (async () =>
-      new Response(JSON.stringify(body), {
-        status,
-        headers: { "Content-Type": "application/json" },
-      })) as any;
-  }
 
   it("returns null for GET 404 (findSource)", async () => {
     mockFetch(404);


### PR DESCRIPTION
## Summary
- Clears all 37 oxlint warnings (0 remaining after `bun run lint`).
- Parallelizes independent API calls with `Promise.all` where safe: org/product domain-alias add/remove, product source re-homing + account linking, and the ignored-URL batch in `remove`.
- Replaces mutating `.sort()`/`.slice().reverse()` with `toSorted()`/`toReversed()`, renames the `argv` shadow in `src/index.ts`, and hoists three inner helpers with no closure (`fmt`, `write`, `mockFetch`) to module scope.
- For the remaining sequential awaits — polling loops (`tail`, `onboard`), the paginated embed backfill (state flows between calls), and the `import`/`add`/`onboard-apply` flows where org → product → source creation must stay ordered to avoid racing on shared parent entities — adds targeted `// eslint-disable-next-line no-await-in-loop` with a short why-sequential note so new violations elsewhere still get flagged.

## Test plan
- [x] `bun run lint` → 0 warnings, 0 errors
- [x] `bun run typecheck` → clean
- [x] `bun test` → 196 pass, 0 fail
- [x] `prettier --check` on changed files → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)