### PR TITLE
feat(admin): restore playbook command (read + --notes)

### DIFF
--- a/.changeset/admin-playbook.md
+++ b/.changeset/admin-playbook.md
@@ -1,0 +1,21 @@
+---
+"@buildinternet/releases": minor
+"@buildinternet/releases-darwin-arm64": minor
+"@buildinternet/releases-darwin-x64": minor
+"@buildinternet/releases-linux-arm64": minor
+"@buildinternet/releases-linux-x64": minor
+"@buildinternet/releases-lib": minor
+"@buildinternet/releases-skills": minor
+---
+
+**`releases admin playbook <org>` is back**
+
+Ships the missing CLI wrapper for reading and updating an organization's playbook. Same shape as the old monorepo command, flattened from `admin content playbook` to `admin playbook` (no other live inhabitants of the `admin content` subgroup remain).
+
+- `releases admin playbook <org>` — read the assembled playbook (header + agent notes)
+- `releases admin playbook <org> --json` — JSON output
+- `releases admin playbook <org> --notes "..."` — replace agent notes; seeds a fresh header on first write
+
+The old `--regenerate` flag is not being ported. It called deterministic logic (no AI) that already runs automatically via `waitUntil` after every source add/edit/remove, and the `--notes` PATCH route auto-seeds a fresh header if no playbook exists yet.
+
+Closes buildinternet/releases#246.

--- a/src/cli/commands/admin/playbook.ts
+++ b/src/cli/commands/admin/playbook.ts
@@ -1,0 +1,90 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { logger } from "@releases/lib/logger";
+import { getPlaybook, updatePlaybookNotes } from "../../../api/client.js";
+import { stripAnsi } from "../../../lib/sanitize.js";
+import { writeJson } from "../../../lib/output.js";
+import { timeAgo } from "@buildinternet/releases-core/dates";
+
+interface PlaybookOpts {
+  json?: boolean;
+  notes?: string;
+}
+
+export function registerPlaybookCommand(program: Command) {
+  program
+    .command("playbook")
+    .description("Read or update an organization's playbook")
+    .argument("<org>", "Organization slug or ID")
+    .option("--json", "Output as JSON")
+    .option("--notes <text>", "Replace agent notes (pass full notes content)")
+    .addHelpText(
+      "after",
+      `
+Examples:
+  releases admin playbook vercel
+  releases admin playbook vercel --json
+  releases admin playbook vercel --notes "### Fetch instructions\\n..."
+
+The playbook's header (source list, products) regenerates automatically after
+any source add/edit/remove — no manual regenerate step is needed. The PATCH
+run by --notes also seeds a fresh header on first write.`,
+    )
+    .action(async (orgIdentifier: string, opts: PlaybookOpts) => {
+      if (opts.notes !== undefined) {
+        try {
+          await updatePlaybookNotes(orgIdentifier, opts.notes);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          logger.error(`Failed to update playbook notes: ${msg}`);
+          process.exit(1);
+        }
+        if (opts.json) {
+          await writeJson({ org: orgIdentifier, notesUpdated: true });
+        } else {
+          console.log(chalk.green(`Notes updated for ${orgIdentifier} playbook.`));
+        }
+        return;
+      }
+
+      const playbook = await getPlaybook(orgIdentifier).catch(() => null);
+
+      if (!playbook) {
+        if (opts.json) {
+          await writeJson({ org: orgIdentifier, playbook: null });
+        } else {
+          console.log(
+            chalk.yellow(
+              `No playbook available for ${orgIdentifier}. ` +
+                `A playbook is auto-created on the first source add/edit/remove, ` +
+                `or when you attach notes with --notes.`,
+            ),
+          );
+        }
+        return;
+      }
+
+      if (opts.json) {
+        await writeJson({
+          org: orgIdentifier,
+          content: playbook.content,
+          notes: playbook.notes ?? null,
+          releaseCount: playbook.releaseCount,
+          generatedAt: playbook.generatedAt,
+          updatedAt: playbook.updatedAt,
+        });
+        return;
+      }
+
+      const ageLabel = playbook.generatedAt ? (timeAgo(playbook.generatedAt) ?? "?") : "?";
+      console.log(chalk.bold(`${orgIdentifier} — playbook`));
+      console.log(chalk.dim(`  generated ${ageLabel} · ${playbook.releaseCount} sources`));
+      console.log();
+      console.log(stripAnsi(playbook.content));
+      if (playbook.notes) {
+        console.log();
+        console.log(chalk.dim("─── Agent notes ───"));
+        console.log(stripAnsi(playbook.notes));
+      }
+    });
+}

--- a/src/cli/commands/admin/playbook.ts
+++ b/src/cli/commands/admin/playbook.ts
@@ -1,8 +1,7 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { logger } from "@releases/lib/logger";
-import { getPlaybook, updatePlaybookNotes } from "../../../api/client.js";
-import { stripAnsi } from "../../../lib/sanitize.js";
+import { findOrg, getPlaybook, updatePlaybookNotes } from "../../../api/client.js";
+import { orgNotFound } from "../../suggest.js";
 import { writeJson } from "../../../lib/output.js";
 import { timeAgo } from "@buildinternet/releases-core/dates";
 
@@ -17,7 +16,7 @@ export function registerPlaybookCommand(program: Command) {
     .description("Read or update an organization's playbook")
     .argument("<org>", "Organization slug or ID")
     .option("--json", "Output as JSON")
-    .option("--notes <text>", "Replace agent notes (pass full notes content)")
+    .option("--notes <text>", "Replace agent notes (pass full notes content; empty string clears)")
     .addHelpText(
       "after",
       `
@@ -31,42 +30,33 @@ any source add/edit/remove — no manual regenerate step is needed. The PATCH
 run by --notes also seeds a fresh header on first write.`,
     )
     .action(async (orgIdentifier: string, opts: PlaybookOpts) => {
+      const org = await findOrg(orgIdentifier);
+      if (!org) return orgNotFound(orgIdentifier);
+
       if (opts.notes !== undefined) {
-        try {
-          await updatePlaybookNotes(orgIdentifier, opts.notes);
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          logger.error(`Failed to update playbook notes: ${msg}`);
-          process.exit(1);
-        }
+        await updatePlaybookNotes(org.slug, opts.notes);
         if (opts.json) {
-          await writeJson({ org: orgIdentifier, notesUpdated: true });
+          await writeJson({ org: org.slug, notesUpdated: true });
         } else {
-          console.log(chalk.green(`Notes updated for ${orgIdentifier} playbook.`));
+          console.log(chalk.green(`Notes updated for ${org.name} playbook.`));
         }
         return;
       }
 
-      const playbook = await getPlaybook(orgIdentifier).catch(() => null);
+      const playbook = await getPlaybook(org.slug);
 
       if (!playbook) {
         if (opts.json) {
-          await writeJson({ org: orgIdentifier, playbook: null });
+          await writeJson({ org: org.slug, playbook: null });
         } else {
-          console.log(
-            chalk.yellow(
-              `No playbook available for ${orgIdentifier}. ` +
-                `A playbook is auto-created on the first source add/edit/remove, ` +
-                `or when you attach notes with --notes.`,
-            ),
-          );
+          console.log(chalk.yellow(`No playbook available for ${org.name}.`));
         }
         return;
       }
 
       if (opts.json) {
         await writeJson({
-          org: orgIdentifier,
+          org: org.slug,
           content: playbook.content,
           notes: playbook.notes ?? null,
           releaseCount: playbook.releaseCount,
@@ -77,14 +67,14 @@ run by --notes also seeds a fresh header on first write.`,
       }
 
       const ageLabel = playbook.generatedAt ? (timeAgo(playbook.generatedAt) ?? "?") : "?";
-      console.log(chalk.bold(`${orgIdentifier} — playbook`));
+      console.log(chalk.bold(`${org.name} — playbook`));
       console.log(chalk.dim(`  generated ${ageLabel} · ${playbook.releaseCount} sources`));
       console.log();
-      console.log(stripAnsi(playbook.content));
+      console.log(playbook.content);
       if (playbook.notes) {
         console.log();
         console.log(chalk.dim("─── Agent notes ───"));
-        console.log(stripAnsi(playbook.notes));
+        console.log(playbook.notes);
       }
     });
 }

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -23,6 +23,7 @@ import { registerChangelogCommand } from "./commands/changelog.js";
 import { registerShowCommand } from "./commands/show.js";
 import { registerEmbedCommand } from "./commands/admin/embed.js";
 import { registerEvaluateCommand } from "./commands/admin/evaluate.js";
+import { registerPlaybookCommand } from "./commands/admin/playbook.js";
 import { registerTelemetryCommand } from "./commands/telemetry.js";
 import { registerServeCommand } from "./commands/serve.js";
 import { registerWhoamiCommand } from "./commands/whoami.js";
@@ -202,6 +203,7 @@ const statsAdmin = admin.command("stats").description("Inspect operator metrics 
 registerUsageCommand(statsAdmin);
 
 registerEmbedCommand(admin);
+registerPlaybookCommand(admin);
 
 const mcpAdmin = admin.command("mcp").description("MCP server management");
 registerServeCommand(mcpAdmin);


### PR DESCRIPTION
## Summary

- Adds `releases admin playbook <org>` — the missing thin wrapper around `GET /v1/playbook?slug=...`. Reads the assembled playbook (header + agent notes).
- Adds `releases admin playbook <org> --notes "..."` — replaces agent notes via `PATCH /v1/playbook/notes`.
- `--json` output supported on both modes for agent consumption.
- Registers at `admin playbook` (flattened) rather than `admin content playbook` per buildinternet/releases#246.

## Why

Closes buildinternet/releases#246. The original consolidation plan ([buildinternet/releases#370](https://github.com/buildinternet/releases/issues/370)) deleted monorepo CLI `playbook` commands on the assumption operators would use the OSS CLI against the remote API — but this command was never actually in the OSS CLI to begin with. Routes and client helpers (`getPlaybook`, `updatePlaybookNotes`) already exist in `src/api/client.ts`; this just wires them to a command.

Same pattern as #39 (evaluate restoration). Full audit at [buildinternet/releases#419](https://github.com/buildinternet/releases/issues/419) captures the other commands the consolidation dropped and which ones are still worth porting.

## Flattening decision

The original reorg ([buildinternet/releases#162](https://github.com/buildinternet/releases/issues/162)) grouped `playbook`, `summary`, and `media` under `admin content`. Today only `playbook` is a live inhabitant — `media` became a backfill script and `summary` hasn't been ported. Registering at `admin playbook` matches both #246's explicit recommendation and the actual command surface. If the other members of `admin content` come back, they can be regrouped at that point.

## `--regenerate` intentionally dropped

The old flag called deterministic `generatePlaybookHeader` + upsert — no AI, no new behavior. Two existing paths cover it:

1. `regeneratePlaybook()` fires via `c.executionCtx.waitUntil(...)` after every source add/edit/remove (`workers/api/src/routes/sources.ts`).
2. `PATCH /v1/playbook/notes` creates the playbook with a fresh header if one doesn't exist yet (`workers/api/src/routes/playbook.ts:69-96`).

The three `seeding-playbooks` skill references to `--regenerate` immediately precede a `--notes` PATCH, making the explicit regen step dead weight in every observed flow.

If a manual-regen verb is genuinely needed later, `POST /v1/playbook` → `regeneratePlaybook(db, orgId)` is ~5 lines; ship on real demand.

## Verification

```console
$ releases admin playbook vercel
vercel — playbook
  generated 10d ago · 6 sources

# Vercel — Playbook
...

$ releases admin playbook vercel --json | jq '.org, .releaseCount'
"vercel"
6

$ releases admin playbook doesnotexist-zzz
No playbook available for doesnotexist-zzz. A playbook is auto-created
on the first source add/edit/remove, or when you attach notes with --notes.
```

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `bun run lint` — 0 warnings, 0 errors
- [x] Read mode verified against production (`vercel` org has a 6-source playbook with notes)
- [x] `--json` verified against production
- [x] Missing-org handled gracefully
- [ ] `--notes` flow intentionally not smoke-tested against production (would mutate live agent notes). Wraps the existing `updatePlaybookNotes` client helper which was already exercised by the deleted monorepo CLI.

## Follow-ups (tracked in buildinternet/releases#419)

- Skills + docs in the monorepo (`src/agent/skills/**`, `plugins/claude/releases/**`, `web/src/content/docs/cli/admin.md`, `.claude/commands/discover-changelog.md`) reference `bun src/index.ts admin content playbook ...` and the `--regenerate` flag. A matching monorepo PR will update these once this ships — there are 8 files that need the rewrite plus hand-syncs to the plugin copies.
- `admin org regenerate-overview` and `admin org refresh` from the original audit are blocked on [buildinternet/releases#420](https://github.com/buildinternet/releases/issues/420) (no live overview generation path in the tree). Split into a Phase 2 on #419.

## Related

- Closes buildinternet/releases#246
- Part of buildinternet/releases#419
- Same class of gap as #39
