### PR TITLE
chore: move admin blocklist calls to /v1/admin/blocklist

### DIFF
--- a/.changeset/blocklist-route.md
+++ b/.changeset/blocklist-route.md
@@ -1,0 +1,7 @@
+---
+"@buildinternet/releases": patch
+---
+
+Move admin blocklist calls to `/v1/admin/blocklist` (was `/v1/blocked-urls`). The registry renamed the route to align with the `/v1/admin/...` convention; the old path is going away. Affects `releases admin block` / `unblock` and the `releases whoami` admin probe.
+
+Closes [registry #524](https://github.com/buildinternet/releases/issues/524).

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -177,7 +177,7 @@ export async function removeIgnoredUrl(url: string, orgId: string): Promise<void
 
 export async function findBlockedUrl(url: string): Promise<BlockedUrl | null> {
   const encoded = encodeURIComponent(url);
-  return apiFetch<BlockedUrl | null>(`/v1/blocked-urls?url=${encoded}&single=true`);
+  return apiFetch<BlockedUrl | null>(`/v1/admin/blocklist?url=${encoded}&single=true`);
 }
 
 export async function addBlockedUrl(
@@ -185,18 +185,18 @@ export async function addBlockedUrl(
   type: "exact" | "domain",
   reason?: string,
 ): Promise<void> {
-  await apiFetch("/v1/blocked-urls", {
+  await apiFetch("/v1/admin/blocklist", {
     method: "POST",
     body: JSON.stringify({ pattern, type, reason }),
   });
 }
 
 export async function listBlockedUrls(): Promise<BlockedUrl[]> {
-  return apiFetch<BlockedUrl[]>("/v1/blocked-urls");
+  return apiFetch<BlockedUrl[]>("/v1/admin/blocklist");
 }
 
 export async function removeBlockedUrl(pattern: string): Promise<void> {
-  await apiFetch(`/v1/blocked-urls/${encodeURIComponent(pattern)}`, { method: "DELETE" });
+  await apiFetch(`/v1/admin/blocklist/${encodeURIComponent(pattern)}`, { method: "DELETE" });
 }
 
 // ── Release CRUD ──

--- a/src/cli/commands/whoami.ts
+++ b/src/cli/commands/whoami.ts
@@ -39,7 +39,7 @@ async function probeApi(mode: WhoamiStatus["mode"]): Promise<NonNullable<WhoamiS
   // Public probe hits a public read to confirm connectivity.
   // We call fetch directly (not apiFetch) because apiFetch returns null on
   // GET 404 — which would false-positive the probe for a misconfigured URL.
-  const path = mode === "admin" ? "/v1/blocked-urls?limit=1" : "/v1/sources?limit=1";
+  const path = mode === "admin" ? "/v1/admin/blocklist?limit=1" : "/v1/sources?limit=1";
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
     "User-Agent": RELEASES_CLI_UA,


### PR DESCRIPTION
## Summary

- Switch the four `BlockedUrl` helpers in `src/api/client.ts` and the `whoami` admin probe from `/v1/blocked-urls` to `/v1/admin/blocklist`.
- The registry route was renamed in [buildinternet/releases#597](https://github.com/buildinternet/releases/pull/597) (closes [registry #524](https://github.com/buildinternet/releases/issues/524)) to align with the `/v1/admin/...` convention.
- Hard cutover on the registry side — **merge + release this only after the registry PR is deployed**, otherwise `releases admin block` / `unblock` / `whoami --admin` will start 404'ing.
- Changeset is a `patch` against `@buildinternet/releases`.

## Test plan

- [ ] Type-check + lint clean locally
- [ ] After registry deploy, smoke `releases admin block <pattern>`, `releases admin unblock <pattern>`, `releases whoami --admin`
- [ ] Confirm changeset publishes a new patch via the release pipeline
