### PR TITLE
refactor(api): move discovery triggers to /v1/workflows/*

### DIFF
--- a/.changeset/nest-discover-workflow.md
+++ b/.changeset/nest-discover-workflow.md
@@ -1,0 +1,9 @@
+---
+"@buildinternet/releases": patch
+---
+
+Discovery triggers moved under `/v1/workflows/*` on the API per issue #504 tier 2. The `releases admin discovery onboard` and `releases admin fetch` commands are unchanged from the user's perspective, but the underlying URLs now follow the convention:
+
+- `POST /v1/discover` → `POST /v1/workflows/discover`
+- `POST /v1/update` → `POST /v1/workflows/update`
+- `GET /v1/discover/:sessionId` is gone — the CLI polls `GET /v1/sessions/:sessionId` instead, which reads from the same DO with a richer shape (progress fields live at the top level, not nested under `progress`).

--- a/src/cli/commands/fetch.ts
+++ b/src/cli/commands/fetch.ts
@@ -145,7 +145,7 @@ Examples:
 
         let result: { sessionId: string };
         try {
-          result = await apiFetch<{ sessionId: string }>("/v1/update", {
+          result = await apiFetch<{ sessionId: string }>("/v1/workflows/update", {
             method: "POST",
             body: JSON.stringify({
               company: label,

--- a/src/cli/commands/onboard.ts
+++ b/src/cli/commands/onboard.ts
@@ -80,7 +80,7 @@ async function runRemoteDiscovery(
 
   let sessionId: string;
   try {
-    const result = await apiFetch<{ sessionId: string }>("/v1/discover", {
+    const result = await apiFetch<{ sessionId: string }>("/v1/workflows/discover", {
       method: "POST",
       body: JSON.stringify({ company, domain: opts.domain, githubOrg: opts.githubOrg, engine }),
     });
@@ -107,23 +107,23 @@ async function runRemoteDiscovery(
     await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL));
 
     let status: {
-      status: "running" | "complete" | "error" | "idle";
-      progress?: {
-        step: string;
-        sourcesFound: number;
-        sourcesValidated: number;
-        currentAction: string;
-      };
+      status: "running" | "complete" | "error" | "cancelled";
+      step?: string;
+      sourcesFound?: number;
+      sourcesValidated?: number;
+      currentAction?: string;
       result?: object;
       error?: string;
-    };
+    } | null;
     try {
       // eslint-disable-next-line no-await-in-loop
-      status = await apiFetch(`/v1/discover/${sessionId}`);
+      status = await apiFetch(`/v1/sessions/${sessionId}`);
     } catch (err) {
       logger.error(`Failed to poll status: ${err instanceof Error ? err.message : String(err)}`);
       process.exit(1);
     }
+
+    if (!status) continue;
 
     if (status.status === "complete") {
       if (!opts.json) process.stderr.write(chalk.green("\n  Discovery complete.\n"));
@@ -152,19 +152,23 @@ async function runRemoteDiscovery(
       process.exit(1);
     }
 
-    if (!opts.json && status.progress) {
-      const { step, sourcesFound, sourcesValidated, currentAction } = status.progress;
-      if (step !== lastStep) {
-        const elapsed = Math.round((Date.now() - startTime) / 1000);
-        process.stderr.write(
-          chalk.gray(`  [${elapsed}s] `) +
-            chalk.dim(`${step}`) +
-            chalk.gray(` — ${sourcesFound} found, ${sourcesValidated} validated`) +
-            (currentAction ? chalk.dim(` — ${currentAction}`) : "") +
-            "\n",
-        );
-        lastStep = step;
-      }
+    if (status.status === "cancelled") {
+      logger.error("Remote discovery was cancelled.");
+      process.exit(1);
+    }
+
+    if (!opts.json && status.step && status.step !== lastStep) {
+      const elapsed = Math.round((Date.now() - startTime) / 1000);
+      const found = status.sourcesFound ?? 0;
+      const validated = status.sourcesValidated ?? 0;
+      process.stderr.write(
+        chalk.gray(`  [${elapsed}s] `) +
+          chalk.dim(status.step) +
+          chalk.gray(` — ${found} found, ${validated} validated`) +
+          (status.currentAction ? chalk.dim(` — ${status.currentAction}`) : "") +
+          "\n",
+      );
+      lastStep = status.step;
     }
   }
 


### PR DESCRIPTION
## Summary

Pairs with buildinternet/releases#TBD (issue #504 tier 2). Updates the CLI's discovery and update triggers to the new nested paths.

- `releases admin discovery onboard` now posts to `/v1/workflows/discover` and polls `/v1/sessions/:id` (the old `/v1/discover/:id` is gone). The status shape changes with the switch: progress fields (`step`, `sourcesFound`, `sourcesValidated`, `currentAction`) are read at the top level instead of under a `progress` wrapper. Also handles `status: "cancelled"` cleanly (previously fell through).
- `releases admin fetch` now posts to `/v1/workflows/update`.

User-visible CLI surface unchanged. Changeset included.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `bun test` — 200 pass / 0 fail
- [x] `bun run lint` / `bun run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
