### PR TITLE
chore(ci): pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,13 +26,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@ef50f123a3a9be95b60040d042717517407c7256 # v1.0.110
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.13
 
@@ -46,7 +46,7 @@ jobs:
 
       - name: Create Release PR or Publish
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
         with:
           version: bun run changeset:version
           publish: bun run changeset:publish

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,9 @@ jobs:
     name: Lint & Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           # Matches the release workflow pin; see release.yml for context.
           bun-version: canary
@@ -33,9 +33,9 @@ jobs:
     name: Type-check and test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           # Matches the release workflow pin; see release.yml for context.
           bun-version: canary


### PR DESCRIPTION
Companion to buildinternet/releases#596 (issue [buildinternet/releases#567](https://github.com/buildinternet/releases/issues/567)).

## Summary

- Pin every third-party action `uses:` ref across `ci.yml`, `claude.yml`, `release.yml` to a full commit SHA, with a trailing `# vX.Y.Z` comment for grep-ability.
- Add `.github/dependabot.yml` for the `github-actions` ecosystem, grouped into a single weekly PR.

Tags are mutable; a compromised maintainer can retarget an existing tag silently. Pinning to commit SHAs is the recommendation in [GitHub's security hardening guide](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) and OpenSSF Scorecard's `Pinned-Dependencies` check.

## SHA mapping

| Action | SHA | Version |
|---|---|---|
| `actions/checkout` | `34e114876b0b11c390a56381ad16ebd13914f8d5` | v4.3.1 |
| `actions/checkout` | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` | v6.0.2 |
| `oven-sh/setup-bun` | `0c5077e51419868618aeaa5fe8019c62421857d6` | v2.2.0 |
| `anthropics/claude-code-action` | `ef50f123a3a9be95b60040d042717517407c7256` | v1.0.110 |
| `changesets/action` | `6a0a831ff30acef54f2c6aa1cbbc1096b066edaf` | v1.7.0 |

No changeset — this is CI-only and doesn't affect the published package.

## Test plan

- [ ] `test.yml` passes on this PR
- [ ] `release.yml` will only run on push to `main` post-merge; expect changesets/action and setup-bun to behave identically at the pinned SHA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configurations to use pinned action versions across all workflows.
  * Added automated GitHub Actions dependency monitoring configuration on a weekly schedule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->