### PR TITLE
feat(admin): add overview, overview-inputs, overview-write commands

### DIFF
--- a/.changeset/admin-overview-commands.md
+++ b/.changeset/admin-overview-commands.md
@@ -1,0 +1,15 @@
+---
+"@buildinternet/releases": minor
+---
+
+feat(admin): add `overview`, `overview-inputs`, `overview-write` commands
+
+Restores the operator-side surface for AI overview regeneration after
+`@buildinternet/releases` deleted the local generator in #385. Pairs with the
+new server route `GET /v1/overview-inputs` and the existing dumb upsert at
+`POST /v1/overview`. Generation itself runs in Claude Code via the
+`regenerating-overviews` skill — no Anthropic client returns to the CLI.
+
+- `releases admin overview <slug>` — read the current overview
+- `releases admin overview-inputs <slug> --json [--window N]` — input-builder
+- `releases admin overview-write <slug> --content-file <path>` — upload result

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -845,6 +845,25 @@ export async function updatePlaybookNotes(orgSlug: string, notes: string): Promi
   });
 }
 
+export interface OverviewInputs {
+  org: Pick<Organization, "id" | "slug" | "name" | "description">;
+  sources: Pick<Source, "id" | "slug" | "name" | "type">[];
+  existingContent: string | null;
+  selected: Release[];
+  totalAvailable: number;
+  windowDays: number;
+}
+
+export async function getOverviewInputs(
+  slug: string,
+  opts: { window?: number; limit?: number } = {},
+): Promise<OverviewInputs> {
+  const params = new URLSearchParams({ slug });
+  if (opts.window !== undefined) params.set("window", String(opts.window));
+  if (opts.limit !== undefined) params.set("limit", String(opts.limit));
+  return apiFetch<OverviewInputs>(`/v1/overview-inputs?${params.toString()}`);
+}
+
 // ── Media Assets ──
 
 export interface MediaAssetInput {

--- a/src/cli/commands/admin/overview/inputs.ts
+++ b/src/cli/commands/admin/overview/inputs.ts
@@ -1,0 +1,87 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { findOrg, getOverviewInputs } from "../../../../api/client.js";
+import { orgNotFound } from "../../../suggest.js";
+import { writeJson } from "../../../../lib/output.js";
+
+interface OverviewInputsOpts {
+  json?: boolean;
+  window?: string;
+  limit?: string;
+}
+
+function parsePositiveInt(label: string, raw: string | undefined): number | undefined {
+  if (raw === undefined) return undefined;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n <= 0) {
+    console.error(chalk.red(`Invalid --${label}: must be a positive integer (got ${raw})`));
+    process.exit(2);
+  }
+  return n;
+}
+
+export function registerOverviewInputsCommand(program: Command) {
+  program
+    .command("overview-inputs")
+    .description("Build the input payload for an overview regeneration")
+    .argument("<org>", "Organization slug or ID")
+    .option("--window <days>", "Lookback window in days (default 90)")
+    .option("--limit <n>", "Max releases to include (default 50)")
+    .option("--json", "Output as JSON (recommended for agent consumption)")
+    .addHelpText(
+      "after",
+      `
+Examples:
+  releases admin overview-inputs vercel --json
+  releases admin overview-inputs vercel --window 30 --json
+
+Returns the org, active sources, prior overview content, and the post-selection
+slice of recent releases. Selection is server-side and deterministic (per-source
+caps, sorted desc by publishedAt, capped at --limit). Feed the JSON to the
+generator described in the \`regenerating-overviews\` skill, then post the
+result with \`releases admin overview-write\`.`,
+    )
+    .action(async (orgIdentifier: string, opts: OverviewInputsOpts) => {
+      const org = await findOrg(orgIdentifier);
+      if (!org) return orgNotFound(orgIdentifier);
+
+      const window = parsePositiveInt("window", opts.window);
+      const limit = parsePositiveInt("limit", opts.limit);
+      const inputs = await getOverviewInputs(org.slug, { window, limit });
+
+      if (opts.json) {
+        await writeJson(inputs);
+        return;
+      }
+
+      console.log(chalk.bold(`${inputs.org.name} — overview inputs`));
+      console.log(
+        chalk.dim(
+          `  window: ${inputs.windowDays}d · sources: ${inputs.sources.length} · selected: ${inputs.selected.length} of ${inputs.totalAvailable}`,
+        ),
+      );
+      console.log();
+      if (inputs.existingContent) {
+        console.log(chalk.dim("Existing overview present (will be passed for amend-and-evolve)."));
+      } else {
+        console.log(chalk.dim("No existing overview — first generation."));
+      }
+      if (inputs.selected.length === 0) {
+        console.log();
+        console.log(chalk.yellow("No releases in window. Skip generation; nothing to write."));
+        return;
+      }
+      console.log();
+      console.log(chalk.dim("Selected releases (most recent first):"));
+      for (const r of inputs.selected.slice(0, 10)) {
+        const v = r.version ? ` ${r.version}` : "";
+        const t = r.title ? ` — ${r.title}` : "";
+        console.log(`  ${r.publishedAt ?? "—"}${v}${t}`);
+      }
+      if (inputs.selected.length > 10) {
+        console.log(
+          chalk.dim(`  … ${inputs.selected.length - 10} more (use --json for full list)`),
+        );
+      }
+    });
+}

--- a/src/cli/commands/admin/overview/inputs.ts
+++ b/src/cli/commands/admin/overview/inputs.ts
@@ -3,21 +3,12 @@ import chalk from "chalk";
 import { findOrg, getOverviewInputs } from "../../../../api/client.js";
 import { orgNotFound } from "../../../suggest.js";
 import { writeJson } from "../../../../lib/output.js";
+import { parsePositiveIntFlag } from "../../../../lib/flags.js";
 
 interface OverviewInputsOpts {
   json?: boolean;
   window?: string;
   limit?: string;
-}
-
-function parsePositiveInt(label: string, raw: string | undefined): number | undefined {
-  if (raw === undefined) return undefined;
-  const n = Number.parseInt(raw, 10);
-  if (!Number.isFinite(n) || n <= 0) {
-    console.error(chalk.red(`Invalid --${label}: must be a positive integer (got ${raw})`));
-    process.exit(2);
-  }
-  return n;
 }
 
 export function registerOverviewInputsCommand(program: Command) {
@@ -45,8 +36,8 @@ result with \`releases admin overview-write\`.`,
       const org = await findOrg(orgIdentifier);
       if (!org) return orgNotFound(orgIdentifier);
 
-      const window = parsePositiveInt("window", opts.window);
-      const limit = parsePositiveInt("limit", opts.limit);
+      const window = parsePositiveIntFlag("window", opts.window);
+      const limit = parsePositiveIntFlag("limit", opts.limit);
       const inputs = await getOverviewInputs(org.slug, { window, limit });
 
       if (opts.json) {

--- a/src/cli/commands/admin/overview/read.ts
+++ b/src/cli/commands/admin/overview/read.ts
@@ -1,0 +1,63 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { findOrg, getOverview } from "../../../../api/client.js";
+import { orgNotFound } from "../../../suggest.js";
+import { writeJson } from "../../../../lib/output.js";
+import { timeAgo } from "@buildinternet/releases-core/dates";
+
+interface OverviewReadOpts {
+  json?: boolean;
+}
+
+export function registerOverviewReadCommand(program: Command) {
+  program
+    .command("overview")
+    .description("Read an organization's AI overview")
+    .argument("<org>", "Organization slug or ID")
+    .option("--json", "Output as JSON")
+    .addHelpText(
+      "after",
+      `
+Examples:
+  releases admin overview vercel
+  releases admin overview vercel --json
+
+Use \`releases admin overview-inputs\` to inspect what would be sent to the
+model on regeneration. Use \`releases admin overview-write\` to upload a new
+overview body — see the \`regenerating-overviews\` skill for the workflow.`,
+    )
+    .action(async (orgIdentifier: string, opts: OverviewReadOpts) => {
+      const org = await findOrg(orgIdentifier);
+      if (!org) return orgNotFound(orgIdentifier);
+
+      const overview = await getOverview("org", org.slug);
+      if (!overview) {
+        if (opts.json) {
+          await writeJson({ org: org.slug, overview: null });
+        } else {
+          console.log(chalk.yellow(`No overview available for ${org.name}.`));
+        }
+        return;
+      }
+
+      if (opts.json) {
+        await writeJson({
+          org: org.slug,
+          content: overview.content,
+          releaseCount: overview.releaseCount,
+          generatedAt: overview.generatedAt,
+          updatedAt: overview.updatedAt,
+          lastContributingReleaseAt: overview.lastContributingReleaseAt,
+        });
+        return;
+      }
+
+      const ageLabel = overview.generatedAt ? (timeAgo(overview.generatedAt) ?? "?") : "?";
+      console.log(chalk.bold(`${org.name} — overview`));
+      console.log(
+        chalk.dim(`  generated ${ageLabel} · ${overview.releaseCount} releases contributing`),
+      );
+      console.log();
+      console.log(overview.content);
+    });
+}

--- a/src/cli/commands/admin/overview/write.ts
+++ b/src/cli/commands/admin/overview/write.ts
@@ -1,9 +1,9 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { readFile } from "node:fs/promises";
 import { findOrg, getOverviewInputs, upsertOverview } from "../../../../api/client.js";
 import { orgNotFound } from "../../../suggest.js";
 import { writeJson } from "../../../../lib/output.js";
+import { parsePositiveIntFlag } from "../../../../lib/flags.js";
 
 interface OverviewWriteOpts {
   contentFile: string;
@@ -48,7 +48,7 @@ overview-inputs to derive them.`,
         process.exit(2);
       }
 
-      let releaseCount = opts.releaseCount === undefined ? undefined : Number(opts.releaseCount);
+      let releaseCount = parsePositiveIntFlag("release-count", opts.releaseCount);
       let lastContributingAt = opts.lastContributingAt ?? undefined;
 
       if (releaseCount === undefined || lastContributingAt === undefined) {
@@ -85,20 +85,6 @@ overview-inputs to derive them.`,
 }
 
 async function readContent(path: string): Promise<string> {
-  if (path === "-") {
-    return await readStdin();
-  }
-  return await readFile(path, "utf8");
-}
-
-function readStdin(): Promise<string> {
-  return new Promise((resolve, reject) => {
-    let data = "";
-    process.stdin.setEncoding("utf8");
-    process.stdin.on("data", (chunk) => {
-      data += chunk;
-    });
-    process.stdin.on("end", () => resolve(data));
-    process.stdin.on("error", reject);
-  });
+  if (path === "-") return Bun.stdin.text();
+  return Bun.file(path).text();
 }

--- a/src/cli/commands/admin/overview/write.ts
+++ b/src/cli/commands/admin/overview/write.ts
@@ -1,0 +1,104 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { readFile } from "node:fs/promises";
+import { findOrg, getOverviewInputs, upsertOverview } from "../../../../api/client.js";
+import { orgNotFound } from "../../../suggest.js";
+import { writeJson } from "../../../../lib/output.js";
+
+interface OverviewWriteOpts {
+  contentFile: string;
+  releaseCount?: string;
+  lastContributingAt?: string;
+  json?: boolean;
+}
+
+export function registerOverviewWriteCommand(program: Command) {
+  program
+    .command("overview-write")
+    .description("Upload a generated overview body for an organization")
+    .argument("<org>", "Organization slug or ID")
+    .requiredOption("--content-file <path>", "Path to a markdown file containing the overview")
+    .option(
+      "--release-count <n>",
+      "Number of releases the overview reflects (defaults to totalAvailable from inputs)",
+    )
+    .option(
+      "--last-contributing-at <iso>",
+      "ISO timestamp of the most recent release reflected (defaults to first selected release)",
+    )
+    .option("--json", "Output as JSON")
+    .addHelpText(
+      "after",
+      `
+Examples:
+  releases admin overview-write vercel --content-file /tmp/vercel-overview.md
+  releases admin overview-write vercel --content-file - --json   (reads stdin)
+
+Writes via the upsert at POST /v1/overview. Last-write-wins on conflict.
+When --release-count or --last-contributing-at are omitted, the CLI re-fetches
+overview-inputs to derive them.`,
+    )
+    .action(async (orgIdentifier: string, opts: OverviewWriteOpts) => {
+      const org = await findOrg(orgIdentifier);
+      if (!org) return orgNotFound(orgIdentifier);
+
+      const content = await readContent(opts.contentFile);
+      if (!content.trim()) {
+        console.error(chalk.red("Content is empty — refusing to write."));
+        process.exit(2);
+      }
+
+      let releaseCount = opts.releaseCount === undefined ? undefined : Number(opts.releaseCount);
+      let lastContributingAt = opts.lastContributingAt ?? undefined;
+
+      if (releaseCount === undefined || lastContributingAt === undefined) {
+        const inputs = await getOverviewInputs(org.slug);
+        if (releaseCount === undefined) releaseCount = inputs.totalAvailable;
+        if (lastContributingAt === undefined) {
+          lastContributingAt = inputs.selected[0]?.publishedAt ?? undefined;
+        }
+      }
+
+      await upsertOverview({
+        scope: "org",
+        orgId: org.id,
+        content,
+        releaseCount,
+        lastContributingReleaseAt: lastContributingAt ?? null,
+      });
+
+      if (opts.json) {
+        await writeJson({
+          org: org.slug,
+          chars: content.length,
+          releaseCount,
+          lastContributingReleaseAt: lastContributingAt ?? null,
+        });
+      } else {
+        console.log(
+          chalk.green(
+            `Overview written for ${org.name}: ${content.length} chars, ${releaseCount} releases.`,
+          ),
+        );
+      }
+    });
+}
+
+async function readContent(path: string): Promise<string> {
+  if (path === "-") {
+    return await readStdin();
+  }
+  return await readFile(path, "utf8");
+}
+
+function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => {
+      data += chunk;
+    });
+    process.stdin.on("end", () => resolve(data));
+    process.stdin.on("error", reject);
+  });
+}

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -24,6 +24,9 @@ import { registerShowCommand } from "./commands/show.js";
 import { registerEmbedCommand } from "./commands/admin/embed.js";
 import { registerEvaluateCommand } from "./commands/admin/evaluate.js";
 import { registerPlaybookCommand } from "./commands/admin/playbook.js";
+import { registerOverviewReadCommand } from "./commands/admin/overview/read.js";
+import { registerOverviewInputsCommand } from "./commands/admin/overview/inputs.js";
+import { registerOverviewWriteCommand } from "./commands/admin/overview/write.js";
 import { registerTelemetryCommand } from "./commands/telemetry.js";
 import { registerServeCommand } from "./commands/serve.js";
 import { registerWhoamiCommand } from "./commands/whoami.js";
@@ -204,6 +207,9 @@ registerUsageCommand(statsAdmin);
 
 registerEmbedCommand(admin);
 registerPlaybookCommand(admin);
+registerOverviewReadCommand(admin);
+registerOverviewInputsCommand(admin);
+registerOverviewWriteCommand(admin);
 
 const mcpAdmin = admin.command("mcp").description("MCP server management");
 registerServeCommand(mcpAdmin);

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -1,0 +1,16 @@
+import chalk from "chalk";
+
+/**
+ * Parse a positive-integer CLI flag value. Returns `undefined` if the option
+ * was not provided. Exits with code 2 (usage error) on invalid input — matches
+ * commander's own conventions for argument errors.
+ */
+export function parsePositiveIntFlag(label: string, raw: string | undefined): number | undefined {
+  if (raw === undefined) return undefined;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n <= 0) {
+    console.error(chalk.red(`Invalid --${label}: must be a positive integer (got ${raw})`));
+    process.exit(2);
+  }
+  return n;
+}


### PR DESCRIPTION
## Summary

Restores the operator-side surface for AI overview regeneration after [buildinternet/releases#385](https://github.com/buildinternet/releases/pull/385) deleted the local generator. Pairs with the new server route `GET /v1/overview-inputs` ([buildinternet/releases#422](https://github.com/buildinternet/releases/pull/422)) and the existing dumb upsert at `POST /v1/overview`. Generation runs in Claude Code via the `regenerating-overviews` skill — no Anthropic client returns to the CLI.

```
releases admin overview <slug>            # read current overview
releases admin overview-inputs <slug>     # input-builder JSON for regeneration
releases admin overview-write <slug>      # upload generated body, last-write-wins
```

Defaults for `--release-count` / `--last-contributing-at` on write: re-fetch `overview-inputs` and derive both. `--content-file` accepts `-` for stdin.

## Test plan

- [x] `bun test` (196 pass)
- [x] `bun run lint` clean
- [x] `bun run format:check` clean
- [x] `bun run build` clean
- [x] `releases admin overview --help` / `overview-inputs --help` / `overview-write --help` all render correctly
- [ ] After the matching server PR merges: `releases admin overview-inputs vercel --json` returns the expected payload
- [ ] End-to-end: generate + write a real overview from inside Claude Code following the `regenerating-overviews` skill
- [ ] Changeset versioning lands a new minor (0.18.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
