### PR TITLE
docs(skills): document on-demand GitHub lookup in releases-cli + releases-mcp

### DIFF
--- a/.changeset/skills-on-demand-lookup.md
+++ b/.changeset/skills-on-demand-lookup.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases-skills": patch
+---
+
+docs(skills): document the on-demand GitHub lookup behavior in the `releases-cli` and `releases-mcp` skills. When a user types a `{org}/{repo}` coordinate (or `github:org/repo`) and no entity matches, the registry probes GitHub on demand and surfaces the result as a `lookup` field. Coordinate matching is case-insensitive.

--- a/plugins/claude/releases/skills/releases-cli/references/reader.md
+++ b/plugins/claude/releases/skills/releases-cli/references/reader.md
@@ -22,6 +22,17 @@ Flags:
 
 Catalog hits also include the response field `catalog`. Older API deploys will still send the deprecated `products` alias instead — the CLI reads either, but new code should consume `catalog`.
 
+### On-demand GitHub lookup
+
+When the query is a `{org}/{repo}` coordinate (optionally prefixed `github:`) and no entity (org or catalog source) matched, the registry probes GitHub on demand and the CLI prints a **Lookup** section above the regular results. Coordinate matching is case-insensitive — `Shopify/toxiproxy` and `shopify/toxiproxy` resolve to the same source row. The lookup fires even when tangential release hits surface on a single segment token, so a coordinate is treated as a precise question about one repo.
+
+```bash
+releases search "vercel/next.js"             # bare coordinate
+releases search "github:Shopify/toxiproxy"   # explicit provider prefix
+```
+
+Statuses on the Lookup section: `INDEXED` (just materialized), `EXISTING` (already tracked), `EMPTY` (real repo, no releases or CHANGELOG yet), `NOT_FOUND` (private/archived/missing), `DEFERRED` (rate-limited or 5xx — retry shortly).
+
 ## Latest releases
 
 ```bash

--- a/plugins/claude/releases/skills/releases-mcp/SKILL.md
+++ b/plugins/claude/releases/skills/releases-mcp/SKILL.md
@@ -32,6 +32,7 @@ If the query returns no results, try variations:
 - The company name instead of the product name (e.g., "Vercel" instead of "Next.js")
 - The GitHub org name (e.g., "supabase")
 - A domain (e.g., "tailwindcss.com")
+- A `{org}/{repo}` GitHub coordinate (e.g., "vercel/next.js" or "github:vercel/next.js"). When `search` finds no entity match for a coordinate-shaped query, the registry probes GitHub on demand and the response includes a `lookup` field with status `indexed` / `existing` / `empty` / `not_found` / `deferred`. Coordinate matching is case-insensitive, so `Shopify/toxiproxy` and `shopify/toxiproxy` resolve identically.
 
 ### Step 2: Choose the Right Tool
 

--- a/skills/releases-cli/references/reader.md
+++ b/skills/releases-cli/references/reader.md
@@ -22,6 +22,17 @@ Flags:
 
 Catalog hits also include the response field `catalog`. Older API deploys will still send the deprecated `products` alias instead — the CLI reads either, but new code should consume `catalog`.
 
+### On-demand GitHub lookup
+
+When the query is a `{org}/{repo}` coordinate (optionally prefixed `github:`) and no entity (org or catalog source) matched, the registry probes GitHub on demand and the CLI prints a **Lookup** section above the regular results. Coordinate matching is case-insensitive — `Shopify/toxiproxy` and `shopify/toxiproxy` resolve to the same source row. The lookup fires even when tangential release hits surface on a single segment token, so a coordinate is treated as a precise question about one repo.
+
+```bash
+releases search "vercel/next.js"             # bare coordinate
+releases search "github:Shopify/toxiproxy"   # explicit provider prefix
+```
+
+Statuses on the Lookup section: `INDEXED` (just materialized), `EXISTING` (already tracked), `EMPTY` (real repo, no releases or CHANGELOG yet), `NOT_FOUND` (private/archived/missing), `DEFERRED` (rate-limited or 5xx — retry shortly).
+
 ## Latest releases
 
 ```bash

--- a/skills/releases-mcp/SKILL.md
+++ b/skills/releases-mcp/SKILL.md
@@ -29,6 +29,7 @@ If the query returns no results, try variations:
 - The company name instead of the product name (e.g., "Vercel" instead of "Next.js")
 - The GitHub org name (e.g., "supabase")
 - A domain (e.g., "tailwindcss.com")
+- A `{org}/{repo}` GitHub coordinate (e.g., "vercel/next.js" or "github:vercel/next.js"). When `search` finds no entity match for a coordinate-shaped query, the registry probes GitHub on demand and the response includes a `lookup` field with status `indexed` / `existing` / `empty` / `not_found` / `deferred`. Coordinate matching is case-insensitive, so `Shopify/toxiproxy` and `shopify/toxiproxy` resolve identically.
 
 ### Step 2: Choose the Right Tool
 


### PR DESCRIPTION
## Summary

Documents the on-demand GitHub lookup behavior in the `releases-cli` and `releases-mcp` skills. The behavior itself was already supported end-to-end by the API (#611, #662, #664) and the CLI (#85, #89) — the skills just hadn't been told, so agents using them weren't suggesting coordinate-shaped queries as a fallback when name searches came up empty.

### What's documented

- Type a `{org}/{repo}` coordinate or `github:org/repo` to probe GitHub on demand when nothing matches in the registry
- The response includes a `lookup` field with one of five statuses: `indexed`, `existing`, `empty`, `not_found`, `deferred`
- Coordinate matching is case-insensitive — `Shopify/toxiproxy` and `shopify/toxiproxy` resolve to the same source row
- The lookup fires even when tangential release hits surface, since a coordinate is a precise question about one repo

### Files

- `skills/releases-mcp/SKILL.md` — adds a coordinate-shaped fallback bullet under the "no results" troubleshooting list
- `skills/releases-cli/references/reader.md` — new "On-demand GitHub lookup" section under Search with example commands and the status table
- Plugin copies regenerated via `bun scripts/sync-plugin-skills.ts`

## Test plan

- [x] `bun scripts/sync-plugin-skills.ts` (clean diff between `skills/` and `plugins/claude/releases/skills/`)
- [ ] Reviewer: run an agent against the updated skill and verify it now suggests a coordinate-shaped fallback when a name-based search returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Documentation**
  * Added on-demand GitHub lookup documentation for `releases-cli` and `releases-mcp` skills
  * Users can search repositories using GitHub coordinates (`{org}/{repo}`) with case-insensitive matching
  * System automatically probes GitHub when coordinates are not indexed
  * Lookup status indicators show repository availability (indexed, existing, empty, not found, or deferred)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->