### PR TITLE
chore: tag outbound CLI traffic with releases-cli User-Agent

### DIFF
--- a/.changeset/cli-user-agent.md
+++ b/.changeset/cli-user-agent.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": patch
+---
+
+Send a distinctive `User-Agent` header (`releases-cli/<version> (+https://releases.sh)`) on every outbound HTTP request — registry API calls, `releases check` feed probes, update checks, telemetry. Replaces the previous fall-through to Bun/undici's default `node` UA so api.releases.sh analytics and third-party site operators can identify CLI traffic.

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,6 +1,7 @@
 import { getApiUrl, getApiKey, isAdminMode } from "../lib/mode.js";
 import { logger } from "@releases/lib/logger";
 import { daysAgoIso } from "@buildinternet/releases-core/dates";
+import { RELEASES_CLI_UA } from "../lib/user-agent.js";
 import type {
   Source,
   Release,
@@ -54,6 +55,7 @@ export async function apiFetch<T>(path: string, opts?: RequestInit): Promise<T> 
   const url = `${getApiUrl()}${path}`;
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
+    "User-Agent": RELEASES_CLI_UA,
     ...(opts?.headers as Record<string, string>),
   };
   // Only send auth header when an API key is configured (admin mode)

--- a/src/cli/commands/check.ts
+++ b/src/cli/commands/check.ts
@@ -5,6 +5,7 @@ import { findSource, listSourcesWithOrg } from "../../api/client.js";
 import { timeAgo } from "@buildinternet/releases-core/dates";
 import { stripAnsi } from "../../lib/sanitize.js";
 import { writeJson } from "../../lib/output.js";
+import { RELEASES_CLI_UA } from "../../lib/user-agent.js";
 
 interface SourceLite {
   name: string;
@@ -36,7 +37,12 @@ async function probe(url: string): Promise<{ status: number | null; ms: number }
   const timeout = setTimeout(() => controller.abort(), 10_000);
   const start = Date.now();
   try {
-    const res = await fetch(url, { method: "HEAD", signal: controller.signal, redirect: "follow" });
+    const res = await fetch(url, {
+      method: "HEAD",
+      headers: { "User-Agent": RELEASES_CLI_UA },
+      signal: controller.signal,
+      redirect: "follow",
+    });
     const ms = Date.now() - start;
     return { status: res.status, ms };
   } catch {

--- a/src/cli/commands/whoami.ts
+++ b/src/cli/commands/whoami.ts
@@ -3,6 +3,7 @@ import chalk from "chalk";
 import { getApiKey, getApiUrl, isAdminMode } from "../../lib/mode.js";
 import { VERSION } from "../version.js";
 import { writeJson } from "../../lib/output.js";
+import { RELEASES_CLI_UA } from "../../lib/user-agent.js";
 
 export type WhoamiStatus = {
   version: string;
@@ -39,7 +40,10 @@ async function probeApi(mode: WhoamiStatus["mode"]): Promise<NonNullable<WhoamiS
   // We call fetch directly (not apiFetch) because apiFetch returns null on
   // GET 404 — which would false-positive the probe for a misconfigured URL.
   const path = mode === "admin" ? "/v1/blocked-urls?limit=1" : "/v1/sources?limit=1";
-  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "User-Agent": RELEASES_CLI_UA,
+  };
   if (mode === "admin") headers["Authorization"] = `Bearer ${getApiKey()}`;
   try {
     const res = await fetch(`${getApiUrl()}${path}`, { headers });

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -3,6 +3,7 @@ import { join } from "path";
 import { randomUUID } from "crypto";
 import { getDataDir } from "@releases/lib/config";
 import { VERSION } from "../cli/version.js";
+import { RELEASES_CLI_UA } from "./user-agent.js";
 import type { TelemetryClientKind, TelemetrySurface } from "@buildinternet/releases-core/schema";
 
 const ANON_ID_FILE = "telemetry-id";
@@ -145,7 +146,7 @@ export async function recordEvent(input: TelemetryEventInput): Promise<void> {
     try {
       await fetch(`${endpoint()}/v1/telemetry`, {
         method: "POST",
-        headers: { "content-type": "application/json" },
+        headers: { "content-type": "application/json", "User-Agent": RELEASES_CLI_UA },
         body: JSON.stringify(body),
         signal: controller.signal,
       });

--- a/src/lib/update-check.ts
+++ b/src/lib/update-check.ts
@@ -2,6 +2,7 @@ import { readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 import { getDataDir } from "@releases/lib/config";
 import { VERSION } from "../cli/version.js";
+import { RELEASES_CLI_UA } from "./user-agent.js";
 
 const CACHE_FILE = "update-check.json";
 const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
@@ -81,7 +82,7 @@ async function fetchLatestVersion(): Promise<string | null> {
       const res = await fetch(
         `https://registry.npmjs.org/${encodeURIComponent(NPM_PACKAGE)}/latest`,
         {
-          headers: { accept: "application/json" },
+          headers: { accept: "application/json", "User-Agent": RELEASES_CLI_UA },
           signal: controller.signal,
         },
       );

--- a/src/lib/user-agent.ts
+++ b/src/lib/user-agent.ts
@@ -1,0 +1,8 @@
+import { VERSION } from "../cli/version.js";
+
+/**
+ * Identifies the CLI to api.releases.sh and to any external URLs the CLI
+ * probes on the user's behalf (feed checks, update checks). Includes the
+ * current CLI version so we can correlate issues with specific releases.
+ */
+export const RELEASES_CLI_UA = `releases-cli/${VERSION} (+https://releases.sh)`;


### PR DESCRIPTION
## Summary

- Every outbound HTTP request from the CLI now sends `User-Agent: releases-cli/<version> (+https://releases.sh)`.
- Introduces a single shared constant in `src/lib/user-agent.ts` — reused across the registry client (`apiFetch`), the whoami probe, `releases check` feed probes, the npm update check, and telemetry POSTs.
- Previously the CLI set no UA at all, so Bun/undici's default `node` went out to api.releases.sh and to third-party feed URLs. The version suffix lets us correlate bug reports with specific CLI releases.

Mirrors the monorepo's outbound-UA standardization in buildinternet/releases#503 — both repos now identify themselves consistently with the `(+https://releases.sh)` scheme.

## Changes

- **New:** `src/lib/user-agent.ts` — `RELEASES_CLI_UA` built from `VERSION` in `src/cli/version.ts` (already kept in sync with `package.json` by `scripts/sync-version.ts`).
- `src/api/client.ts` — `apiFetch` adds the UA to every request (userland headers can still override).
- `src/cli/commands/whoami.ts` — the probe that bypasses `apiFetch` gets the UA directly.
- `src/cli/commands/check.ts` — `releases check` HEAD probes send the UA to the user's source URLs.
- `src/lib/update-check.ts` — npm registry call.
- `src/lib/telemetry.ts` — telemetry POST.
- `.changeset/cli-user-agent.md` — patch bump for `@buildinternet/releases`.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun test` — 200 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)
