### PR TITLE
feat(cli): publish Windows x64 binary via npm

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,6 +9,7 @@
       "@buildinternet/releases-darwin-x64",
       "@buildinternet/releases-linux-arm64",
       "@buildinternet/releases-linux-x64",
+      "@buildinternet/releases-windows-x64",
       "@buildinternet/releases-lib",
       "@buildinternet/releases-skills"
     ]

--- a/.changeset/windows-binary.md
+++ b/.changeset/windows-binary.md
@@ -1,6 +1,6 @@
 ---
-"@buildinternet/releases": patch
-"@buildinternet/releases-windows-x64": patch
+"@buildinternet/releases": minor
+"@buildinternet/releases-windows-x64": minor
 ---
 
 feat(cli): publish a Windows x64 binary. `npm install -g @buildinternet/releases` now works on Windows; the dispatcher resolves `releases.exe` from the new `@buildinternet/releases-windows-x64` platform package. Homebrew remains macOS/Linux-only. `windows-arm64` is intentionally not shipped — open an issue if you need it.

--- a/.changeset/windows-binary.md
+++ b/.changeset/windows-binary.md
@@ -1,0 +1,6 @@
+---
+"@buildinternet/releases": patch
+"@buildinternet/releases-windows-x64": patch
+---
+
+feat(cli): publish a Windows x64 binary. `npm install -g @buildinternet/releases` now works on Windows; the dispatcher resolves `releases.exe` from the new `@buildinternet/releases-windows-x64` platform package. Homebrew remains macOS/Linux-only. `windows-arm64` is intentionally not shipped — open an issue if you need it.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
           bun build --compile src/index.ts --outfile npm/releases-darwin-x64/releases --target=bun-darwin-x64
           bun build --compile src/index.ts --outfile npm/releases-linux-x64/releases --target=bun-linux-x64
           bun build --compile src/index.ts --outfile npm/releases-linux-arm64/releases --target=bun-linux-arm64
+          bun build --compile src/index.ts --outfile npm/releases-windows-x64/releases.exe --target=bun-windows-x64
 
       - name: Configure npm auth
         env:
@@ -69,7 +70,12 @@ jobs:
             gzip -k "dist/release/releases-${target}"
             sha256sum "dist/release/releases-${target}.gz" | awk '{print $1}' > "dist/release/releases-${target}.gz.sha256"
           done
-          sha256sum dist/release/*.gz > dist/release/checksums.txt
+          # Windows ships the .exe inside a .zip (the conventional Windows
+          # archive format) rather than a single-binary .gz like the others.
+          cp "npm/releases-windows-x64/releases.exe" "dist/release/releases-windows-x64.exe"
+          (cd dist/release && zip -q "releases-windows-x64.zip" "releases-windows-x64.exe")
+          sha256sum "dist/release/releases-windows-x64.zip" | awk '{print $1}' > "dist/release/releases-windows-x64.zip.sha256"
+          sha256sum dist/release/*.gz dist/release/*.zip > dist/release/checksums.txt
 
       - name: Publish binaries to GitHub Releases
         if: steps.changesets.outputs.published == 'true'
@@ -99,6 +105,8 @@ jobs:
             dist/release/releases-linux-x64.gz.sha256 \
             dist/release/releases-linux-arm64.gz \
             dist/release/releases-linux-arm64.gz.sha256 \
+            dist/release/releases-windows-x64.zip \
+            dist/release/releases-windows-x64.zip.sha256 \
             dist/release/checksums.txt
 
       - name: Update Homebrew tap

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,3 +47,25 @@ jobs:
 
       - name: Test
         run: bun test
+
+  smoke-windows:
+    name: Windows binary smoke test
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: canary
+
+      - run: bun install --frozen-lockfile
+
+      # Native compile on Windows — proves the same artifact published via npm
+      # actually starts on a Windows host. Cross-compile from Linux is what
+      # release.yml ships; this catches Bun-on-Windows runtime regressions.
+      - name: Compile for Windows
+        run: bun build --compile src/index.ts --outfile dist/releases.exe
+
+      - name: Run --version
+        shell: bash
+        run: ./dist/releases.exe --version

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist
 *.bun-build
 .*.bun-build
 npm/*/releases
+npm/*/releases.exe
 npm/releases/README.md
 .bun-runtimes
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The CLI talks to the hosted registry at `api.releases.sh`. Reader commands work 
 brew install buildinternet/tap/releases
 ```
 
-### npm
+### npm (macOS, Linux, Windows)
 
 ```bash
 npm install -g @buildinternet/releases
@@ -33,13 +33,17 @@ npx @buildinternet/releases@latest search "react"
 
 Always include the `@latest` tag — bare `npx @buildinternet/releases` caches the first-fetched version forever and won't pick up updates.
 
-### Shell installer
+### Shell installer (macOS, Linux)
 
 ```bash
 curl -fsSL https://releases.sh/install | bash
 ```
 
-Downloads the matching platform binary from npm. Respects `RELEASED_INSTALL_DIR` (default: `/usr/local/bin`).
+Downloads the matching platform binary from npm. Respects `RELEASED_INSTALL_DIR` (default: `/usr/local/bin`). Windows users should use npm or the GitHub Releases archive below.
+
+### Precompiled binaries (GitHub Releases)
+
+Every version publishes signed archives for each platform on the [Releases page](https://github.com/buildinternet/releases-cli/releases) — `releases-{darwin-arm64,darwin-x64,linux-arm64,linux-x64}.gz` and `releases-windows-x64.zip`, each with a matching `.sha256` and a top-level `checksums.txt`. Useful for air-gapped installs, version pinning, or platforms where npm and Homebrew aren't an option.
 
 ## Usage
 

--- a/bun.lock
+++ b/bun.lock
@@ -27,40 +27,45 @@
     },
     "npm/releases": {
       "name": "@buildinternet/releases",
-      "version": "0.20.2",
+      "version": "0.22.1",
       "bin": {
         "releases": "bin/releases",
       },
       "optionalDependencies": {
-        "@buildinternet/releases-darwin-arm64": "0.19.5",
-        "@buildinternet/releases-darwin-x64": "0.19.5",
-        "@buildinternet/releases-linux-arm64": "0.19.5",
-        "@buildinternet/releases-linux-x64": "0.19.5",
+        "@buildinternet/releases-darwin-arm64": "0.22.1",
+        "@buildinternet/releases-darwin-x64": "0.22.1",
+        "@buildinternet/releases-linux-arm64": "0.22.1",
+        "@buildinternet/releases-linux-x64": "0.22.1",
+        "@buildinternet/releases-windows-x64": "0.22.1",
       },
     },
     "npm/releases-darwin-arm64": {
       "name": "@buildinternet/releases-darwin-arm64",
-      "version": "0.20.2",
+      "version": "0.22.1",
     },
     "npm/releases-darwin-x64": {
       "name": "@buildinternet/releases-darwin-x64",
-      "version": "0.20.2",
+      "version": "0.22.1",
     },
     "npm/releases-linux-arm64": {
       "name": "@buildinternet/releases-linux-arm64",
-      "version": "0.20.2",
+      "version": "0.22.1",
     },
     "npm/releases-linux-x64": {
       "name": "@buildinternet/releases-linux-x64",
-      "version": "0.20.2",
+      "version": "0.22.1",
+    },
+    "npm/releases-windows-x64": {
+      "name": "@buildinternet/releases-windows-x64",
+      "version": "0.22.1",
     },
     "packages/lib": {
       "name": "@buildinternet/releases-lib",
-      "version": "0.20.2",
+      "version": "0.22.1",
     },
     "packages/skills": {
       "name": "@buildinternet/releases-skills",
-      "version": "0.20.2",
+      "version": "0.22.1",
     },
   },
   "packages": {
@@ -83,6 +88,8 @@
     "@buildinternet/releases-linux-x64": ["@buildinternet/releases-linux-x64@workspace:npm/releases-linux-x64"],
 
     "@buildinternet/releases-skills": ["@buildinternet/releases-skills@workspace:packages/skills"],
+
+    "@buildinternet/releases-windows-x64": ["@buildinternet/releases-windows-x64@workspace:npm/releases-windows-x64"],
 
     "@changesets/apply-release-plan": ["@changesets/apply-release-plan@7.1.1", "", { "dependencies": { "@changesets/config": "^3.1.4", "@changesets/get-version-range-type": "^0.4.0", "@changesets/git": "^3.0.4", "@changesets/should-skip-package": "^0.1.2", "@changesets/types": "^6.1.0", "@manypkg/get-packages": "^1.1.3", "detect-indent": "^6.0.0", "fs-extra": "^7.0.1", "lodash.startcase": "^4.4.0", "outdent": "^0.5.0", "prettier": "^2.7.1", "resolve-from": "^5.0.0", "semver": "^7.5.3" } }, "sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA=="],
 

--- a/npm/releases-windows-x64/package.json
+++ b/npm/releases-windows-x64/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@buildinternet/releases-windows-x64",
+  "version": "0.22.1",
+  "description": "releases binary for Windows x64",
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "files": [
+    "releases.exe"
+  ],
+  "license": "MIT"
+}

--- a/npm/releases/bin/releases
+++ b/npm/releases/bin/releases
@@ -9,6 +9,7 @@ const PLATFORMS = {
   "darwin-x64": "@buildinternet/releases-darwin-x64",
   "linux-x64": "@buildinternet/releases-linux-x64",
   "linux-arm64": "@buildinternet/releases-linux-arm64",
+  "win32-x64": "@buildinternet/releases-windows-x64",
 };
 
 const key = `${os.platform()}-${os.arch()}`;
@@ -20,9 +21,11 @@ if (!pkg) {
   process.exit(1);
 }
 
+const binName = os.platform() === "win32" ? "releases.exe" : "releases";
+
 let binPath;
 try {
-  binPath = path.join(require.resolve(`${pkg}/package.json`), "..", "releases");
+  binPath = path.join(require.resolve(`${pkg}/package.json`), "..", binName);
 } catch {
   console.error(`Missing platform package: ${pkg}`);
   console.error(`Try reinstalling: npm install @buildinternet/releases`);

--- a/npm/releases/package.json
+++ b/npm/releases/package.json
@@ -16,7 +16,8 @@
     "@buildinternet/releases-darwin-arm64": "0.22.1",
     "@buildinternet/releases-darwin-x64": "0.22.1",
     "@buildinternet/releases-linux-x64": "0.22.1",
-    "@buildinternet/releases-linux-arm64": "0.22.1"
+    "@buildinternet/releases-linux-arm64": "0.22.1",
+    "@buildinternet/releases-windows-x64": "0.22.1"
   },
   "keywords": [
     "changelog",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build:linux": "bun build --compile src/index.ts --outfile dist/releases --target=bun-linux-x64",
     "build:linux-arm64": "bun build --compile src/index.ts --outfile dist/releases --target=bun-linux-arm64",
     "build:darwin-x64": "bun build --compile src/index.ts --outfile dist/releases --target=bun-darwin-x64",
+    "build:windows-x64": "bun build --compile src/index.ts --outfile dist/releases.exe --target=bun-windows-x64",
     "dev": "bun --watch src/index.ts",
     "sync:plugin-skills": "bun scripts/sync-plugin-skills.ts",
     "sync:version": "bun scripts/sync-version.ts",

--- a/scripts/sync-version.ts
+++ b/scripts/sync-version.ts
@@ -52,6 +52,7 @@ for (const pkg of [
   "npm/releases-darwin-x64/package.json",
   "npm/releases-linux-x64/package.json",
   "npm/releases-linux-arm64/package.json",
+  "npm/releases-windows-x64/package.json",
 ]) {
   updateJson(pkg, (j) => {
     j.version = newVersion;


### PR DESCRIPTION
Closes [#93](https://github.com/buildinternet/releases-cli/issues/93).

## Summary

- `npm install -g @buildinternet/releases` now works on Windows.
- Adds a fifth platform package, `@buildinternet/releases-windows-x64`, containing a Bun-compiled `releases.exe`.
- Dispatcher (`npm/releases/bin/releases`) routes `win32-x64` to the new package and resolves `releases.exe` instead of `releases`.
- Release pipeline cross-compiles the Windows binary alongside the existing four targets and ships it as a `.zip` (the conventional Windows archive format) on each GH Release.
- New `windows-latest` CI smoke job natively compiles on Windows and runs `--version` so PRs catch Bun-on-Windows runtime regressions before they reach a published version.

## Out of scope

- `windows-arm64` — Bun supports it, small audience. Open an issue if you need it.
- Scoop / winget. npm is the v1 install path on Windows.
- Homebrew formula remains macOS/Linux-only (Homebrew on Windows is a separate world).

## Verification

- `bun run build:windows-x64` from macOS produces a valid `PE32+ executable (console) x86-64, for MS Windows`.
- `bun run sync:version` propagates to the new package.
- `bun run lint`, `bun run format:check`, and `npx tsc --noEmit` all clean.
- The `smoke-windows` job will provide the actual Windows runtime check on this PR.

## Test plan

- [ ] CI: `lint`, `test`, and `smoke-windows` all green.
- [ ] After merge + version bump, manually `npm install -g @buildinternet/releases@<new>` on a Windows host and confirm `releases --version` and one real lookup work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Windows x64 binary added for the CLI and published as a release asset — enables global install/use on Windows.

* **Tests**
  * Added a Windows binary smoke test to verify the CLI starts correctly on Windows.

* **Chores**
  * Build/release pipeline updated to produce Windows artifacts and combined checksums.
  * New Windows platform package and package metadata adjustments.
  * Installation docs clarified (Homebrew remains macOS/Linux; windows-arm64 not shipped) and ignore rules updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->