### PR TITLE
chore(ci): add bun ecosystem to Dependabot

### DIFF
--- a/.changeset/dependabot-bun-ecosystem.md
+++ b/.changeset/dependabot-bun-ecosystem.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": patch
+---
+
+Add the `bun` ecosystem to the Dependabot config so npm dependency bumps land as weekly grouped PRs (production and dev separated). Pairs with the SHA-pinned GitHub Actions config — bun.lock already pins every package by sha512 integrity hash and CI runs with `--frozen-lockfile`, so this closes the loop on surfacing upstream drift. CI-only; no runtime behavior change.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,19 @@ updates:
       actions:
         patterns:
           - "*"
+  - package-ecosystem: "bun"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      production-deps:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      dev-deps:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Follow-up to #73 (now merged) and the parallel monorepo PR ([buildinternet/releases#596](https://github.com/buildinternet/releases/pull/596)). Same theme — close the loop on supply-chain visibility on the package side now that the Actions side is SHA-pinned.

## Summary

- Add the `bun` ecosystem to `.github/dependabot.yml`, grouped weekly into two PRs (production deps, dev deps).
- Includes a patch changeset.

## Why this is enough on the bun side

Already in place — no changes needed:

- `bun.lock` is the text-format lockfile and pins every package by `sha512` integrity hash (~hundreds of entries).
- Every CI install in `test.yml` and `release.yml` runs with `--frozen-lockfile`, so any drift between `package.json` and `bun.lock` fails the build instead of silently resolving.

The remaining gap was getting upstream version bumps surfaced as PRs. Dependabot's `bun` ecosystem (GA in `dependabot-core` over the last few months) updates `package.json` and regenerates `bun.lock` in the same PR, so the integrity hashes stay correct after a bump.

Grouping config:
- `production-deps` — minor + patch, runtime deps, one PR
- `dev-deps` — minor + patch, dev deps, one PR
- Majors stay ungrouped so they get individual review

## Test plan

- [ ] `test.yml` passes on this PR
- [ ] First Dependabot bun PR opens within a week and the grouped CI run is green
