### PR TITLE
chore(ci): bump actions/checkout to v6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     name: Lint & Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -33,7 +33,7 @@ jobs:
     name: Type-check and test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: oven-sh/setup-bun@v2
         with:


### PR DESCRIPTION
## Summary

- Bumps `actions/checkout` v4 → v6 in both workflows. Runtime-only major bump (Node 20 → Node 24); no API changes.
- `oven-sh/setup-bun@v2` and `changesets/action@v1` are already on their latest majors — left alone.

## Why

GitHub is forcing Node 20 actions onto Node 24 starting June 2 2026 and removing Node 20 entirely on September 16 2026. Bumping now silences the deprecation warnings and de-risks the cutover.

Mirrors buildinternet/releases#429.

## Test plan

- [ ] CI (test.yml) runs cleanly on this PR
- [ ] No Node 20 deprecation warnings in the workflow logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
