### PR TITLE
feat(admin): --wait mode for source fetch with provider-error exit codes

### DIFF
--- a/.changeset/admin-source-fetch-wait.md
+++ b/.changeset/admin-source-fetch-wait.md
@@ -1,0 +1,14 @@
+---
+"@buildinternet/releases": minor
+---
+
+`releases admin source fetch` now accepts `--wait [seconds]`, blocking until the managed-agent session reaches a terminal state. Without `--wait` the command stays fire-and-forget. Default wait is 900s; pass an explicit value to shorten it (e.g. `--wait 60`).
+
+Exit codes:
+
+- `0` — session completed successfully
+- `1` — our-side error (no tools called, parser failure, timeout)
+- `2` — managed-agents/provider error (e.g. `unknown_error`, `model_overloaded_error`, retries exhausted) — the message is tagged `(managed-agents · <type>)` and includes retry count when the session ended in `retries_exhausted`
+- `130` — session cancelled
+
+Closes the silent-failure gap surfaced in [registry #590](https://github.com/buildinternet/releases/issues/590) where backend incidents bubbled up as `exit 0` even though no work happened.

--- a/src/cli/commands/fetch-wait.ts
+++ b/src/cli/commands/fetch-wait.ts
@@ -1,0 +1,57 @@
+import type { Session } from "@buildinternet/releases-api-types";
+
+/**
+ * Local extension of `Session` carrying the classification fields added in
+ * the registry's API release (api-types ≥ 0.2.0). The pinned api-types is
+ * still 0.1.0 — drop this alias and import `Session` directly once the CLI
+ * bumps.
+ */
+export type SessionWithClassification = Session & {
+  errorSource?: "provider" | "us";
+  errorType?: string;
+  stopReason?: string;
+  retryCount?: number;
+};
+
+export const DEFAULT_WAIT_SECONDS = 900;
+export const POLL_INTERVAL_MS = 3_000;
+/** Tolerate brief 404s right after starting (StatusHub may lag the workflow trigger). */
+export const NOT_FOUND_GRACE_MS = 15_000;
+
+export interface TerminalSummary {
+  exitCode: 0 | 1 | 2 | 130;
+  status: "complete" | "error" | "cancelled" | "timeout";
+  message: string;
+}
+
+/**
+ * Map a polled session into the exit code + human message the CLI should use.
+ * - `0` complete · `1` our-side error · `2` provider error · `130` cancelled
+ * - Provider messages are tagged `(managed-agents · <type>)` and include retry
+ *   count when the session ended in `retries_exhausted`.
+ */
+export function classifySessionTerminalState(
+  session: SessionWithClassification,
+): TerminalSummary | null {
+  if (session.status === "running") return null;
+  if (session.status === "complete") {
+    return { exitCode: 0, status: "complete", message: "Session complete" };
+  }
+  if (session.status === "cancelled") {
+    return { exitCode: 130, status: "cancelled", message: "Session cancelled" };
+  }
+  const error = session.error ?? "Session error";
+  if (session.errorSource === "provider") {
+    const typeNote = session.errorType ? ` · ${session.errorType}` : "";
+    const retryNote =
+      session.stopReason === "retries_exhausted" && session.retryCount !== undefined
+        ? ` (after ${session.retryCount} retries)`
+        : "";
+    return {
+      exitCode: 2,
+      status: "error",
+      message: `Provider error (managed-agents${typeNote})${retryNote}: ${error}`,
+    };
+  }
+  return { exitCode: 1, status: "error", message: error };
+}

--- a/src/cli/commands/fetch.ts
+++ b/src/cli/commands/fetch.ts
@@ -4,6 +4,7 @@ import { logger } from "@releases/lib/logger";
 import {
   apiFetch,
   getActiveSources,
+  getSession,
   listFetchableSources,
   listSourcesWithChanges,
   findSource,
@@ -13,6 +14,14 @@ import {
 import { newCorrelationId } from "@buildinternet/releases-core/id";
 import { orgNotFound, sourceNotFound } from "../suggest.js";
 import { writeJson, writeJsonLine } from "../../lib/output.js";
+import { sleep } from "../../lib/sleep.js";
+import {
+  classifySessionTerminalState,
+  DEFAULT_WAIT_SECONDS,
+  NOT_FOUND_GRACE_MS,
+  POLL_INTERVAL_MS,
+  type SessionWithClassification,
+} from "./fetch-wait.js";
 
 export function registerFetchCommand(program: Command) {
   program
@@ -28,6 +37,11 @@ export function registerFetchCommand(program: Command) {
     .option("--changed", "Only fetch sources where poll detected upstream changes")
     .option("--retry-errors", "Only fetch sources whose last fetch was an error")
     .option("--org <slug>", "Fetch all active sources for an organization")
+    .option(
+      "--wait [seconds]",
+      `Block until the session reaches a terminal state (default: ${DEFAULT_WAIT_SECONDS}s). ` +
+        `Exits non-zero on failure: 2 for managed-agents/provider errors, 1 for our-side errors, 130 for cancellation.`,
+    )
     .addHelpText(
       "after",
       `
@@ -38,7 +52,9 @@ Examples:
   releases admin source fetch --unfetched           Fetch sources never fetched before
   releases admin source fetch --changed             Fetch sources where poll detected changes
   releases admin source fetch --retry-errors        Retry sources that errored last time
-  releases admin source fetch --org acme            Fetch all active sources for an org`,
+  releases admin source fetch --org acme            Fetch all active sources for an org
+  releases admin source fetch --org acme --wait     Wait for completion; exit non-zero on failure
+  releases admin source fetch --org acme --wait 60  Wait up to 60 seconds`,
     )
     .action(
       async (
@@ -51,6 +67,7 @@ Examples:
           changed?: boolean;
           retryErrors?: boolean;
           org?: string;
+          wait?: string | true;
         },
       ) => {
         const identifier = slugArg ?? opts.source;
@@ -165,8 +182,98 @@ Examples:
         } else {
           logger.info(`Update session started: ${result.sessionId}`);
           logger.info(`Fetching ${sourceIdentifiers.length} source(s).`);
-          logger.info(`Track progress: releases admin discovery task list`);
+          if (opts.wait === undefined) {
+            logger.info(`Track progress: releases admin discovery task list`);
+          }
+        }
+
+        if (opts.wait !== undefined) {
+          const waitSeconds =
+            opts.wait === true ? DEFAULT_WAIT_SECONDS : parseWaitSeconds(opts.wait);
+          if (waitSeconds === null) {
+            logger.error(`--wait must be a positive integer (seconds), got "${opts.wait}"`);
+            process.exit(1);
+          }
+          await waitForSession({
+            sessionId: result.sessionId,
+            waitSeconds,
+            json: opts.json === true,
+          });
         }
       },
     );
+}
+
+function parseWaitSeconds(raw: string): number | null {
+  const n = parseInt(raw, 10);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return n;
+}
+
+async function waitForSession({
+  sessionId,
+  waitSeconds,
+  json,
+}: {
+  sessionId: string;
+  waitSeconds: number;
+  json: boolean;
+}): Promise<void> {
+  const startedAt = Date.now();
+  const deadline = startedAt + waitSeconds * 1000;
+  if (!json) logger.info(`Waiting up to ${waitSeconds}s for session to complete…`);
+
+  while (Date.now() < deadline) {
+    let session: SessionWithClassification | null = null;
+    try {
+      // oxlint-disable-next-line no-await-in-loop -- sequential polling: each tick depends on the previous response
+      session = await getSession(sessionId);
+    } catch (err) {
+      if (Date.now() - startedAt > NOT_FOUND_GRACE_MS) {
+        logger.error(
+          `Failed to poll session ${sessionId.slice(0, 8)}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        process.exit(1);
+      }
+    }
+
+    if (!session) {
+      // 404 right after start is normal — the StatusHub event may not have landed yet.
+      if (Date.now() - startedAt > NOT_FOUND_GRACE_MS) {
+        logger.error(`Session ${sessionId} not found after grace window — giving up`);
+        process.exit(1);
+      }
+      // oxlint-disable-next-line no-await-in-loop -- intentional poll interval
+      await sleep(POLL_INTERVAL_MS);
+      continue;
+    }
+
+    const summary = classifySessionTerminalState(session);
+    if (summary) {
+      if (json) {
+        // oxlint-disable-next-line no-await-in-loop -- terminal write before exiting; not actually a loop iteration
+        await writeJson({ ...session, exitCode: summary.exitCode });
+      } else if (summary.exitCode === 0) {
+        logger.info(chalk.green(summary.message));
+      } else {
+        logger.error(chalk.red(summary.message));
+      }
+      process.exit(summary.exitCode);
+    }
+
+    // oxlint-disable-next-line no-await-in-loop -- intentional poll interval
+    await sleep(POLL_INTERVAL_MS);
+  }
+
+  // Hit the wait deadline — session is still running.
+  if (json) {
+    await writeJson({ sessionId, status: "timeout", waitSeconds });
+  } else {
+    logger.error(
+      chalk.red(
+        `Session ${sessionId.slice(0, 8)} did not reach a terminal state within ${waitSeconds}s`,
+      ),
+    );
+  }
+  process.exit(1);
 }

--- a/src/cli/commands/fetch.ts
+++ b/src/cli/commands/fetch.ts
@@ -72,6 +72,16 @@ Examples:
       ) => {
         const identifier = slugArg ?? opts.source;
 
+        // Resolve --wait up front so a malformed value fails before we kick off a remote workflow.
+        let waitSeconds: number | null = null;
+        if (opts.wait !== undefined) {
+          waitSeconds = opts.wait === true ? DEFAULT_WAIT_SECONDS : parseWaitSeconds(opts.wait);
+          if (waitSeconds === null) {
+            logger.error(`--wait must be a positive integer (seconds), got "${opts.wait}"`);
+            process.exit(1);
+          }
+        }
+
         let entries: Array<{ id: string; slug: string }> = [];
         let label = "manual fetch";
         let orgId: string | undefined;
@@ -177,23 +187,20 @@ Examples:
           );
           process.exit(1);
         }
-        if (opts.json) {
+        const waiting = opts.wait !== undefined;
+        if (opts.json && !waiting) {
+          // When waiting, the final JSON is emitted by waitForSession so we
+          // don't write two top-level documents to stdout.
           await writeJson(result);
-        } else {
+        } else if (!opts.json) {
           logger.info(`Update session started: ${result.sessionId}`);
           logger.info(`Fetching ${sourceIdentifiers.length} source(s).`);
-          if (opts.wait === undefined) {
+          if (!waiting) {
             logger.info(`Track progress: releases admin discovery task list`);
           }
         }
 
-        if (opts.wait !== undefined) {
-          const waitSeconds =
-            opts.wait === true ? DEFAULT_WAIT_SECONDS : parseWaitSeconds(opts.wait);
-          if (waitSeconds === null) {
-            logger.error(`--wait must be a positive integer (seconds), got "${opts.wait}"`);
-            process.exit(1);
-          }
+        if (waiting && waitSeconds !== null) {
           await waitForSession({
             sessionId: result.sessionId,
             waitSeconds,
@@ -204,8 +211,10 @@ Examples:
     );
 }
 
-function parseWaitSeconds(raw: string): number | null {
-  const n = parseInt(raw, 10);
+/** Strict integer parse — `parseInt("60abc")` returns 60, which would silently misuse `--wait 60s`. */
+export function parseWaitSeconds(raw: string): number | null {
+  if (!/^\d+$/.test(raw)) return null;
+  const n = Number.parseInt(raw, 10);
   if (!Number.isFinite(n) || n <= 0) return null;
   return n;
 }
@@ -224,17 +233,17 @@ async function waitForSession({
   if (!json) logger.info(`Waiting up to ${waitSeconds}s for session to complete…`);
 
   while (Date.now() < deadline) {
-    let session: SessionWithClassification | null = null;
+    let session: SessionWithClassification | null;
     try {
       // oxlint-disable-next-line no-await-in-loop -- sequential polling: each tick depends on the previous response
       session = await getSession(sessionId);
     } catch (err) {
-      if (Date.now() - startedAt > NOT_FOUND_GRACE_MS) {
-        logger.error(
-          `Failed to poll session ${sessionId.slice(0, 8)}: ${err instanceof Error ? err.message : String(err)}`,
-        );
-        process.exit(1);
-      }
+      // apiFetch returns null on GET 404 — anything thrown here is a real
+      // transport/auth/5xx problem. Surface it instead of swallowing.
+      logger.error(
+        `Failed to poll session ${sessionId.slice(0, 8)}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      process.exit(1);
     }
 
     if (!session) {

--- a/src/cli/commands/tail.ts
+++ b/src/cli/commands/tail.ts
@@ -4,6 +4,7 @@ import { findOrg, findSource, getLatestReleases } from "../../api/client.js";
 import type { LatestRelease } from "../../api/types.js";
 import { orgNotFound, sourceNotFound } from "../suggest.js";
 import { stripAnsi } from "../../lib/sanitize.js";
+import { sleep } from "../../lib/sleep.js";
 import { renderLatestReleasesTable } from "../render/releases-table.js";
 import { writeJson, writeJsonLine } from "../../lib/output.js";
 
@@ -14,10 +15,6 @@ function renderStreamLine(row: LatestRelease): string {
   const title = stripAnsi(row.title);
   const id = chalk.dim(row.id.slice(0, 12));
   return `${when}  ${src}  ${version ? version + "  " : ""}${title}  ${id}`;
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 // Cap the seen-id set so a long-running follow loop can't grow unbounded.

--- a/src/lib/sleep.ts
+++ b/src/lib/sleep.ts
@@ -1,0 +1,3 @@
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/tests/cli/fetch-wait.test.ts
+++ b/tests/cli/fetch-wait.test.ts
@@ -3,6 +3,7 @@ import {
   classifySessionTerminalState,
   type SessionWithClassification,
 } from "../../src/cli/commands/fetch-wait.js";
+import { parseWaitSeconds } from "../../src/cli/commands/fetch.js";
 
 const baseSession: SessionWithClassification = {
   sessionId: "sess_abc",
@@ -97,5 +98,27 @@ describe("classifySessionTerminalState", () => {
     });
     expect(summary?.exitCode).toBe(2);
     expect(summary?.message).toBe("Provider error (managed-agents): Session error");
+  });
+});
+
+describe("parseWaitSeconds", () => {
+  it("accepts plain positive integers", () => {
+    expect(parseWaitSeconds("60")).toBe(60);
+    expect(parseWaitSeconds("1")).toBe(1);
+    expect(parseWaitSeconds("900")).toBe(900);
+  });
+
+  it("rejects strings with trailing non-digits", () => {
+    // parseInt("60s") would return 60 — silent acceptance of malformed input.
+    expect(parseWaitSeconds("60s")).toBeNull();
+    expect(parseWaitSeconds("1m")).toBeNull();
+    expect(parseWaitSeconds("60.5")).toBeNull();
+  });
+
+  it("rejects zero, negative numbers, and non-numeric strings", () => {
+    expect(parseWaitSeconds("0")).toBeNull();
+    expect(parseWaitSeconds("-5")).toBeNull();
+    expect(parseWaitSeconds("forever")).toBeNull();
+    expect(parseWaitSeconds("")).toBeNull();
   });
 });

--- a/tests/cli/fetch-wait.test.ts
+++ b/tests/cli/fetch-wait.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "bun:test";
+import {
+  classifySessionTerminalState,
+  type SessionWithClassification,
+} from "../../src/cli/commands/fetch-wait.js";
+
+const baseSession: SessionWithClassification = {
+  sessionId: "sess_abc",
+  company: "acme",
+  type: "update",
+  status: "running",
+  startedAt: 0,
+  lastUpdatedAt: 0,
+};
+
+describe("classifySessionTerminalState", () => {
+  it("returns null while the session is still running", () => {
+    expect(classifySessionTerminalState(baseSession)).toBeNull();
+  });
+
+  it("returns exitCode 0 when complete", () => {
+    expect(classifySessionTerminalState({ ...baseSession, status: "complete" })).toEqual({
+      exitCode: 0,
+      status: "complete",
+      message: "Session complete",
+    });
+  });
+
+  it("returns exitCode 130 when cancelled", () => {
+    expect(classifySessionTerminalState({ ...baseSession, status: "cancelled" })).toEqual({
+      exitCode: 130,
+      status: "cancelled",
+      message: "Session cancelled",
+    });
+  });
+
+  it("returns exitCode 1 for our-side errors (no errorSource)", () => {
+    const summary = classifySessionTerminalState({
+      ...baseSession,
+      status: "error",
+      error: "Agent completed without calling any tools",
+    });
+    expect(summary).toEqual({
+      exitCode: 1,
+      status: "error",
+      message: "Agent completed without calling any tools",
+    });
+  });
+
+  it("returns exitCode 1 when errorSource is explicitly 'us'", () => {
+    expect(
+      classifySessionTerminalState({
+        ...baseSession,
+        status: "error",
+        error: "Session timed out (no updates received)",
+        errorSource: "us",
+      })?.exitCode,
+    ).toBe(1);
+  });
+
+  it("returns exitCode 2 for provider errors and tags errorType", () => {
+    const summary = classifySessionTerminalState({
+      ...baseSession,
+      status: "error",
+      error: "An internal service error occurred.",
+      errorSource: "provider",
+      errorType: "unknown_error",
+    });
+    expect(summary).toEqual({
+      exitCode: 2,
+      status: "error",
+      message:
+        "Provider error (managed-agents · unknown_error): An internal service error occurred.",
+    });
+  });
+
+  it("includes retry count when the provider stop reason is retries_exhausted", () => {
+    const summary = classifySessionTerminalState({
+      ...baseSession,
+      status: "error",
+      error: "An internal service error occurred.",
+      errorSource: "provider",
+      errorType: "unknown_error",
+      stopReason: "retries_exhausted",
+      retryCount: 6,
+    });
+    expect(summary?.message).toBe(
+      "Provider error (managed-agents · unknown_error) (after 6 retries): An internal service error occurred.",
+    );
+  });
+
+  it("falls back gracefully when error metadata is sparse", () => {
+    const summary = classifySessionTerminalState({
+      ...baseSession,
+      status: "error",
+      errorSource: "provider",
+    });
+    expect(summary?.exitCode).toBe(2);
+    expect(summary?.message).toBe("Provider error (managed-agents): Session error");
+  });
+});


### PR DESCRIPTION
## Summary

Adds `--wait [seconds]` to `releases admin source fetch`. The CLI now blocks until the remote managed-agents session reaches a terminal state, then exits with an exit code that distinguishes provider-side incidents from our-side problems:

- `0` — session completed
- `1` — our-side error (no tools called, parser failure, timeout)
- `2` — managed-agents/provider error (`unknown_error`, `model_overloaded_error`, retries exhausted, …)
- `130` — session cancelled

Provider errors carry a tagged message: `Provider error (managed-agents · unknown_error) (after 6 retries): <upstream message>`.

Default wait is 900 seconds; pass an explicit shorter value when you want to fail fast (e.g. `--wait 60`). Without `--wait` the existing fire-and-forget behavior is preserved.

## Why

The 2026-04-28 overview-regen sweep against [registry #590](https://github.com/buildinternet/releases/issues/590) surfaced this gap: 12 sessions all hit a backend incident (`unknown_error → retries_exhausted`) and `releases admin source fetch --org <slug>` returned `exit 0` for every one of them, so the orchestrating agent confabulated around stale data. Registry-side classification landed in [registry #591](https://github.com/buildinternet/releases/pull/591); this PR consumes it on the client side.

## Test plan

- [x] `bun test` — 208 pass (8 new for `classifySessionTerminalState`)
- [x] `bun run lint` — 0 warnings, 0 errors
- [x] `npx tsc --noEmit` — clean
- [ ] Smoke against staging once api-types ≥ 0.2.0 publishes (CLI inline-extends `Session` until then; flagged in `fetch-wait.ts`)

## Notes for reviewers

- `Session` from `@buildinternet/releases-api-types@0.1.0` doesn't yet carry the new classification fields. The CLI uses a small `SessionWithClassification` extension type until api-types publishes 0.2.0; the comment in `src/cli/commands/fetch-wait.ts` flags it for cleanup.
- `src/lib/sleep.ts` extracts a tiny shared helper that previously lived inline in `tail.ts`. No behavior change, just dedupe.
- Polling cadence is 3s; not-found grace is 15s. Both are constants in `fetch-wait.ts` if anyone wants to tune.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `--wait [seconds]` to `releases admin source fetch` to block until the remote update session reaches a terminal state (900s default when flag provided without a value); accepts shorter durations. Emits final success/failure output (JSON includes exitCode when requested) and returns classified exit codes: 0 (success), 1 (system errors/timeout), 2 (provider/managed-agent errors), 130 (cancelled).

* **Tests**
  * Added tests covering terminal-state classification and wait-seconds parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->