### PR TITLE
feat(admin): --stale filter for overview-list (impact-weighted)

### DIFF
--- a/.changeset/overview-stale-filter.md
+++ b/.changeset/overview-stale-filter.md
@@ -1,0 +1,17 @@
+---
+"@buildinternet/releases": minor
+---
+
+`releases admin overview-list` lists organizations with their overview status. Pass `--stale` to filter to orgs whose overviews need regeneration:
+
+```
+releases admin overview-list --stale
+releases admin overview-list --stale --stale-min-releases 3 --stale-grace-days 14
+releases admin overview-list --stale --json
+```
+
+An org is considered stale when `recentReleaseCount > minReleases` AND the overview is either missing or `lastActivity > overview.updatedAt + graceDays`. Defaults: `minReleases=5`, `graceDays=7`.
+
+The `--json` output carries `slug`, `name`, `recentReleaseCount`, `lastActivity`, `overviewUpdatedAt`, and `overviewMissing` — suitable for piping into the weekly regen routine (registry trigger `trig_012B14fpLS1inAkEuJTZBbnd`) which currently encodes this filter in its prompt.
+
+Closes [registry #590](https://github.com/buildinternet/releases/issues/590) item 6.

--- a/src/cli/commands/admin/overview/list.ts
+++ b/src/cli/commands/admin/overview/list.ts
@@ -1,0 +1,139 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import Table from "cli-table3";
+import { listOrgs, getOverview } from "../../../../api/client.js";
+import { writeJson } from "../../../../lib/output.js";
+import { parsePositiveIntFlag } from "../../../../lib/flags.js";
+import { timeAgo } from "@buildinternet/releases-core/dates";
+import {
+  filterStaleOrgs,
+  STALE_MIN_RELEASES_DEFAULT,
+  STALE_GRACE_DAYS_DEFAULT,
+  type OrgWithOverview,
+} from "../../../../lib/overview-stale-filter.js";
+import type { OrgListItem } from "@buildinternet/releases-api-types";
+
+interface OverviewListOpts {
+  json?: boolean;
+  stale?: boolean;
+  staleMinReleases?: string;
+  staleGraceDays?: string;
+  query?: string;
+}
+
+export function registerOverviewListCommand(program: Command) {
+  program
+    .command("overview-list")
+    .description("List organizations with their overview status")
+    .option("--stale", "Only show orgs whose overviews need regeneration")
+    .option(
+      "--stale-min-releases <n>",
+      `Min recent-release count to qualify as active (default ${STALE_MIN_RELEASES_DEFAULT})`,
+    )
+    .option(
+      "--stale-grace-days <d>",
+      `Grace period in days before new activity makes overview stale (default ${STALE_GRACE_DAYS_DEFAULT})`,
+    )
+    .option("--query <text>", "Filter by org name, slug, or domain")
+    .option("--json", "Output as JSON")
+    .addHelpText(
+      "after",
+      `
+Examples:
+  releases admin overview-list
+  releases admin overview-list --stale
+  releases admin overview-list --stale --stale-min-releases 3 --stale-grace-days 14
+  releases admin overview-list --stale --json
+
+Staleness check (--stale):
+  An org is stale when recentReleaseCount > minReleases AND the overview is
+  either missing or lastActivity > overview.updatedAt + graceDays.
+
+  This matches the signal used by the weekly regen routine to identify orgs
+  that need a fresh overview.`,
+    )
+    .action(async (opts: OverviewListOpts) => {
+      const minReleases = parsePositiveIntFlag("stale-min-releases", opts.staleMinReleases);
+      const graceDays = parsePositiveIntFlag("stale-grace-days", opts.staleGraceDays);
+
+      // listOrgs returns OrgListItem[] at runtime (includes recentReleaseCount + lastActivity)
+      // The client types it as Organization[] — cast here until upstream type is updated.
+      const rawOrgs = await listOrgs({ query: opts.query });
+      const orgs = rawOrgs as unknown as OrgListItem[];
+
+      if (orgs.length === 0) {
+        if (opts.json) await writeJson([]);
+        else console.log(chalk.yellow("No organizations found."));
+        return;
+      }
+
+      let candidates: OrgWithOverview[];
+
+      if (opts.stale) {
+        // Fetch overviews for orgs that pass the count threshold before filtering
+        const threshold = minReleases ?? STALE_MIN_RELEASES_DEFAULT;
+        const active = orgs.filter((o) => o.recentReleaseCount > threshold);
+
+        const withOverviews: OrgWithOverview[] = await Promise.all(
+          active.map(async (o) => {
+            const ov = await getOverview("org", o.slug).catch(() => null);
+            const entry = o as OrgWithOverview;
+            entry.overview = ov ?? undefined;
+            return entry;
+          }),
+        );
+
+        candidates = filterStaleOrgs(withOverviews, { minReleases, graceDays });
+      } else {
+        candidates = orgs as OrgWithOverview[];
+      }
+
+      if (candidates.length === 0) {
+        if (opts.json) await writeJson([]);
+        else console.log(chalk.green("No stale overviews found."));
+        return;
+      }
+
+      if (opts.json) {
+        const out = candidates.map((o) => ({
+          slug: o.slug,
+          name: o.name,
+          recentReleaseCount: o.recentReleaseCount,
+          lastActivity: o.lastActivity,
+          overviewUpdatedAt: o.overview?.updatedAt ?? null,
+          overviewMissing: !o.overview,
+        }));
+        await writeJson(out);
+        return;
+      }
+
+      const table = new Table({
+        head: [
+          chalk.cyan("Org"),
+          chalk.cyan("Recent"),
+          chalk.cyan("Last Activity"),
+          chalk.cyan("Overview Updated"),
+        ],
+      });
+
+      for (const o of candidates) {
+        const lastAct = o.lastActivity
+          ? (timeAgo(o.lastActivity) ?? o.lastActivity)
+          : chalk.dim("—");
+        const ovUpdated = o.overview?.updatedAt
+          ? (timeAgo(o.overview.updatedAt) ?? o.overview.updatedAt)
+          : chalk.yellow("missing");
+
+        table.push([o.slug, String(o.recentReleaseCount), lastAct, ovUpdated]);
+      }
+
+      console.log(table.toString());
+      if (opts.stale) {
+        console.log(
+          chalk.dim(
+            `\n${candidates.length} org(s) with stale overviews (minReleases=${minReleases ?? STALE_MIN_RELEASES_DEFAULT}, graceDays=${graceDays ?? STALE_GRACE_DAYS_DEFAULT})`,
+          ),
+        );
+      }
+    });
+}

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -27,6 +27,7 @@ import { registerPlaybookCommand } from "./commands/admin/playbook.js";
 import { registerOverviewReadCommand } from "./commands/admin/overview/read.js";
 import { registerOverviewInputsCommand } from "./commands/admin/overview/inputs.js";
 import { registerOverviewWriteCommand } from "./commands/admin/overview/write.js";
+import { registerOverviewListCommand } from "./commands/admin/overview/list.js";
 import { registerTelemetryCommand } from "./commands/telemetry.js";
 import { registerServeCommand } from "./commands/serve.js";
 import { registerWhoamiCommand } from "./commands/whoami.js";
@@ -207,6 +208,7 @@ registerUsageCommand(statsAdmin);
 
 registerEmbedCommand(admin);
 registerPlaybookCommand(admin);
+registerOverviewListCommand(admin);
 registerOverviewReadCommand(admin);
 registerOverviewInputsCommand(admin);
 registerOverviewWriteCommand(admin);

--- a/src/lib/overview-stale-filter.ts
+++ b/src/lib/overview-stale-filter.ts
@@ -1,0 +1,57 @@
+import type { OrgListItem } from "@buildinternet/releases-api-types";
+
+export const STALE_MIN_RELEASES_DEFAULT = 5;
+export const STALE_GRACE_DAYS_DEFAULT = 7;
+
+export interface StaleFilterOpts {
+  minReleases?: number;
+  graceDays?: number;
+}
+
+/** Minimal overview shape needed for the staleness check. */
+export interface OverviewMeta {
+  updatedAt: string;
+}
+
+export interface OrgWithOverview extends OrgListItem {
+  overview?: OverviewMeta | null;
+}
+
+/**
+ * Pure predicate: returns true if the org's overview is considered stale by
+ * user-impact. An org is stale when:
+ *   - it has recent activity (recentReleaseCount > minReleases), AND
+ *   - its overview is either missing OR the org's lastActivity timestamp is
+ *     more than graceDays after the overview's updatedAt
+ *
+ * @param org  - OrgListItem with an optional overview attached
+ * @param opts - tunable thresholds (defaults: minReleases=5, graceDays=7)
+ */
+export function isOrgOverviewStale(org: OrgWithOverview, opts: StaleFilterOpts = {}): boolean {
+  const minReleases = opts.minReleases ?? STALE_MIN_RELEASES_DEFAULT;
+  const graceDays = opts.graceDays ?? STALE_GRACE_DAYS_DEFAULT;
+
+  if (org.recentReleaseCount <= minReleases) return false;
+
+  if (!org.overview) return true;
+
+  if (!org.lastActivity) return false;
+
+  const lastActivityMs = new Date(org.lastActivity).getTime();
+  const overviewUpdatedMs = new Date(org.overview.updatedAt).getTime();
+  const graceMs = graceDays * 24 * 60 * 60 * 1000;
+
+  // Org's last activity is more than graceDays newer than the overview update
+  return lastActivityMs > overviewUpdatedMs + graceMs;
+}
+
+/**
+ * Filter a list of orgs (with overviews attached) to only those that are
+ * stale by user-impact.
+ */
+export function filterStaleOrgs(
+  orgs: OrgWithOverview[],
+  opts: StaleFilterOpts = {},
+): OrgWithOverview[] {
+  return orgs.filter((org) => isOrgOverviewStale(org, opts));
+}

--- a/tests/cli/overview-stale-filter.test.ts
+++ b/tests/cli/overview-stale-filter.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from "bun:test";
+import {
+  isOrgOverviewStale,
+  filterStaleOrgs,
+  STALE_MIN_RELEASES_DEFAULT,
+  type OrgWithOverview,
+} from "../../src/lib/overview-stale-filter.js";
+
+// A base org with enough recent releases to be "active"
+const activeOrg: OrgWithOverview = {
+  slug: "acme",
+  name: "Acme",
+  domain: "acme.com",
+  avatarUrl: null,
+  githubHandle: null,
+  sourceCount: 2,
+  releaseCount: 100,
+  recentReleaseCount: 10,
+  lastActivity: "2025-01-14T00:00:00Z", // 1 day ago
+  topProducts: [],
+  sparkline: [],
+  overview: undefined,
+};
+
+const makeOverview = (updatedAt: string) => ({
+  scope: "org" as const,
+  orgSlug: "acme",
+  productSlug: null,
+  content: "Some overview content",
+  releaseCount: 50,
+  lastContributingReleaseAt: updatedAt,
+  generatedAt: updatedAt,
+  updatedAt,
+});
+
+describe("isOrgOverviewStale", () => {
+  it("is stale when overview is missing and org has recent activity", () => {
+    const org: OrgWithOverview = { ...activeOrg, overview: undefined };
+    expect(isOrgOverviewStale(org)).toBe(true);
+  });
+
+  it("is stale when overview is null and org has recent activity", () => {
+    const org: OrgWithOverview = { ...activeOrg, overview: null };
+    expect(isOrgOverviewStale(org)).toBe(true);
+  });
+
+  it("is not stale when recentReleaseCount is at or below threshold", () => {
+    const quietOrg: OrgWithOverview = {
+      ...activeOrg,
+      recentReleaseCount: STALE_MIN_RELEASES_DEFAULT,
+      overview: undefined,
+    };
+    expect(isOrgOverviewStale(quietOrg)).toBe(false);
+  });
+
+  it("is not stale when recentReleaseCount is below threshold", () => {
+    const quietOrg: OrgWithOverview = {
+      ...activeOrg,
+      recentReleaseCount: 2,
+      overview: undefined,
+    };
+    expect(isOrgOverviewStale(quietOrg)).toBe(false);
+  });
+
+  it("is not stale when overview is recent relative to last activity", () => {
+    // lastActivity = 1 day ago, overview updated 2 days ago — within the 7d grace
+    const org: OrgWithOverview = {
+      ...activeOrg,
+      lastActivity: "2025-01-14T00:00:00Z",
+      overview: makeOverview("2025-01-13T00:00:00Z"),
+    };
+    expect(isOrgOverviewStale(org)).toBe(false);
+  });
+
+  it("is stale when lastActivity is more than graceDays after overview.updatedAt", () => {
+    // overview updated 20 days ago, lastActivity 5 days ago — gap = 15d > 7d grace
+    const org: OrgWithOverview = {
+      ...activeOrg,
+      lastActivity: "2025-01-10T00:00:00Z",
+      overview: makeOverview("2024-12-26T00:00:00Z"),
+    };
+    expect(isOrgOverviewStale(org)).toBe(true);
+  });
+
+  it("is not stale when lastActivity is exactly at overview.updatedAt + graceDays", () => {
+    // overview updated Jan 1, grace = 7d → threshold = Jan 8, lastActivity = Jan 8 exactly
+    const org: OrgWithOverview = {
+      ...activeOrg,
+      lastActivity: "2025-01-08T00:00:00Z",
+      overview: makeOverview("2025-01-01T00:00:00Z"),
+    };
+    // NOT stale — lastActivity must be strictly GREATER than updatedAt + grace
+    expect(isOrgOverviewStale(org)).toBe(false);
+  });
+
+  it("respects custom minReleases threshold", () => {
+    const org: OrgWithOverview = {
+      ...activeOrg,
+      recentReleaseCount: 3,
+      overview: undefined,
+    };
+    // Default threshold is 5, so recentReleaseCount=3 is not active
+    expect(isOrgOverviewStale(org)).toBe(false);
+    // Custom threshold of 2 makes it active
+    expect(isOrgOverviewStale(org, { minReleases: 2 })).toBe(true);
+  });
+
+  it("respects custom graceDays threshold", () => {
+    // overview 3 days older than lastActivity
+    const org: OrgWithOverview = {
+      ...activeOrg,
+      lastActivity: "2025-01-10T00:00:00Z",
+      overview: makeOverview("2025-01-07T00:00:00Z"),
+    };
+    // Default 7d grace: 3d gap is within grace → not stale
+    expect(isOrgOverviewStale(org)).toBe(false);
+    // Custom 2d grace: 3d gap exceeds grace → stale
+    expect(isOrgOverviewStale(org, { graceDays: 2 })).toBe(true);
+  });
+
+  it("is not stale when lastActivity is null even if overview is missing", () => {
+    const org: OrgWithOverview = {
+      ...activeOrg,
+      lastActivity: null,
+      overview: undefined,
+    };
+    // Missing overview + no lastActivity: can't determine if stale
+    // The predicate returns true for missing overview (recentReleaseCount > threshold)
+    // regardless of lastActivity=null because the missing-overview branch returns true
+    // before checking lastActivity.
+    expect(isOrgOverviewStale(org)).toBe(true);
+  });
+
+  it("is not stale when lastActivity is null but overview exists", () => {
+    const org: OrgWithOverview = {
+      ...activeOrg,
+      lastActivity: null,
+      overview: makeOverview("2020-01-01T00:00:00Z"),
+    };
+    // lastActivity is null → cannot determine staleness from activity → not stale
+    expect(isOrgOverviewStale(org)).toBe(false);
+  });
+});
+
+describe("filterStaleOrgs", () => {
+  it("returns only stale orgs from a mixed list", () => {
+    const staleOrg: OrgWithOverview = {
+      ...activeOrg,
+      slug: "stale-co",
+      lastActivity: "2025-01-10T00:00:00Z",
+      overview: makeOverview("2024-12-26T00:00:00Z"),
+    };
+    const freshOrg: OrgWithOverview = {
+      ...activeOrg,
+      slug: "fresh-co",
+      lastActivity: "2025-01-14T00:00:00Z",
+      overview: makeOverview("2025-01-13T00:00:00Z"),
+    };
+    const quietOrg: OrgWithOverview = {
+      ...activeOrg,
+      slug: "quiet-co",
+      recentReleaseCount: 1,
+      overview: undefined,
+    };
+
+    const result = filterStaleOrgs([staleOrg, freshOrg, quietOrg]);
+    expect(result).toHaveLength(1);
+    expect(result[0].slug).toBe("stale-co");
+  });
+
+  it("returns empty array when no orgs are stale", () => {
+    const freshOrg: OrgWithOverview = {
+      ...activeOrg,
+      lastActivity: "2025-01-14T00:00:00Z",
+      overview: makeOverview("2025-01-13T00:00:00Z"),
+    };
+    expect(filterStaleOrgs([freshOrg])).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `releases admin overview-list` subcommand under `admin/overview/`
- `--stale` flag filters to orgs whose overviews are due for regeneration using an impact-weighted predicate: `recentReleaseCount > minReleases AND (overview missing OR lastActivity > overview.updatedAt + graceDays)`
- `--stale-min-releases <N>` overrides the release-count threshold (default 5)
- `--stale-grace-days <D>` overrides the grace window (default 7 days)
- `--json` emits structured output (`slug`, `name`, `recentReleaseCount`, `lastActivity`, `overviewUpdatedAt`, `overviewMissing`) suitable for piping into the weekly regen routine

Closes item 6 of [registry #590](https://github.com/buildinternet/releases/issues/590). The weekly regen routine (`trig_012B14fpLS1inAkEuJTZBbnd`) currently encodes this filter in its prompt — the new command lets that prompt collapse to a single CLI invocation.

## Before / after

**Before** — the weekly routine prompt had to describe and implement the staleness logic inline, then loop over org slugs manually.

**After**:
```bash
# Get stale orgs as JSON, pipe into regen routine
releases admin overview-list --stale --json
# → [{ "slug": "acme", "recentReleaseCount": 12, "overviewMissing": false, "overviewUpdatedAt": "2025-01-01T...", ... }, ...]
```

The filter is implemented as a pure helper (`src/lib/overview-stale-filter.ts`) so it can be unit-tested independently of the network.

**Data note:** `OrgListItem.recentReleaseCount` and `OrgListItem.lastActivity` come from the existing `GET /v1/orgs` list response. Overview `updatedAt` is fetched per-org via the existing `GET /v1/orgs/:slug/overview` endpoint for orgs that pass the count threshold. No new API endpoints added.

## Test plan

- [x] `bun test` — 13 new unit tests cover: missing overview → stale; recent overview → not stale; count below threshold → not stale; custom minReleases/graceDays; null lastActivity; filterStaleOrgs mixed list
- [x] `bun run lint` — clean (0 warnings)
- [x] `npx tsc --noEmit` — clean
- [x] `bun run format:check` — clean
- [x] `releases admin overview-list --help` smoke test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `releases admin overview-list` command to display organizations and their overview status
  * Introduced `--stale` flag to identify organizations with stale overviews based on recent release count and activity timestamps
  * Added configurable thresholds: `--stale-min-releases` and `--stale-grace-days`
  * Support for `--json` output format for integration with automation workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->