### PR TITLE
fix(cli): show full release IDs in search, tail, and table renders

### DIFF
--- a/.changeset/full-release-ids.md
+++ b/.changeset/full-release-ids.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": patch
+---
+
+fix(cli): show full release IDs in `search`, `tail`, and the releases table. The previous 12-char prefix wasn't usable for any follow-up call (the API only resolves full IDs, not short forms), so the truncation was misleading without saving real horizontal space.

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -209,7 +209,7 @@ export function registerSearchCommand(program: Command) {
         if (types.includes("releases") && response.releases.length > 0) {
           console.log(chalk.bold.underline("Releases"));
           for (const r of response.releases) {
-            const idLabel = r.id ? ` ${chalk.dim(r.id.slice(0, 12))}` : "";
+            const idLabel = r.id ? ` ${chalk.dim(r.id)}` : "";
             console.log(`  ${chalk.cyan.bold(stripAnsi(r.title))}${idLabel}`);
             console.log(
               chalk.dim(

--- a/src/cli/commands/tail.ts
+++ b/src/cli/commands/tail.ts
@@ -13,7 +13,7 @@ function renderStreamLine(row: LatestRelease): string {
   const when = row.publishedAt ? chalk.dim(row.publishedAt) : chalk.dim("(no date)");
   const src = `${chalk.cyan(stripAnsi(row.sourceName))} ${chalk.dim(`(${row.sourceSlug})`)}`;
   const title = stripAnsi(row.title);
-  const id = chalk.dim(row.id.slice(0, 12));
+  const id = chalk.dim(row.id);
   return `${when}  ${src}  ${version ? version + "  " : ""}${title}  ${id}`;
 }
 

--- a/src/cli/render/releases-table.ts
+++ b/src/cli/render/releases-table.ts
@@ -33,7 +33,7 @@ export function renderLatestReleasesTable(rows: LatestRelease[], opts: RenderOpt
       : (row.publishedAt?.slice(0, 10) ?? chalk.dim("—"));
 
     table.push([
-      chalk.dim(row.id.slice(0, 12)),
+      chalk.dim(row.id),
       `${stripAnsi(row.sourceName)} ${chalk.dim(`(${row.sourceSlug})`)}`,
       titleCell,
       row.version ? stripAnsi(row.version) : opts.withSummary ? "-" : chalk.dim("—"),


### PR DESCRIPTION
## Summary

- The CLI was truncating release IDs to 12 chars in `search`, `tail`, and the latest-releases table.
- The API only resolves full IDs — a 12-char prefix returns 404 — so the displayed form was useless for any follow-up call (`admin release get`, MCP `get_release`, direct curl).
- Drops `.slice(0, 12)` from all three call sites; styling stays `chalk.dim`.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [ ] Reviewer: run `releases search Shopify/toxiproxy` after the next CLI release and confirm the printed ID resolves through `releases admin release get rel_<full_id>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release IDs are now displayed in full across the CLI, including in search results, tail output, and the releases table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->