### PR TITLE
fix(api): move embed backfill paths to /v1/workflows/embed-*

### DIFF
--- a/.changeset/fix-admin-embed-workflow-paths.md
+++ b/.changeset/fix-admin-embed-workflow-paths.md
@@ -1,0 +1,22 @@
+---
+"@buildinternet/releases": patch
+"@buildinternet/releases-darwin-arm64": patch
+"@buildinternet/releases-darwin-x64": patch
+"@buildinternet/releases-linux-arm64": patch
+"@buildinternet/releases-linux-x64": patch
+"@buildinternet/releases-lib": patch
+"@buildinternet/releases-skills": patch
+---
+
+**Fix `releases admin embed {releases,entities,changelogs}` after monorepo route consolidation**
+
+The API worker moved the three embed-backfill triggers from `/v1/admin/embed/*` to `/v1/workflows/embed-*` in [buildinternet/releases#494](https://github.com/buildinternet/releases/issues/494). Without this bump, those three commands return `404` against the live API.
+
+Changes:
+
+- `embedReleases` now posts to `/v1/workflows/embed-releases`
+- `embedEntities` now posts to `/v1/workflows/embed-entities`
+- `embedChangelogs` now posts to `/v1/workflows/embed-changelogs`
+- `getEmbedStatus` stays on `/v1/admin/embed/status` (telemetry reads were not moved)
+
+The `releases admin embed …` command surface is unchanged — the path rename is invisible to users.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,15 +52,17 @@ The CLI sends anonymous pings (command name, duration, exit code, CLI version, O
 
 ## Releasing
 
+**Every PR with user-visible changes MUST ship a `.changeset/*.md` file.** Run `bun changeset` (interactive) or write the file directly in `.changeset/`. Bump level: `patch` for bug fixes, `minor` for additive features, `major` for breaking changes. The seven fixed-group packages below must all appear in the changeset header — `bun changeset` selects them together; if writing by hand, copy the header from a prior changeset in git history.
+
+**Never hand-edit a `version` field.** Not in the root `package.json`, not in `npm/*/package.json`, not in `packages/*/package.json`, not in `src/cli/version.ts`, and not in `src/mcp/server.ts`. The release pipeline owns all of them — `changeset version` updates the package files, and `scripts/sync-version.ts` mirrors the result into `src/cli/version.ts` and `src/mcp/server.ts`.
+
 Changesets versions seven `@buildinternet/releases*` packages together (fixed group):
 
 - `@buildinternet/releases` — meta package
 - `@buildinternet/releases-{darwin-arm64,darwin-x64,linux-arm64,linux-x64}` — platform binaries
 - `@buildinternet/releases-{lib,skills}` — shared libraries
 
-`@buildinternet/releases-core` is published independently from the monorepo and consumed here as a regular npm dependency — bump its pin in `package.json` when adopting a new schema.
-
-`scripts/sync-version.ts` mirrors the bumped version into `src/cli/version.ts`, `src/mcp/server.ts`, and the root `package.json` after `changeset version` runs. Never hand-edit versions.
+`@buildinternet/releases-core` is published independently from the monorepo and consumed here as a regular npm dependency — bump its pin in `package.json` when adopting a new schema. It is **not** part of the fixed group.
 
 On merge to `main`, `.github/workflows/release.yml` opens or updates a `chore: version packages` PR. Merging that PR re-runs the workflow, publishes to npm, and cuts a GitHub release with the platform binaries attached.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -932,7 +932,7 @@ export async function embedReleases(body: {
   limit?: number;
   dryRun?: boolean;
 }): Promise<EmbedBackfillResponse> {
-  return apiFetch<EmbedBackfillResponse>("/v1/admin/embed/releases", {
+  return apiFetch<EmbedBackfillResponse>("/v1/workflows/embed-releases", {
     method: "POST",
     body: JSON.stringify(body),
   });
@@ -943,7 +943,7 @@ export async function embedEntities(body: {
   limit?: number;
   dryRun?: boolean;
 }): Promise<EmbedBackfillResponse> {
-  return apiFetch<EmbedBackfillResponse>("/v1/admin/embed/entities", {
+  return apiFetch<EmbedBackfillResponse>("/v1/workflows/embed-entities", {
     method: "POST",
     body: JSON.stringify(body),
   });
@@ -954,7 +954,7 @@ export async function embedChangelogs(body: {
   limit?: number;
   dryRun?: boolean;
 }): Promise<EmbedBackfillResponse> {
-  return apiFetch<EmbedBackfillResponse>("/v1/admin/embed/changelogs", {
+  return apiFetch<EmbedBackfillResponse>("/v1/workflows/embed-changelogs", {
     method: "POST",
     body: JSON.stringify(body),
   });

--- a/tests/unit/api-client.test.ts
+++ b/tests/unit/api-client.test.ts
@@ -168,3 +168,60 @@ describe("listSourcesWithOrg", () => {
     expect(res.pagination.hasMore).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Embed backfill routes — paths moved from /v1/admin/embed/* to /v1/workflows/embed-*
+// (monorepo #494); status endpoint stayed on /v1/admin/embed/status.
+// ---------------------------------------------------------------------------
+
+describe("embed backfill routes", () => {
+  let originalFetch: typeof globalThis.fetch;
+  let capturedUrl = "";
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    capturedUrl = "";
+    globalThis.fetch = (async (url: string) => {
+      capturedUrl = url;
+      return new Response(JSON.stringify({ processed: 0, remaining: 0, dryRun: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as any;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("embedReleases posts to /v1/workflows/embed-releases", async () => {
+    await client.embedReleases({ dryRun: true });
+    expect(capturedUrl).toBe("https://test.example.com/v1/workflows/embed-releases");
+  });
+
+  it("embedEntities posts to /v1/workflows/embed-entities", async () => {
+    await client.embedEntities({ dryRun: true });
+    expect(capturedUrl).toBe("https://test.example.com/v1/workflows/embed-entities");
+  });
+
+  it("embedChangelogs posts to /v1/workflows/embed-changelogs", async () => {
+    await client.embedChangelogs({ dryRun: true });
+    expect(capturedUrl).toBe("https://test.example.com/v1/workflows/embed-changelogs");
+  });
+
+  it("getEmbedStatus stays on /v1/admin/embed/status", async () => {
+    globalThis.fetch = (async (url: string) => {
+      capturedUrl = url;
+      return new Response(
+        JSON.stringify({
+          releases: { total: 0, embedded: 0, remaining: 0 },
+          entities: { total: 0, embedded: 0, remaining: 0 },
+          changelogs: { total: 0, embedded: 0, remaining: 0 },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }) as any;
+    await client.getEmbedStatus();
+    expect(capturedUrl).toBe("https://test.example.com/v1/admin/embed/status");
+  });
+});


### PR DESCRIPTION
## Summary

- Flips the three embed-backfill POST paths from `/v1/admin/embed/*` to `/v1/workflows/embed-*` to match the API worker's route consolidation in [buildinternet/releases#494](https://github.com/buildinternet/releases/issues/494).
- Adds URL-assertion tests for the three renamed paths plus a regression guard on `GET /v1/admin/embed/status` (telemetry stayed).
- Ships a `patch` changeset covering the full fixed group.

The `releases admin embed …` command surface is unchanged — path rename is invisible to users (Option 1 from #50's UX question).

## Scope

`grep -rn "/v1/admin" src/` surfaces exactly four hits, all in `src/api/client.ts`. Three flipped, one (status) kept:

| Function | Old | New |
|---|---|---|
| `embedReleases` | `POST /v1/admin/embed/releases` | `POST /v1/workflows/embed-releases` |
| `embedEntities` | `POST /v1/admin/embed/entities` | `POST /v1/workflows/embed-entities` |
| `embedChangelogs` | `POST /v1/admin/embed/changelogs` | `POST /v1/workflows/embed-changelogs` |
| `getEmbedStatus` | `GET /v1/admin/embed/status` | *(unchanged)* |

## Coordination

The API paths are already live on `api.releases.sh` (#499 merged + deployed). No dual-registration shim required — the CLI publish can land immediately.

## Test plan

- [x] `bun test` — 200 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [ ] Reviewer smoke: `releases admin embed releases --dry-run` against prod after publish should return a `processed/remaining` payload (previously 404'd)
- [ ] Reviewer smoke: `releases admin embed status` still returns counts

Closes #50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
