### PR TITLE
chore(lint): disable no-underscore-dangle in oxlint config

### DIFF
--- a/.changeset/oxlint-no-underscore-dangle.md
+++ b/.changeset/oxlint-no-underscore-dangle.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": patch
+---
+
+Disable oxlint's `no-underscore-dangle` rule, surfaced by the 1.62 upgrade. The codebase deliberately uses leading-underscore identifiers for module-private state (`_dataDir`, `_apiUrl`, `_apiKey`, `_admin`); the rule's complaints aren't actionable. Keeps lint output clean and matches the same change in the monorepo for cross-repo consistency. CI-only; no runtime change.

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -8,6 +8,7 @@
   },
   "rules": {
     "no-console": "off",
+    "no-underscore-dangle": "off",
     "no-unused-vars": ["warn", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
     "typescript/no-explicit-any": "off",
     "typescript/no-non-null-assertion": "off",


### PR DESCRIPTION
Follow-up to the oxlint 1.62 upgrade. The new release turned `no-underscore-dangle` on by default, surfacing 4 warnings on intentional leading-underscore identifiers.

## What this changes

One line added to `.oxlintrc.json`:

```diff
   "rules": {
     "no-console": "off",
+    "no-underscore-dangle": "off",
     "no-unused-vars": ["warn", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
```

## Why disable rather than allow-list

The complaints aren't actionable — they all flag deliberate module-private state conventions:
- `_dataDir` in `packages/lib/src/config.ts`
- `_apiUrl`, `_apiKey`, `_admin` in `src/lib/mode.ts`

A blanket disable is honest about the codebase's stance: leading underscores for module-internal state are fine. Allow-listing each identifier creates churn every time another is added.

## Cross-repo consistency

Same one-line change is going into `buildinternet/releases` to keep linting standards aligned across the monorepo and CLI.

## Changeset

Patch — CI-only, no runtime change.

## Verification

- [x] `bun run lint` — was 4 warnings, now 0
- [x] No other rules touched
