### PR TITLE
ci(test): guard against bun.lock drift on every PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,16 @@ jobs:
 
       - run: bun install --frozen-lockfile
 
+      # Catches workspace-topology drift (new/renamed/removed packages under
+      # npm/* or packages/*) and version-metadata drift across releases.
+      # `--frozen-lockfile` only enforces the dependency graph; a fresh install
+      # rewrites the workspaces section, and any diff means bun.lock wasn't
+      # committed alongside the change that produced it.
+      - name: Verify lockfile is up to date
+        run: |
+          bun install
+          git diff --exit-code bun.lock
+
       - name: Oxlint
         run: bun run lint
 


### PR DESCRIPTION
## Why

`bun install --frozen-lockfile` enforces the dependency-resolution graph but **not** the workspaces section's version metadata. That meant the `npm/releases-*` and `packages/*` version fields in `bun.lock` drifted silently across the last several releases (0.20.2 → 0.22.1), going unnoticed because every PR's CI was happy. The drift only became a hard failure when [#94](https://github.com/buildinternet/releases-cli/pull/94) added a new workspace member (`npm/releases-windows-x64`) — at that point `--frozen-lockfile` rejected the *topology* change, and the drift had to be cleaned up in the same PR ([63dde19](https://github.com/buildinternet/releases-cli/commit/63dde19)).

This is the same pattern as commit [222294b](https://github.com/buildinternet/releases-cli/commit/222294b) (`chore: regenerate lockfile after api-types ^0.3.0 bump`) — a recurring "manual cleanup" rather than a one-off.

## What

Adds one step to the `lint` job in `test.yml`:

```yaml
- name: Verify lockfile is up to date
  run: |
    bun install
    git diff --exit-code bun.lock
```

Any PR that introduces drift — workspace topology change without `bun install`, version bump without a lockfile refresh, etc. — turns red instead of merging silently.

## Test plan

- [ ] CI on this PR is green (it should be; lockfile is currently clean post-#94 cleanup).
- [ ] Future PRs that add/rename workspace packages or bump versions will be required to commit a refreshed `bun.lock`.

## Out of scope

- Fixing `release.yml` so the `chore: version packages` PR commits a refreshed `bun.lock` automatically — that's the deeper fix and would eliminate the source of drift, but it's a separate change with more risk surface (changesets/action timing). The CI guard here works regardless of which path produces the drift.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build process verification to ensure lockfile integrity and consistency across the project workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->