### PR TITLE
chore: nest admin log paths under /v1/admin/logs/*

### DIFF
--- a/.changeset/nest-admin-logs.md
+++ b/.changeset/nest-admin-logs.md
@@ -1,0 +1,10 @@
+---
+"@buildinternet/releases": patch
+---
+
+Admin log routes moved under `/v1/admin/logs/*` on the API per issue #504 tier 3. The `releases admin source fetch-log` command and `getUsageStats` / `postUsageLog` / `postFetchLog` helpers are unchanged from the user's perspective, only the underlying URLs shift:
+
+- `GET /v1/fetch-log` → `GET /v1/admin/logs/fetch`
+- `POST /v1/fetch-log` → `POST /v1/admin/logs/fetch`
+- `GET /v1/usage-log/stats` → `GET /v1/admin/logs/usage/stats`
+- `POST /v1/usage-log` → `POST /v1/admin/logs/usage`

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -321,7 +321,7 @@ export async function getStatsSummary(days: number): Promise<StatsSummary> {
         error: string | null;
         createdAt: string;
       }>
-    >("/v1/fetch-log?limit=20"),
+    >("/v1/admin/logs/fetch?limit=20"),
     apiFetch<
       Array<{
         slug: string;
@@ -374,7 +374,7 @@ export async function getStatsSummary(days: number): Promise<StatsSummary> {
 // ── Usage log ──
 
 export async function getUsageStats(days: number): Promise<UsageStatsResponse> {
-  return apiFetch<UsageStatsResponse>(`/v1/usage-log/stats?days=${days}`);
+  return apiFetch<UsageStatsResponse>(`/v1/admin/logs/usage/stats?days=${days}`);
 }
 
 export async function postUsageLog(entry: {
@@ -385,7 +385,7 @@ export async function postUsageLog(entry: {
   sourceSlug?: string | null;
   releaseCount?: number | null;
 }): Promise<void> {
-  await apiFetch("/v1/usage-log", {
+  await apiFetch("/v1/admin/logs/usage", {
     method: "POST",
     body: JSON.stringify(entry),
   });
@@ -403,7 +403,7 @@ export async function postFetchLog(entry: {
   rawContent?: string | null;
   sessionId?: string | null;
 }): Promise<void> {
-  await apiFetch("/v1/fetch-log", {
+  await apiFetch("/v1/admin/logs/fetch", {
     method: "POST",
     body: JSON.stringify(entry),
   });
@@ -429,7 +429,7 @@ export async function getFetchLogs(opts: {
       rawContent: string | null;
       createdAt: string;
     }>
-  >(`/v1/fetch-log?${params}`);
+  >(`/v1/admin/logs/fetch?${params}`);
 
   // The API fetch-log endpoint returns raw fetch_log rows without source name/slug.
   // In remote mode we don't have the join data, so we provide what we can.


### PR DESCRIPTION
## Summary

Pairs with buildinternet/releases#TBD (issue #504 tier 3). Updates the CLI's admin telemetry helpers to the new nested paths under `/v1/admin/logs/*`.

- `getFetchLogs` / `postFetchLog` → `/v1/admin/logs/fetch`
- `getUsageStats` → `/v1/admin/logs/usage/stats`
- `postUsageLog` → `/v1/admin/logs/usage`

User-visible CLI surface unchanged (`releases admin source fetch-log`, `releases admin cli stats`, etc.). Changeset included.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `bun test` — 200 pass / 0 fail
- [x] `bun run lint` / `bun run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
