### PR TITLE
docs(release): drop stale src/mcp/server.ts reference from version sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ The CLI sends anonymous pings (command name, duration, exit code, CLI version, O
 
 **Every PR with user-visible changes MUST ship a `.changeset/*.md` file.** Run `bun changeset` (interactive) or write the file directly in `.changeset/`. Bump level: `patch` for bug fixes, `minor` for additive features, `major` for breaking changes. The seven fixed-group packages below must all appear in the changeset header — `bun changeset` selects them together; if writing by hand, copy the header from a prior changeset in git history.
 
-**Never hand-edit a `version` field.** Not in the root `package.json`, not in `npm/*/package.json`, not in `packages/*/package.json`, not in `src/cli/version.ts`, and not in `src/mcp/server.ts`. The release pipeline owns all of them — `changeset version` updates the package files, and `scripts/sync-version.ts` mirrors the result into `src/cli/version.ts` and `src/mcp/server.ts`.
+**Never hand-edit a `version` field.** Not in the root `package.json`, not in `npm/*/package.json`, not in `packages/*/package.json`, and not in `src/cli/version.ts`. The release pipeline owns all of them — `changeset version` updates the package files, and `scripts/sync-version.ts` mirrors the result into `src/cli/version.ts`. The MCP server re-exports that constant (`src/mcp/server.ts` imports `VERSION` from `../cli/version.js`), so there's no separate string to sync.
 
 Changesets versions seven `@buildinternet/releases*` packages together (fixed group):
 

--- a/scripts/sync-version.ts
+++ b/scripts/sync-version.ts
@@ -3,8 +3,8 @@
 // npm/releases/package.json (the source of truth for the published CLI)
 // back to the places the build needs it:
 //   - root package.json (displayed by `releases --version`)
-//   - src/cli/version.ts (compiled into the binary)
-//   - src/mcp/server.ts (MCP server identifier)
+//   - src/cli/version.ts (compiled into the binary; also re-exported
+//     as the MCP server identifier via src/mcp/server.ts)
 //   - npm/releases-*/package.json (platform packages)
 // The Homebrew formula lives in the public tap repo
 // (buildinternet/homebrew-tap) and is regenerated on publish by CI —
@@ -68,8 +68,8 @@ updateJson("npm/releases/package.json", (j) => {
   }
 });
 
-// CLI version.ts and MCP server identifier
+// CLI version.ts — single TypeScript source of truth. src/mcp/server.ts
+// imports VERSION from this file, so no separate write needed.
 replaceInFile("src/cli/version.ts", /VERSION = "[^"]+"/, `VERSION = "${newVersion}"`);
-replaceInFile("src/mcp/server.ts", /version: "[^"]+"/, `version: "${newVersion}"`);
 
 console.log("Done.");


### PR DESCRIPTION
## Summary

Two doc-accuracy fixes flagged during the `v0.19.1` release prep.

**Problem.** `src/mcp/server.ts` imports `VERSION` from `../cli/version.js` (lines 21, 29) — it doesn't carry its own version literal. The regex in `scripts/sync-version.ts` (`/version: "[^"]+"/`) therefore silently no-ops against it (`version: VERSION,` has no quoted string to match). Both `AGENTS.md` and the script's own header comment still claimed `src/mcp/server.ts` was an independent version-bearing file, which is why PR #52's file list didn't touch it.

**Fix.**
- `AGENTS.md` Releasing section: drop `src/mcp/server.ts` from the "never hand-edit" list; add a one-sentence note clarifying the MCP server re-exports the shared constant.
- `scripts/sync-version.ts`: update the header comment to match, and remove the dead `replaceInFile("src/mcp/server.ts", ...)` call.

No runtime behavior change. Published versions were already correct because every consumer reads from `src/cli/version.ts`.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [ ] Next `chore: version packages` run mirrors 0.19.x → only `src/cli/version.ts` gets rewritten (as it has been on every prior bump; the removed line was a silent no-op)

No changeset — docs / build-script internals only, not shipped in the npm tarball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
