### PR TITLE
refactor(api): move overview admin calls to nested routes

### DIFF
--- a/.changeset/overview-nested-routes.md
+++ b/.changeset/overview-nested-routes.md
@@ -1,0 +1,7 @@
+---
+"@buildinternet/releases": patch
+---
+
+Overview admin commands now call the nested API routes (`/v1/orgs/:slug/overview`, `/v1/orgs/:slug/overview/inputs`, `/v1/products/:slug/overview`). The `releases admin overview-read`, `overview-write`, and `overview-inputs` commands are unchanged — only the URLs the CLI hits have moved.
+
+`OverviewInputs.selected` entries now carry pre-hydrated `content` (absolute CDN URLs) and a typed `media` array with `r2Url` resolved, so the overview agent can paste image URLs directly into generated markdown.

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -815,26 +815,30 @@ export async function getMonthlySummary(
 
 // ── Overview / Playbook Pages ──
 
+const SCOPE_RESOURCE = { org: "orgs", product: "products" } as const;
+
 export async function getOverview(
-  scope: "org" | "product",
+  scope: keyof typeof SCOPE_RESOURCE,
   slug: string,
 ): Promise<KnowledgePage | null> {
-  return apiFetch<KnowledgePage | null>(`/v1/overview?scope=${scope}&slug=${slug}`);
+  return apiFetch<KnowledgePage | null>(
+    `/v1/${SCOPE_RESOURCE[scope]}/${encodeURIComponent(slug)}/overview`,
+  );
 }
 
 export async function getPlaybook(slug: string): Promise<KnowledgePage | null> {
   return apiFetch<KnowledgePage | null>(`/v1/playbook?slug=${slug}`);
 }
 
-export async function upsertOverview(data: {
-  scope: "org" | "product" | "playbook";
-  orgId?: string | null;
-  productId?: string | null;
-  content: string;
-  releaseCount: number;
-  lastContributingReleaseAt?: string | null;
-}): Promise<void> {
-  await apiFetch("/v1/overview", {
+export async function upsertOverview(
+  orgSlug: string,
+  data: {
+    content: string;
+    releaseCount: number;
+    lastContributingReleaseAt?: string | null;
+  },
+): Promise<void> {
+  await apiFetch(`/v1/orgs/${encodeURIComponent(orgSlug)}/overview`, {
     method: "POST",
     body: JSON.stringify(data),
   });
@@ -847,11 +851,27 @@ export async function updatePlaybookNotes(orgSlug: string, notes: string): Promi
   });
 }
 
+/**
+ * Release shape in overview inputs. `content` is pre-hydrated (absolute CDN
+ * URLs), and `media` entries carry resolved `r2Url`s — ready to paste into
+ * generated markdown. This is a narrower projection than the raw `Release`
+ * row: only the fields the overview agent needs.
+ */
+export interface OverviewInputRelease {
+  id: string;
+  version: string | null;
+  title: string;
+  content: string;
+  publishedAt: string | null;
+  url: string | null;
+  media: MediaItem[];
+}
+
 export interface OverviewInputs {
   org: Pick<Organization, "id" | "slug" | "name" | "description">;
   sources: Pick<Source, "id" | "slug" | "name" | "type">[];
   existingContent: string | null;
-  selected: Release[];
+  selected: OverviewInputRelease[];
   totalAvailable: number;
   windowDays: number;
 }
@@ -860,10 +880,13 @@ export async function getOverviewInputs(
   slug: string,
   opts: { window?: number; limit?: number } = {},
 ): Promise<OverviewInputs> {
-  const params = new URLSearchParams({ slug });
+  const params = new URLSearchParams();
   if (opts.window !== undefined) params.set("window", String(opts.window));
   if (opts.limit !== undefined) params.set("limit", String(opts.limit));
-  return apiFetch<OverviewInputs>(`/v1/overview-inputs?${params.toString()}`);
+  const qs = params.toString();
+  return apiFetch<OverviewInputs>(
+    `/v1/orgs/${encodeURIComponent(slug)}/overview/inputs${qs ? `?${qs}` : ""}`,
+  );
 }
 
 // ── Media Assets ──

--- a/src/cli/commands/admin/overview/write.ts
+++ b/src/cli/commands/admin/overview/write.ts
@@ -34,7 +34,7 @@ Examples:
   releases admin overview-write vercel --content-file /tmp/vercel-overview.md
   releases admin overview-write vercel --content-file - --json   (reads stdin)
 
-Writes via the upsert at POST /v1/overview. Last-write-wins on conflict.
+Writes via POST /v1/orgs/:slug/overview. Last-write-wins on conflict.
 When --release-count or --last-contributing-at are omitted, the CLI re-fetches
 overview-inputs to derive them.`,
     )
@@ -59,9 +59,7 @@ overview-inputs to derive them.`,
         }
       }
 
-      await upsertOverview({
-        scope: "org",
-        orgId: org.id,
+      await upsertOverview(org.slug, {
         content,
         releaseCount,
         lastContributingReleaseAt: lastContributingAt ?? null,


### PR DESCRIPTION
## Summary

- Point the overview admin commands at the nested API routes introduced in buildinternet/releases#506: `GET|POST /v1/orgs/:slug/overview`, `GET /v1/products/:slug/overview`, `GET /v1/orgs/:slug/overview/inputs`.
- `upsertOverview` now takes `(orgSlug, data)`; the body no longer carries `scope`/`orgId` (identity lives in the path).
- Add a typed `OverviewInputRelease` for `OverviewInputs.selected` — pre-hydrated `content` and typed `media` array so overview-regen agents can paste image URLs directly.
- Use a `SCOPE_RESOURCE` const map for scope→path translation so a future scope value fails at compile time instead of producing a silent wrong URL.

## Pairing

Requires buildinternet/releases#506 to be deployed before this CLI version is published. The intent is to bundle the #504 tier 1+2 route moves into the same CLI release so clients only need one URL-shape bump.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [ ] Smoke: `releases admin overview-inputs <slug> --json` and `releases admin overview-write <slug> --content-file …` against a deploy of #506
- [ ] Changeset committed; `changeset publish` will bump the patch on the next release cut
