### PR TITLE
search: adopt catalog rename in unified search response

### DIFF
--- a/.changeset/adopt-catalog-rename.md
+++ b/.changeset/adopt-catalog-rename.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": patch
+---
+
+Adopt the `catalog` rename in unified search responses (monorepo issue #539 follow-up). `releases search` now reads `response.catalog` and renders the section as **Catalog** in human and markdown output (it covered products + standalone sources already; the header now matches the wire field). `--type catalog` is the canonical filter; `--type products` is accepted as a deprecated alias. The deprecated `response.products` field is still read as a fallback so older API deploys keep working — that fallback can be dropped once the alias is removed from the wire. Plugin docs and the `releases-mcp` skill updated to point at the new `search` / `list_catalog` / `get_catalog_entry` MCP tools.

--- a/plugins/claude/releases/README.md
+++ b/plugins/claude/releases/README.md
@@ -26,21 +26,29 @@ claude --plugin-dir plugins/claude/releases
 
 ## Available MCP Tools
 
+### search
+
+Unified lexical/semantic search across organizations, the catalog (products + standalone sources), and releases. Returns three sections in one call (`orgs`, `catalog`, `releases`); narrow with `type`. Catalog hits include a `kind: "product" | "source"` discriminator; release hits include `kind: "release" | "changelog_chunk"`. Replaces the older `search_registry` / `search_releases` pair.
+
 ### search_releases
 
-Full-text search across all indexed release notes. Filter by product, organization, or release `type`.
+Releases-only full-text search (back-compat shim — prefer `search`). Filter by product, organization, or release `type`.
 
 ### get_latest_releases
 
 Get the most recent releases, optionally filtered by product, organization, or release `type`.
 
-### list_sources
+### list_catalog
 
-List all indexed changelog sources, optionally scoped to one organization.
+List catalog entries — products and standalone sources combined into one list with a `kind: "product" | "source"` discriminator per row. Replaces `list_products` + `list_sources`.
 
-### get_source
+### get_catalog_entry
 
-Detail for a single source including org/product linkage, release count, last-fetched timestamp, and whether a CHANGELOG file is stored.
+Detail for a single catalog entry (product or standalone source) including org linkage, category, tags, and grouped sources.
+
+### list_sources / get_source
+
+Deprecated — use `list_catalog` / `get_catalog_entry`. Kept as aliases for one release cycle.
 
 ### get_source_changelog
 
@@ -58,13 +66,9 @@ Get detailed information about a single organization. Includes a short preview o
 
 Read the full AI-generated overview for an organization — a short briefing that distills recent changelog activity into themed sections.
 
-### list_products
+### list_products / get_product
 
-List products, optionally scoped to one organization.
-
-### get_product
-
-Detail for a single product with its organization, category, tags, and the sources grouped under it.
+Deprecated — use `list_catalog` / `get_catalog_entry`. Kept as aliases for one release cycle.
 
 ## Usage Examples
 

--- a/plugins/claude/releases/agents/discovery.md
+++ b/plugins/claude/releases/agents/discovery.md
@@ -14,10 +14,10 @@ You have two kinds of tools:
 
 Connected via the Releases MCP server. Use for all read/search operations:
 
-- **search_releases** — Hybrid lexical + semantic search across releases and CHANGELOG chunks (default `mode: "hybrid"`); each hit carries a `kind: "release"|"changelog_chunk"` discriminator
-- **search_registry** — Vector-backed lookup across orgs, products, and sources by name/description/category
+- **search** — Unified hybrid lexical + semantic search across orgs, the catalog (products + standalone sources), and releases. Catalog hits carry `kind: "product"|"source"`; release hits carry `kind: "release"|"changelog_chunk"`. Replaces the separate `search_registry` / `search_releases` pair (both kept as deprecated aliases).
+- **list_catalog** — List catalog entries (products + standalone sources combined) with a `kind` discriminator. Replaces `list_products` + `list_sources` (both kept as deprecated aliases).
+- **get_catalog_entry** — Detail for a single catalog entry. Replaces `get_product` + `get_source` (both kept as deprecated aliases).
 - **get_latest_releases** — Recent releases for a product or organization
-- **list_sources** — List indexed changelog sources
 - **list_organizations** — Search/list organizations
 - **get_organization** — Detailed view of a single org (accounts, tags, sources, products, aliases)
 - **summarize_changes** — AI-generated summary of recent changes
@@ -49,8 +49,8 @@ Key commands:
 
 ## Onboarding Workflow
 
-1. **Pre-check** — Use `list_organizations` and `list_sources` MCP tools to check if the company already exists with sources. If it does, report the existing state and stop — do not re-discover or add duplicate sources.
-2. **Discover** — Use `releases admin discovery evaluate <url> --json`, web search, and `list_sources` to find changelog URLs, feeds, and GitHub repos.
+1. **Pre-check** — Use `list_organizations` and `list_catalog` MCP tools to check if the company already exists with sources. If it does, report the existing state and stop — do not re-discover or add duplicate sources.
+2. **Discover** — Use `releases admin discovery evaluate <url> --json`, web search, and `list_catalog` to find changelog URLs, feeds, and GitHub repos.
 3. **Add** — Add sources with `releases admin source add` using appropriate types. When creating an org, always include `--description` with a brief one-sentence product description.
 4. **Validate** — Fetch each source with `releases admin source fetch <slug> --dry-run` first, then real fetch. Check results with `releases tail <slug> --json`.
 5. **Assess content depth** — For feed sources, check if pages have richer content than feed summaries.

--- a/plugins/claude/releases/agents/worker.md
+++ b/plugins/claude/releases/agents/worker.md
@@ -12,9 +12,9 @@ You are a worker agent for the Releases.sh registry. Your job is to execute fetc
 
 Connected via the Releases MCP server:
 
-- **search_releases** — Hybrid lexical + semantic search across releases and CHANGELOG chunks (default `mode: "hybrid"`); each hit carries a `kind: "release"|"changelog_chunk"` discriminator
+- **search** — Unified hybrid lexical + semantic search across orgs, the catalog (products + standalone sources), and releases. Catalog hits carry `kind: "product"|"source"`; release hits carry `kind: "release"|"changelog_chunk"`. (`search_registry` / `search_releases` still exist as deprecated aliases.)
 - **get_latest_releases** — Recent releases for a product or organization
-- **list_sources** — List indexed changelog sources
+- **list_catalog** — List catalog entries (products + standalone sources). Replaces `list_products` + `list_sources` (both kept as deprecated aliases).
 - **list_organizations** — Search/list organizations
 - **get_organization** — Detailed view of a single org
 

--- a/plugins/claude/releases/skills/analyzing-releases/SKILL.md
+++ b/plugins/claude/releases/skills/analyzing-releases/SKILL.md
@@ -20,10 +20,10 @@ Turn changelog data into competitive intelligence by analyzing release patterns 
 
 | Operation | CLI | Typed tool |
 |-----------|-----|------------|
-| Check existing sources | `releases list --query <company> --json` | `list_sources` with query param |
+| Check existing sources | `releases list --query <company> --json` | `list_catalog` with query param; `list_sources` is a deprecated alias |
 | Fetch releases | `releases admin source fetch <slug> --max 50` | `manage_source` action "fetch" with identifier (ID or slug) |
 | Get latest releases | `releases tail <slug> --json` | `get_latest_releases` with source/org and limit |
-| Search releases | `releases search <query> --json` | `search_releases` with query |
+| Search releases | `releases search <query> --json` | `search` with `type: ["releases"]`; `search_releases` is a deprecated alias |
 | Summarize | `releases summary <slug> --json` | (not available as typed tool) |
 | Compare | `releases compare <slugA> <slugB> --json` | (not available as typed tool) |
 
@@ -47,13 +47,13 @@ Get structured release data with dates for each source. Use a limit (e.g., 50) t
 
 ### 5. Search and cross-reference
 
-Search across all indexed releases to find specific features, breaking changes, or patterns. `search_releases` is hybrid (lexical + semantic) by default — natural-language queries like "auth refresh tokens" or "cold start improvements" work without exact keyword matches. Pass `mode: "lexical"` if you need strict keyword behavior.
+Search across all indexed releases to find specific features, breaking changes, or patterns. The unified `search` tool (with `type: ["releases"]`) is hybrid (lexical + semantic) by default — natural-language queries like "auth refresh tokens" or "cold start improvements" work without exact keyword matches. Pass `mode: "lexical"` if you need strict keyword behavior.
 
 **Result shape:** every hit carries a `kind` discriminator:
 - `kind: "release"` — a normal release row, use as-is.
 - `kind: "changelog_chunk"` — a passage from a stored CHANGELOG.md file. The hit includes `sourceSlug`, `chunkOffset`, and `chunkLength`. Chain into `get_source_changelog({ slug: sourceSlug, offset: chunkOffset, limit: chunkLength * 3 })` to read the surrounding section before quoting it. Chunk hits often surface older or more granular notes than what's in the indexed release rows, so they're useful for "when did X first ship" questions.
 
-For org/product/source discovery (e.g. "find observability vendors with edge offerings"), use `search_registry` instead of `list_sources --query` — it's vector-backed and matches on description and category, not just slug substring.
+For org/product/source discovery (e.g. "find observability vendors with edge offerings"), use `search` with `type: ["orgs", "catalog"]` instead of `list_catalog --query` — it's vector-backed and matches on description and category, not just slug substring.
 
 ### 6. Synthesize
 

--- a/plugins/claude/releases/skills/managing-sources/SKILL.md
+++ b/plugins/claude/releases/skills/managing-sources/SKILL.md
@@ -16,13 +16,13 @@ Operations can be performed via CLI commands or typed MCP/agent tools. Use which
 
 | Operation | CLI | Typed tool |
 |-----------|-----|------------|
-| List sources | `releases list [slug] --json [--org <org>] [--query <text>] [--has-feed] [--category <c>] [--compact] [--limit <n>] [--page <n>]` | `list_sources` with query, organization, category, has_feed params |
+| List sources | `releases list [slug] --json [--org <org>] [--query <text>] [--has-feed] [--category <c>] [--compact] [--limit <n>] [--page <n>]` | `list_catalog` (filter `kind: "source"` to exclude products); `list_sources` is a deprecated alias |
 | Add source | `releases admin source add <name> --url <url> [--type <type>] [--org <org>] [--feed-url <url>] [--primary]` | `manage_source` action "add" with name, url, type, organization, feed_url, **is_primary** (type auto-detected if omitted; only pass is_primary=true when the source is the org's primary changelog — see "Primary Sources") |
 | Edit source | `releases admin source edit <identifier> [--primary] [--priority <p>]` | `manage_source` action "edit" with identifier, is_primary, fetch_priority, name, url, type (use only when changing an already-added source; prefer setting flags on "add") |
 | Remove source | `releases admin source remove <slug> [--ignore --reason <reason>]` | `manage_source` action "remove" with identifier |
 | Fetch releases | `releases admin source fetch <slug> [--dry-run] [--max <n>]` | `manage_source` action "fetch" with identifier |
 | Get latest releases | `releases tail [slug] --json [--org <org>]` | `get_latest_releases` with source, organization, limit params |
-| Search releases | `releases search <query> --json` | `search_releases` with query, limit params |
+| Search releases | `releases search <query> --json` | `search` with `type: ["releases"]`; `search_releases` is a deprecated alias |
 | Evaluate URL | `releases admin discovery evaluate <url> --json` | `evaluate_url` with url param |
 | Add org | `releases admin org add <name> [--domain <d>] [--description <t>] [--category <c>] [--tags <t1,t2>]` | `manage_org` action "add" with name, domain, description, category, tags |
 | Edit org | `releases admin org edit <slug> [--category <c>]` | `manage_org` action "edit" with identifier, category |
@@ -70,7 +70,7 @@ When in doubt: would a developer reading this name on its own (with the org alre
 
 ### Organization descriptions
 
-When creating an org, include a brief one-sentence product description. This grounds AI summaries for lesser-known products, and it's also the primary signal for the entity vector index — `search_registry` and the registry side of hybrid search match on description + category, not just name. A good description noticeably improves recall.
+When creating an org, include a brief one-sentence product description. This grounds AI summaries for lesser-known products, and it's also the primary signal for the entity vector index — the unified `search` tool (and the registry side of hybrid search) matches on description + category, not just name. A good description noticeably improves recall.
 
 ### Embedding side effects
 

--- a/plugins/claude/releases/skills/releases-cli/references/reader.md
+++ b/plugins/claude/releases/skills/releases-cli/references/reader.md
@@ -4,25 +4,23 @@ Reader commands are unauthenticated — no API key required. They talk to `api.r
 
 ## Search
 
-Hybrid lexical + semantic search across releases and CHANGELOG chunks.
+Unified search across organizations, the catalog (products + standalone sources), and releases.
 
 ```bash
 releases search "authentication"
 releases search "vercel" --type releases --limit 5
+releases search "react" --type catalog
 releases search "breaking change" --json
-releases search "retry" --org stripe
 ```
 
 Flags:
 
-- `--type <releases|sources|all>` — narrow result kind (default: `all`).
-- `--org <slug>` — scope to one organization.
-- `--product <slug>` — scope to one product.
-- `--limit <n>` — default 20.
-- `--mode <lexical|semantic|hybrid>` — default `hybrid`. Use `lexical` for pure FTS ranking.
-- `--json` — machine output; each hit includes a `kind: "release" | "changelog_chunk"` discriminator.
+- `--type <orgs|catalog|releases>` — narrow to one section (default: all three). `products` is accepted as a deprecated alias for `catalog`.
+- `--limit <n>` — max results per section (default: 10).
+- `--mode <lexical|semantic|hybrid>` — pick the release-retrieval strategy. Server default is hybrid; pass `lexical` for pure FTS ranking.
+- `--json` — machine output. Release hits include a `kind: "release" | "changelog_chunk"` discriminator. Catalog hits include `kind: "product" | "source"` so you can route a click to either a product page or a standalone source.
 
-Chunk hits carry `sourceSlug`, `chunkOffset`, and `chunkLength` so you can chain into `releases admin source changelog <slug> --offset N` (or the MCP `get_source_changelog` tool) to read surrounding context.
+Catalog hits also include the response field `catalog`. Older API deploys will still send the deprecated `products` alias instead — the CLI reads either, but new code should consume `catalog`.
 
 ## Latest releases
 

--- a/plugins/claude/releases/skills/releases-mcp/SKILL.md
+++ b/plugins/claude/releases/skills/releases-mcp/SKILL.md
@@ -22,9 +22,11 @@ Activate when the user:
 
 ## How to Look Up Releases
 
-### Step 1: Find the Organization or Product
+### Step 1: Find the Organization or Catalog Entry
 
-Call `list_organizations` with the library/product name as the `query` parameter. Multi-product orgs (e.g. Vercel → Next.js, Turborepo) are exposed via `list_products` and `get_product` — use those when the user's question is product-specific rather than company-wide.
+Call `list_organizations` with the library/product name as the `query` parameter. For product-specific questions, browse the catalog (products + standalone sources) with `list_catalog` and fetch detail with `get_catalog_entry` — these replaced the older `list_products` / `get_product` / `list_sources` / `get_source` tools, which still exist as deprecated aliases.
+
+The unified `search` tool is also available — it returns `orgs`, `catalog`, and `releases` sections in one call. Catalog hits carry a `kind: "product" | "source"` discriminator, so you can route a click to either a product page or a standalone source. (Older API responses send the same array under a deprecated `products` alias; new clients should consume `catalog`.)
 
 If the query returns no results, try variations:
 - The company name instead of the product name (e.g., "Vercel" instead of "Next.js")
@@ -34,9 +36,11 @@ If the query returns no results, try variations:
 ### Step 2: Choose the Right Tool
 
 - **"What's new?" / "Latest releases"** → Use `get_latest_releases` with the organization or product slug
-- **Specific feature or keyword** → Use `search_releases` with a descriptive query and organization filter
+- **Specific feature or keyword across orgs + catalog + releases** → Use `search` (unified) with a descriptive query; narrow via `type: ["releases"]` etc.
+- **Releases-only search** → Use `search_releases` (kept for back-compat) when you only want release rows
 - **Single release by id** → Use `get_release` when you already have a `rel_` id (search results include ids)
-- **Source or product deep-dive** → Use `get_source`, `get_product`, or `get_organization` for metadata, tags, and linkage
+- **Catalog deep-dive (product or standalone source)** → Use `get_catalog_entry` for metadata, tags, and linkage
+- **Organization detail** → Use `get_organization`
 - **Canonical CHANGELOG.md from a GitHub repo** → Use `get_source_changelog` when the user wants the full maintained file, not just the tagged releases (refreshed on every fetch). For large files, pass `tokens` (cl100k_base budget, e.g. 5000 or 10000) to get a heading-aligned slice that fits a known context window; chain via the returned `nextOffset`. Every response reports `totalTokens` so you can plan how many calls you need upfront.
 - **Compare two products** → Use `compare_products` with an array of two product slugs
 - **Summarize recent activity** → Use `summarize_changes` with the product slug

--- a/skills/analyzing-releases/SKILL.md
+++ b/skills/analyzing-releases/SKILL.md
@@ -17,10 +17,10 @@ Turn changelog data into competitive intelligence by analyzing release patterns 
 
 | Operation | CLI | Typed tool |
 |-----------|-----|------------|
-| Check existing sources | `releases list --query <company> --json` | `list_sources` with query param |
+| Check existing sources | `releases list --query <company> --json` | `list_catalog` with query param; `list_sources` is a deprecated alias |
 | Fetch releases | `releases admin source fetch <slug> --max 50` | `manage_source` action "fetch" with identifier (ID or slug) |
 | Get latest releases | `releases tail <slug> --json` | `get_latest_releases` with source/org and limit |
-| Search releases | `releases search <query> --json` | `search_releases` with query |
+| Search releases | `releases search <query> --json` | `search` with `type: ["releases"]`; `search_releases` is a deprecated alias |
 | Summarize | `releases summary <slug> --json` | (not available as typed tool) |
 | Compare | `releases compare <slugA> <slugB> --json` | (not available as typed tool) |
 
@@ -44,13 +44,13 @@ Get structured release data with dates for each source. Use a limit (e.g., 50) t
 
 ### 5. Search and cross-reference
 
-Search across all indexed releases to find specific features, breaking changes, or patterns. `search_releases` is hybrid (lexical + semantic) by default — natural-language queries like "auth refresh tokens" or "cold start improvements" work without exact keyword matches. Pass `mode: "lexical"` if you need strict keyword behavior.
+Search across all indexed releases to find specific features, breaking changes, or patterns. The unified `search` tool (with `type: ["releases"]`) is hybrid (lexical + semantic) by default — natural-language queries like "auth refresh tokens" or "cold start improvements" work without exact keyword matches. Pass `mode: "lexical"` if you need strict keyword behavior.
 
 **Result shape:** every hit carries a `kind` discriminator:
 - `kind: "release"` — a normal release row, use as-is.
 - `kind: "changelog_chunk"` — a passage from a stored CHANGELOG.md file. The hit includes `sourceSlug`, `chunkOffset`, and `chunkLength`. Chain into `get_source_changelog({ slug: sourceSlug, offset: chunkOffset, limit: chunkLength * 3 })` to read the surrounding section before quoting it. Chunk hits often surface older or more granular notes than what's in the indexed release rows, so they're useful for "when did X first ship" questions.
 
-For org/product/source discovery (e.g. "find observability vendors with edge offerings"), use `search_registry` instead of `list_sources --query` — it's vector-backed and matches on description and category, not just slug substring.
+For org/product/source discovery (e.g. "find observability vendors with edge offerings"), use `search` with `type: ["orgs", "catalog"]` instead of `list_catalog --query` — it's vector-backed and matches on description and category, not just slug substring.
 
 ### 6. Synthesize
 

--- a/skills/managing-sources/SKILL.md
+++ b/skills/managing-sources/SKILL.md
@@ -13,13 +13,13 @@ Operations can be performed via CLI commands or typed MCP/agent tools. Use which
 
 | Operation | CLI | Typed tool |
 |-----------|-----|------------|
-| List sources | `releases list [slug] --json [--org <org>] [--query <text>] [--has-feed] [--category <c>] [--compact] [--limit <n>] [--page <n>]` | `list_sources` with query, organization, category, has_feed params |
+| List sources | `releases list [slug] --json [--org <org>] [--query <text>] [--has-feed] [--category <c>] [--compact] [--limit <n>] [--page <n>]` | `list_catalog` (filter `kind: "source"` to exclude products); `list_sources` is a deprecated alias |
 | Add source | `releases admin source add <name> --url <url> [--type <type>] [--org <org>] [--feed-url <url>] [--primary]` | `manage_source` action "add" with name, url, type, organization, feed_url, **is_primary** (type auto-detected if omitted; only pass is_primary=true when the source is the org's primary changelog — see "Primary Sources") |
 | Edit source | `releases admin source edit <identifier> [--primary] [--priority <p>]` | `manage_source` action "edit" with identifier, is_primary, fetch_priority, name, url, type (use only when changing an already-added source; prefer setting flags on "add") |
 | Remove source | `releases admin source remove <slug> [--ignore --reason <reason>]` | `manage_source` action "remove" with identifier |
 | Fetch releases | `releases admin source fetch <slug> [--dry-run] [--max <n>]` | `manage_source` action "fetch" with identifier |
 | Get latest releases | `releases tail [slug] --json [--org <org>]` | `get_latest_releases` with source, organization, limit params |
-| Search releases | `releases search <query> --json` | `search_releases` with query, limit params |
+| Search releases | `releases search <query> --json` | `search` with `type: ["releases"]`; `search_releases` is a deprecated alias |
 | Evaluate URL | `releases admin discovery evaluate <url> --json` | `evaluate_url` with url param |
 | Add org | `releases admin org add <name> [--domain <d>] [--description <t>] [--category <c>] [--tags <t1,t2>]` | `manage_org` action "add" with name, domain, description, category, tags |
 | Edit org | `releases admin org edit <slug> [--category <c>]` | `manage_org` action "edit" with identifier, category |
@@ -67,7 +67,7 @@ When in doubt: would a developer reading this name on its own (with the org alre
 
 ### Organization descriptions
 
-When creating an org, include a brief one-sentence product description. This grounds AI summaries for lesser-known products, and it's also the primary signal for the entity vector index — `search_registry` and the registry side of hybrid search match on description + category, not just name. A good description noticeably improves recall.
+When creating an org, include a brief one-sentence product description. This grounds AI summaries for lesser-known products, and it's also the primary signal for the entity vector index — the unified `search` tool (and the registry side of hybrid search) matches on description + category, not just name. A good description noticeably improves recall.
 
 ### Embedding side effects
 

--- a/skills/releases-cli/references/reader.md
+++ b/skills/releases-cli/references/reader.md
@@ -4,25 +4,23 @@ Reader commands are unauthenticated — no API key required. They talk to `api.r
 
 ## Search
 
-Hybrid lexical + semantic search across releases and CHANGELOG chunks.
+Unified search across organizations, the catalog (products + standalone sources), and releases.
 
 ```bash
 releases search "authentication"
 releases search "vercel" --type releases --limit 5
+releases search "react" --type catalog
 releases search "breaking change" --json
-releases search "retry" --org stripe
 ```
 
 Flags:
 
-- `--type <releases|sources|all>` — narrow result kind (default: `all`).
-- `--org <slug>` — scope to one organization.
-- `--product <slug>` — scope to one product.
-- `--limit <n>` — default 20.
-- `--mode <lexical|semantic|hybrid>` — default `hybrid`. Use `lexical` for pure FTS ranking.
-- `--json` — machine output; each hit includes a `kind: "release" | "changelog_chunk"` discriminator.
+- `--type <orgs|catalog|releases>` — narrow to one section (default: all three). `products` is accepted as a deprecated alias for `catalog`.
+- `--limit <n>` — max results per section (default: 10).
+- `--mode <lexical|semantic|hybrid>` — pick the release-retrieval strategy. Server default is hybrid; pass `lexical` for pure FTS ranking.
+- `--json` — machine output. Release hits include a `kind: "release" | "changelog_chunk"` discriminator. Catalog hits include `kind: "product" | "source"` so you can route a click to either a product page or a standalone source.
 
-Chunk hits carry `sourceSlug`, `chunkOffset`, and `chunkLength` so you can chain into `releases admin source changelog <slug> --offset N` (or the MCP `get_source_changelog` tool) to read surrounding context.
+Catalog hits also include the response field `catalog`. Older API deploys will still send the deprecated `products` alias instead — the CLI reads either, but new code should consume `catalog`.
 
 ## Latest releases
 

--- a/skills/releases-mcp/SKILL.md
+++ b/skills/releases-mcp/SKILL.md
@@ -19,9 +19,11 @@ Activate when the user:
 
 ## How to Look Up Releases
 
-### Step 1: Find the Organization or Product
+### Step 1: Find the Organization or Catalog Entry
 
-Call `list_organizations` with the library/product name as the `query` parameter. Multi-product orgs (e.g. Vercel → Next.js, Turborepo) are exposed via `list_products` and `get_product` — use those when the user's question is product-specific rather than company-wide.
+Call `list_organizations` with the library/product name as the `query` parameter. For product-specific questions, browse the catalog (products + standalone sources) with `list_catalog` and fetch detail with `get_catalog_entry` — these replaced the older `list_products` / `get_product` / `list_sources` / `get_source` tools, which still exist as deprecated aliases.
+
+The unified `search` tool is also available — it returns `orgs`, `catalog`, and `releases` sections in one call. Catalog hits carry a `kind: "product" | "source"` discriminator, so you can route a click to either a product page or a standalone source. (Older API responses send the same array under a deprecated `products` alias; new clients should consume `catalog`.)
 
 If the query returns no results, try variations:
 - The company name instead of the product name (e.g., "Vercel" instead of "Next.js")
@@ -31,9 +33,11 @@ If the query returns no results, try variations:
 ### Step 2: Choose the Right Tool
 
 - **"What's new?" / "Latest releases"** → Use `get_latest_releases` with the organization or product slug
-- **Specific feature or keyword** → Use `search_releases` with a descriptive query and organization filter
+- **Specific feature or keyword across orgs + catalog + releases** → Use `search` (unified) with a descriptive query; narrow via `type: ["releases"]` etc.
+- **Releases-only search** → Use `search_releases` (kept for back-compat) when you only want release rows
 - **Single release by id** → Use `get_release` when you already have a `rel_` id (search results include ids)
-- **Source or product deep-dive** → Use `get_source`, `get_product`, or `get_organization` for metadata, tags, and linkage
+- **Catalog deep-dive (product or standalone source)** → Use `get_catalog_entry` for metadata, tags, and linkage
+- **Organization detail** → Use `get_organization`
 - **Canonical CHANGELOG.md from a GitHub repo** → Use `get_source_changelog` when the user wants the full maintained file, not just the tagged releases (refreshed on every fetch). For large files, pass `tokens` (cl100k_base budget, e.g. 5000 or 10000) to get a heading-aligned slice that fits a known context window; chain via the returned `nextOffset`. Every response reports `totalTokens` so you can plan how many calls you need upfront.
 - **Compare two products** → Use `compare_products` with an array of two product slugs
 - **Summarize recent activity** → Use `summarize_changes` with the product slug

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -15,13 +15,21 @@ function parseMode(raw: string | undefined): SearchMode | undefined {
   throw new Error(`Invalid --mode value: "${raw}". Expected one of: ${SEARCH_MODES.join(", ")}.`);
 }
 
+type SearchSection = "orgs" | "catalog" | "releases";
+
+function normalizeType(raw: string): SearchSection {
+  if (raw === "products") return "catalog";
+  if (raw === "orgs" || raw === "catalog" || raw === "releases") return raw;
+  throw new Error(`Invalid --type value: "${raw}". Expected one of: orgs, catalog, releases.`);
+}
+
 export function registerSearchCommand(program: Command) {
   program
     .command("search")
-    .description("Search across organizations, products, and releases")
+    .description("Search across organizations, the catalog, and releases")
     .argument("<query>", "Search query")
     .option("-l, --limit <n>", "Max results per type", "10")
-    .option("--type <type>", "Limit to a result type: orgs, products, releases")
+    .option("--type <type>", "Limit to a result type: orgs, catalog, releases")
     .option("--mode <mode>", `Search mode: ${SEARCH_MODES.join(" | ")}`)
     .option("--json", "Output as JSON")
     .action(
@@ -39,15 +47,32 @@ export function registerSearchCommand(program: Command) {
           process.exit(1);
         }
 
+        let types: readonly SearchSection[];
+        try {
+          types = opts.type
+            ? [normalizeType(opts.type)]
+            : (["orgs", "catalog", "releases"] as const);
+        } catch (err) {
+          logger.error(err instanceof Error ? err.message : String(err));
+          process.exit(1);
+        }
+
         const response = await unifiedSearch(query, limit, mode ? { mode } : undefined);
 
-        const types = opts.type
-          ? [opts.type as keyof Omit<UnifiedSearchResponse, "query">]
-          : (["orgs", "products", "releases"] as const);
+        // Read the new `catalog` field, falling back to the deprecated `products`
+        // alias so older API deployments keep working. Drop the fallback once
+        // the alias is removed from the wire. Bracket access avoids the
+        // deprecation diagnostic on the alias read.
+        const legacy = (response as unknown as Record<string, unknown>)["products"] as
+          | UnifiedSearchResponse["catalog"]
+          | undefined;
+        const catalog: UnifiedSearchResponse["catalog"] = response.catalog ?? legacy ?? [];
 
         if (opts.json) {
           const filtered: Record<string, unknown> = { query: response.query };
-          for (const t of types) filtered[t] = response[t];
+          for (const t of types) {
+            filtered[t] = t === "catalog" ? catalog : response[t];
+          }
           if (response.mode !== undefined) filtered.mode = response.mode;
           if (response.degraded !== undefined) filtered.degraded = response.degraded;
           if (response.degradedReason !== undefined)
@@ -75,16 +100,16 @@ export function registerSearchCommand(program: Command) {
           totalResults += response.orgs.length;
         }
 
-        if (types.includes("products") && response.products.length > 0) {
-          console.log(chalk.bold.underline("Products"));
-          for (const p of response.products) {
+        if (types.includes("catalog") && catalog.length > 0) {
+          console.log(chalk.bold.underline("Catalog"));
+          for (const p of catalog) {
             const org = p.orgName ? ` ${chalk.dim(`by ${stripAnsi(p.orgName)}`)}` : "";
             console.log(
               `  ${chalk.cyan.bold(stripAnsi(p.name))} ${chalk.dim(`(${p.slug})`)}${org}`,
             );
           }
           console.log();
-          totalResults += response.products.length;
+          totalResults += catalog.length;
         }
 
         if (types.includes("releases") && response.releases.length > 0) {

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -373,10 +373,18 @@ export function searchToMarkdown(results: UnifiedSearchResponse, opts: FormatOpt
     lines.push("");
   }
 
-  if (results.products.length > 0) {
-    lines.push("## Products");
+  // Read the new `catalog` field, falling back to the deprecated `products`
+  // alias so older API deployments keep working. Drop the fallback once the
+  // alias is removed from the wire.
+  const legacyCatalog = (results as unknown as Record<string, unknown>)["products"] as
+    | UnifiedSearchResponse["catalog"]
+    | undefined;
+  const catalog: UnifiedSearchResponse["catalog"] = results.catalog ?? legacyCatalog ?? [];
+
+  if (catalog.length > 0) {
+    lines.push("## Catalog");
     lines.push("");
-    for (const p of results.products) {
+    for (const p of catalog) {
       const orgInfo = p.orgSlug ? ` (${p.orgName})` : "";
       const viewSlug = p.kind === "source" && p.sourceSlug ? p.sourceSlug : `product/${p.slug}`;
       const url =
@@ -402,7 +410,7 @@ export function searchToMarkdown(results: UnifiedSearchResponse, opts: FormatOpt
     lines.push("");
   }
 
-  if (results.orgs.length === 0 && results.products.length === 0 && results.releases.length === 0) {
+  if (results.orgs.length === 0 && catalog.length === 0 && results.releases.length === 0) {
     lines.push("No results found.");
     lines.push("");
   }

--- a/tests/unit/formatters-markdown.test.ts
+++ b/tests/unit/formatters-markdown.test.ts
@@ -48,21 +48,31 @@ const feedReleases: OrgReleaseItem[] = [
   },
 ];
 
+const catalogHits: UnifiedSearchResponse["catalog"] = [
+  {
+    slug: "react",
+    name: "React",
+    orgSlug: "meta",
+    orgName: "Meta",
+    category: "frontend",
+    kind: "product",
+  },
+  {
+    slug: "react-native",
+    name: "React Native",
+    orgSlug: "meta",
+    orgName: "Meta",
+    category: null,
+    kind: "source",
+    sourceSlug: "react-native",
+  },
+];
+
 const searchResults: UnifiedSearchResponse = {
   query: "react",
   orgs: [{ slug: "meta", name: "Meta", domain: "meta.com", avatarUrl: null, category: "ai" }],
-  products: [
-    { slug: "react", name: "React", orgSlug: "meta", orgName: "Meta", category: "frontend" },
-    {
-      slug: "react-native",
-      name: "React Native",
-      orgSlug: "meta",
-      orgName: "Meta",
-      category: null,
-      kind: "source",
-      sourceSlug: "react-native",
-    },
-  ],
+  catalog: catalogHits,
+  products: catalogHits,
   sources: [],
   releases: [
     {
@@ -234,14 +244,29 @@ describe("searchToMarkdown", () => {
     expect(md).toContain("[ai]");
   });
 
-  it("has Products section with product and standalone source details", () => {
+  it("has Catalog section with product and standalone source details", () => {
     const md = searchToMarkdown(searchResults);
-    expect(md).toContain("## Products");
+    expect(md).toContain("## Catalog");
     expect(md).toContain("**React**");
     expect(md).toContain("`react`");
     expect(md).toContain("(Meta)");
     expect(md).toContain("**React Native**");
     expect(md).not.toContain("## Sources");
+  });
+
+  it("falls back to deprecated `products` alias when `catalog` is absent", () => {
+    // Older API deploys send only `products`. Drop this test once the alias
+    // is removed from the wire (see monorepo issue #539 follow-up).
+    const legacyOnly = {
+      query: "react",
+      orgs: [],
+      products: catalogHits,
+      sources: [],
+      releases: [],
+    } as unknown as UnifiedSearchResponse;
+    const md = searchToMarkdown(legacyOnly);
+    expect(md).toContain("## Catalog");
+    expect(md).toContain("**React**");
   });
 
   it("has Releases section with release details", () => {
@@ -268,6 +293,7 @@ describe("searchToMarkdown", () => {
     const empty: UnifiedSearchResponse = {
       query: "nothing",
       orgs: [],
+      catalog: [],
       products: [],
       sources: [],
       releases: [],
@@ -275,7 +301,7 @@ describe("searchToMarkdown", () => {
     const md = searchToMarkdown(empty);
     expect(md).toContain("No results found.");
     expect(md).not.toContain("## Organizations");
-    expect(md).not.toContain("## Products");
+    expect(md).not.toContain("## Catalog");
     expect(md).not.toContain("## Sources");
     expect(md).not.toContain("## Releases");
   });
@@ -284,6 +310,7 @@ describe("searchToMarkdown", () => {
     const partial: UnifiedSearchResponse = {
       query: "test",
       orgs: [],
+      catalog: [],
       products: [],
       sources: [],
       releases: [
@@ -301,7 +328,7 @@ describe("searchToMarkdown", () => {
     };
     const md = searchToMarkdown(partial);
     expect(md).not.toContain("## Organizations");
-    expect(md).not.toContain("## Products");
+    expect(md).not.toContain("## Catalog");
     expect(md).not.toContain("## Sources");
     expect(md).toContain("## Releases");
   });

--- a/tests/unit/formatters.test.ts
+++ b/tests/unit/formatters.test.ts
@@ -6,7 +6,7 @@ import {
   type FormatSourceDetail,
   type FormatOrgDetail,
 } from "../../src/lib/formatters.js";
-import type { KnowledgePageItem } from "../../src/api/types.js";
+import type { OverviewPageItem } from "../../src/api/types.js";
 
 // ── Fixtures ───────────────────────────────────────────────────────
 
@@ -450,7 +450,7 @@ describe("orgToMarkdown", () => {
 // ── knowledgeToMarkdown ───────────────────────────────────────────
 
 describe("knowledgeToMarkdown", () => {
-  const fullKnowledge: KnowledgePageItem = {
+  const fullKnowledge: OverviewPageItem = {
     scope: "org",
     content: "# Overview\n\nThis org ships fast.",
     releaseCount: 42,
@@ -483,14 +483,14 @@ describe("knowledgeToMarkdown", () => {
   });
 
   it("includes product slug for product-scoped pages", () => {
-    const knowledge: KnowledgePageItem = { ...fullKnowledge, scope: "product" };
+    const knowledge: OverviewPageItem = { ...fullKnowledge, scope: "product" };
     const md = knowledgeToMarkdown(knowledge, { productSlug: "nextjs" });
     expect(md).toContain("scope: product");
     expect(md).toContain("product: nextjs");
   });
 
   it("handles null lastContributingReleaseAt", () => {
-    const knowledge: KnowledgePageItem = { ...fullKnowledge, lastContributingReleaseAt: null };
+    const knowledge: OverviewPageItem = { ...fullKnowledge, lastContributingReleaseAt: null };
     const md = knowledgeToMarkdown(knowledge);
     expect(md).not.toContain("last_release:");
   });


### PR DESCRIPTION
## Summary

- Reads `response.catalog` from the unified-search API and renders the section as **Catalog** in human and markdown output. Falls back to the deprecated `products` alias so older API deploys keep working — fallback can be dropped once the alias is removed from the wire.
- Accepts `--type catalog` (canonical) and `--type products` (deprecated alias). Help output and skill docs updated.
- Picks up adjacent name drift while we're in the area: `search`, `list_catalog`, `get_catalog_entry` are now the primary tools in skill and plugin docs; deprecated aliases (`search_releases`, `search_registry`, `list_sources`, `list_products`, `get_source`, `get_product`) are flagged inline. Discovery agent's pre-check step now calls `list_catalog` instead of the deprecated `list_sources`.
- Renames `KnowledgePageItem` → `OverviewPageItem` in formatter tests to match the api-types canonical export.

Closes #65. Tracks the monorepo unification in buildinternet/releases#539.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `bun run lint` 0 warnings/errors
- [x] `bun test` 234/234 (added a regression test for the legacy `products` alias fallback)
- [x] Smoke test against prod API: default search, `--type catalog`, deprecated `--type products`, `--json`, invalid `--type` (errors with exit 1) all behave correctly
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unified search spanning organizations, catalog entries, and releases with improved result organization
  * Catalog section now properly distinguished in search results with hit-type categorization (product vs. source)
  * Updated search filtering with new `--type` options for refined scoping

* **Deprecations**
  * Legacy search and listing tools marked as deprecated; users are directed to unified alternatives
  * Product/source listing tools consolidated into unified catalog tools

<!-- end of auto-generated comment: release notes by coderabbit.ai -->