### PR TITLE
feat(admin): add discovery evaluate subcommand, drop stale discover alias

### DIFF
--- a/.changeset/admin-discovery-evaluate.md
+++ b/.changeset/admin-discovery-evaluate.md
@@ -1,0 +1,17 @@
+---
+"@buildinternet/releases": minor
+"@buildinternet/releases-darwin-arm64": minor
+"@buildinternet/releases-darwin-x64": minor
+"@buildinternet/releases-linux-arm64": minor
+"@buildinternet/releases-linux-x64": minor
+"@buildinternet/releases-lib": minor
+"@buildinternet/releases-skills": minor
+---
+
+**`releases admin discovery evaluate <url>` is back**
+
+Ships the missing thin wrapper around `GET /v1/evaluate?url=...`, returning the AI-backed ingestion recommendation (method, feed URL, provider, confidence, alternatives). Supports `--json` for piping into `jq`. Mirrors the typed MCP `evaluate_url` tool.
+
+The legacy top-level alias `releases evaluate <url>` still resolves to this subcommand (with a deprecation warning).
+
+The stale `discover` entry in the legacy alias table has been removed — it pointed to a subcommand that never existed, and the API's `POST /v1/discover` is already covered by `releases admin discovery onboard`. The one in-repo docs reference has been updated.

--- a/plugins/claude/releases/skills/releases-cli/references/admin.md
+++ b/plugins/claude/releases/skills/releases-cli/references/admin.md
@@ -158,7 +158,7 @@ AI-powered onboarding for whole companies:
 ```bash
 releases admin discovery onboard "Vercel"
 releases admin discovery onboard "Stripe" --domain stripe.com --github-org stripe
-releases admin discovery discover vercel.com --verify --add
+releases admin discovery evaluate https://linear.app/changelog --json
 releases admin discovery task list                # in-flight discovery sessions
 releases admin discovery task cancel <sessionId>
 ```

--- a/skills/releases-cli/references/admin.md
+++ b/skills/releases-cli/references/admin.md
@@ -158,7 +158,7 @@ AI-powered onboarding for whole companies:
 ```bash
 releases admin discovery onboard "Vercel"
 releases admin discovery onboard "Stripe" --domain stripe.com --github-org stripe
-releases admin discovery discover vercel.com --verify --add
+releases admin discovery evaluate https://linear.app/changelog --json
 releases admin discovery task list                # in-flight discovery sessions
 releases admin discovery task cancel <sessionId>
 ```

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -29,6 +29,7 @@ import type {
   Session,
   EmbedBackfillResponse,
   EmbedStatusResponse,
+  EvaluationResult,
   MediaItem,
 } from "./types.js";
 import type { ListResponse } from "@buildinternet/releases-core/cli-contracts";
@@ -44,6 +45,7 @@ export type {
   Session,
   EmbedBackfillResponse,
   EmbedStatusResponse,
+  EvaluationResult,
   Stats,
   SourceListItem,
 } from "./types.js";
@@ -896,6 +898,12 @@ export async function cancelSession(sessionId: string): Promise<{ ok: boolean; e
   return apiFetch<{ ok: boolean; error?: string }>(`/v1/sessions/${sessionId}/cancel`, {
     method: "POST",
   });
+}
+
+// ── URL evaluation (admin-only) ──
+
+export async function evaluateUrl(url: string): Promise<EvaluationResult> {
+  return apiFetch<EvaluationResult>(`/v1/evaluate?url=${encodeURIComponent(url)}`);
 }
 
 // ── Semantic search backfill (admin-only) ──

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -657,3 +657,16 @@ export interface EmbedStatusResponse {
   };
   chunks: { total: number; embedded: number; unembedded: number };
 }
+
+export interface EvaluationResult {
+  recommendedMethod: "feed" | "github" | "markdown" | "scrape" | "crawl";
+  recommendedUrl: string;
+  feedUrl?: string;
+  feedType?: "rss" | "atom" | "jsonfeed";
+  githubRepo?: string;
+  pageStructure: "single-page" | "index" | "unknown";
+  alternatives: Array<{ url: string; method: string; note: string }>;
+  confidence: "high" | "medium" | "low";
+  provider?: string;
+  notes?: string;
+}

--- a/src/cli/commands/admin/evaluate.ts
+++ b/src/cli/commands/admin/evaluate.ts
@@ -1,0 +1,72 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { logger } from "@releases/lib/logger";
+import * as apiClient from "../../../api/client.js";
+import { writeJson } from "../../../lib/output.js";
+
+interface EvaluateOpts {
+  json?: boolean;
+}
+
+export function registerEvaluateCommand(program: Command) {
+  program
+    .command("evaluate")
+    .description("Evaluate a URL for best changelog ingestion method")
+    .argument("<url>", "URL to evaluate")
+    .option("--json", "Output as JSON")
+    .action(async (url: string, opts: EvaluateOpts) => {
+      try {
+        void new URL(url);
+      } catch {
+        logger.error(`Invalid URL: ${url}`);
+        process.exit(1);
+      }
+
+      const result = await apiClient.evaluateUrl(url);
+
+      if (opts.json) {
+        await writeJson(result);
+        return;
+      }
+
+      const confColor =
+        result.confidence === "high"
+          ? chalk.green
+          : result.confidence === "medium"
+            ? chalk.yellow
+            : chalk.gray;
+
+      console.log();
+      console.log(`  ${chalk.bold("Method")}    ${result.recommendedMethod}`);
+      console.log(`  ${chalk.bold("URL")}       ${result.recommendedUrl}`);
+      if (result.feedUrl) {
+        console.log(
+          `  ${chalk.bold("Feed")}      ${result.feedUrl}` +
+            chalk.gray(` (${result.feedType ?? "feed"})`),
+        );
+      }
+      if (result.githubRepo) {
+        console.log(`  ${chalk.bold("GitHub")}    ${result.githubRepo}`);
+      }
+      if (result.provider) {
+        console.log(`  ${chalk.bold("Provider")}  ${result.provider}`);
+      }
+      console.log(`  ${chalk.bold("Structure")} ${result.pageStructure}`);
+      console.log(`  ${chalk.bold("Confidence")} ${confColor(result.confidence)}`);
+
+      if (result.alternatives.length > 0) {
+        console.log();
+        console.log(chalk.bold("  Alternatives"));
+        for (const alt of result.alternatives) {
+          console.log(`    ${chalk.gray("•")} ${alt.method.padEnd(8)} ${alt.url}`);
+          if (alt.note) console.log(`      ${chalk.gray(alt.note)}`);
+        }
+      }
+
+      if (result.notes) {
+        console.log();
+        console.log(chalk.gray(`  ${result.notes}`));
+      }
+      console.log();
+    });
+}

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -22,6 +22,7 @@ import { registerTaskCommand } from "./commands/task.js";
 import { registerChangelogCommand } from "./commands/changelog.js";
 import { registerShowCommand } from "./commands/show.js";
 import { registerEmbedCommand } from "./commands/admin/embed.js";
+import { registerEvaluateCommand } from "./commands/admin/evaluate.js";
 import { registerTelemetryCommand } from "./commands/telemetry.js";
 import { registerServeCommand } from "./commands/serve.js";
 import { registerWhoamiCommand } from "./commands/whoami.js";
@@ -191,6 +192,7 @@ const discoveryAdmin = admin
   .description("Run onboarding and remote session workflows");
 registerOnboardCommand(discoveryAdmin);
 registerTaskCommand(discoveryAdmin);
+registerEvaluateCommand(discoveryAdmin);
 
 const policyAdmin = admin.command("policy").description("Manage ignored URLs and blocked URLs");
 registerIgnoreCommand(policyAdmin);

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,6 @@ const LEGACY_COMMAND_ALIASES: Record<string, string[]> = {
   fetch: ["admin", "source", "fetch"],
   "fetch-log": ["admin", "source", "fetch-log"],
   poll: ["admin", "source", "poll"],
-  discover: ["admin", "discovery", "discover"],
   evaluate: ["admin", "discovery", "evaluate"],
   org: ["admin", "org"],
   product: ["admin", "product"],


### PR DESCRIPTION
## Summary

- Adds `releases admin discovery evaluate <url>` — the missing thin wrapper around `GET /v1/evaluate?url=...`. Returns the AI-backed ingestion recommendation (method, feed URL, provider, confidence, alternatives).
- Removes the `discover` entry from `LEGACY_COMMAND_ALIASES` — it pointed to a non-existent `admin discovery discover` subcommand, and the API's `POST /v1/discover` is already covered by `admin discovery onboard`. Also updates the one docs reference that mentioned it.
- Exports `EvaluationResult` from the shared types and adds `evaluateUrl()` to the API client.

## Why

Closes #38. The original consolidation plan ([buildinternet/releases#370](https://github.com/buildinternet/releases/issues/370)) deleted these commands from the monorepo's private CLI but never tracked whether the OSS CLI should ship thin API-backed replacements. Skills in both repos kept documenting `admin discovery evaluate` as a working command, and the legacy alias table kept pointing at subcommands that didn't exist. This ships the one that's genuinely useful and prunes the other.

## Verification

```console
$ releases admin discovery evaluate https://linear.app/changelog

  Method    feed
  URL       https://linear.app/rss/changelog.json
  Feed      https://linear.app/rss/changelog.json (jsonfeed)
  Structure unknown
  Confidence high

  Resolved from automated pre-checks

$ releases admin discovery evaluate https://linear.app/changelog --json
{
  "recommendedMethod": "feed",
  "recommendedUrl": "https://linear.app/rss/changelog.json",
  ...
}

$ releases evaluate https://linear.app/changelog --json
[releases] WARN: The top-level "evaluate" command is deprecated. Use "releases admin discovery evaluate" instead.
{ ... }
```

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `bun run lint` — 0 warnings, 0 errors
- [x] Command works against production API with an admin key (human + JSON output modes)
- [x] Legacy top-level `releases evaluate <url>` alias still works with deprecation warning
- [x] Legacy top-level `releases discover <domain>` alias is gone (was broken anyway — pointed at a non-existent subcommand)

## Follow-ups

- The monorepo's mirrored skill files (`src/agent/skills/finding-changelogs`, `src/agent/skills/managing-sources`, plus plugin copies and `web/src/content/docs/cli/admin.md`) all reference `releases admin discovery evaluate` — they'll be accurate once this ships. No code changes needed there; can confirm via grep once this merges.

Closes #38
