### PR TITLE
chore(deps): bump @buildinternet/releases-api-types to ^0.4.0

### DIFF
--- a/.changeset/bump-api-types-0-4-0.md
+++ b/.changeset/bump-api-types-0-4-0.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": patch
+---
+
+Bump `@buildinternet/releases-api-types` to `^0.4.0`. Adds the optional `type: "feature" | "rollup"` field to release-shaped wire types (`ReleaseItem`, `ReleaseDetail`, `SearchReleaseHit`) so consumers can render rollup posts (Brex Fall Release, Ramp quarterly editions, etc.) differently from feature releases. Optional on the wire — older API responses degrade gracefully.

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "releases-cli",
       "dependencies": {
-        "@buildinternet/releases-api-types": "^0.3.0",
+        "@buildinternet/releases-api-types": "^0.4.0",
         "@buildinternet/releases-core": "^0.17.0",
         "@buildinternet/releases-lib": "workspace:*",
         "@buildinternet/releases-skills": "workspace:*",
@@ -27,7 +27,7 @@
     },
     "npm/releases": {
       "name": "@buildinternet/releases",
-      "version": "0.22.1",
+      "version": "0.23.0",
       "bin": {
         "releases": "bin/releases",
       },
@@ -41,31 +41,31 @@
     },
     "npm/releases-darwin-arm64": {
       "name": "@buildinternet/releases-darwin-arm64",
-      "version": "0.22.1",
+      "version": "0.23.0",
     },
     "npm/releases-darwin-x64": {
       "name": "@buildinternet/releases-darwin-x64",
-      "version": "0.22.1",
+      "version": "0.23.0",
     },
     "npm/releases-linux-arm64": {
       "name": "@buildinternet/releases-linux-arm64",
-      "version": "0.22.1",
+      "version": "0.23.0",
     },
     "npm/releases-linux-x64": {
       "name": "@buildinternet/releases-linux-x64",
-      "version": "0.22.1",
+      "version": "0.23.0",
     },
     "npm/releases-windows-x64": {
       "name": "@buildinternet/releases-windows-x64",
-      "version": "0.22.1",
+      "version": "0.23.0",
     },
     "packages/lib": {
       "name": "@buildinternet/releases-lib",
-      "version": "0.22.1",
+      "version": "0.23.0",
     },
     "packages/skills": {
       "name": "@buildinternet/releases-skills",
-      "version": "0.22.1",
+      "version": "0.23.0",
     },
   },
   "packages": {
@@ -73,7 +73,7 @@
 
     "@buildinternet/releases": ["@buildinternet/releases@workspace:npm/releases"],
 
-    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.3.0", "", {}, "sha512-+763uxjEiUK2BDvAiew8Cbsptbfa1SeZxutfyawOulDhSEtoZt9Zw1sZMJ6ZhEV3vfBwuYihkoglGVCdmpSGEA=="],
+    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.4.0", "", {}, "sha512-liLiH20aD6YqZ/7Q3fqy7zFX0hIP3SMMj+umaG0LZYxFCjg8+MpHswJ5cOMT+csDwXtelyH+gcV6qPcOk4L7vQ=="],
 
     "@buildinternet/releases-core": ["@buildinternet/releases-core@0.17.0", "", { "dependencies": { "drizzle-orm": "^0.45.2", "js-tiktoken": "^1.0.21", "nanoid": "^5.1.7" } }, "sha512-ijIcgPHqAG7Jb2dFD83l6FRXN0XPLi02bqWomQneM+tkes9vfENg7WXx++rNPyMaHoe5Y1Gb0eZn6evNUr/rnA=="],
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "homepage": "https://releases.sh",
   "dependencies": {
-    "@buildinternet/releases-api-types": "^0.3.0",
+    "@buildinternet/releases-api-types": "^0.4.0",
     "@buildinternet/releases-core": "^0.17.0",
     "@buildinternet/releases-lib": "workspace:*",
     "@buildinternet/releases-skills": "workspace:*",


### PR DESCRIPTION
## Summary

- Bump `@buildinternet/releases-api-types` from `^0.3.0` → `^0.4.0`. The new release ([buildinternet/releases#694](https://github.com/buildinternet/releases/pull/694), phase 0 of [#693](https://github.com/buildinternet/releases/issues/693)) adds an optional `type: "feature" | "rollup"` field to `ReleaseItem`, `ReleaseDetail`, and `SearchReleaseHit`, plus a `ReleaseType` union export.
- Includes a changeset (`.changeset/bump-api-types-0-4-0.md`) so the next CLI release bundles this dep bump.
- The new field is optional on the wire — existing CLI behavior is unchanged. Surfaces that want to render rollups differently (badge, filter, dedicated view) can now do so against the typed contract in a follow-up.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun run format:check` — clean
- [x] `bun test` — 233 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release items now include an optional type field to distinguish between feature releases and rollup posts, while maintaining compatibility with existing API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->