### PR TITLE
feat(cli): cascade-confirmation prompt for admin org delete --hard

### DIFF
--- a/.changeset/cascade-confirmation-prompt.md
+++ b/.changeset/cascade-confirmation-prompt.md
@@ -1,0 +1,13 @@
+---
+"@buildinternet/releases": minor
+---
+
+`admin org delete --hard` now shows a cascade-scope preview and requires the user to type the org slug back to confirm. Backs the post-#690 Phase C schema, where hard-deleting an org now cascades into every source, release, fetch_log, changelog file/chunk, release summary, media asset, and webhook subscription tied to it (vs. orphaning sources via SET NULL pre-flip).
+
+- `releases admin org delete <slug> --hard` lists exact dependent counts, then waits for slug typeback. Wrong slug aborts with exit 1 and no API call to the destructive endpoint.
+- `--yes` / `-y` skips the prompt for scripted ops.
+- A piped (non-TTY) stdin without `--yes` exits 1 with a clear "no interactive TTY" message instead of silently auto-confirming.
+- Soft-delete (default, no `--hard`) is unchanged — still tombstones via `deleted_at`, no prompt.
+- `admin org remove` continues to work as an alias of `admin org delete`.
+
+Counts are pulled from the new `GET /v1/admin/orgs/:slug/dependents` endpoint, so the preview matches whatever the API would actually cascade-delete. Requires `@buildinternet/releases-api-types` ≥ 0.5.0 on the server side.

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -31,6 +31,7 @@ import type {
   EmbedStatusResponse,
   EvaluationResult,
   MediaItem,
+  OrgDependentsResponse,
 } from "./types.js";
 import type { ListResponse } from "@buildinternet/releases-core/cli-contracts";
 export type {
@@ -48,6 +49,7 @@ export type {
   EvaluationResult,
   Stats,
   SourceListItem,
+  OrgDependentsResponse,
 } from "./types.js";
 
 export async function apiFetch<T>(path: string, opts?: RequestInit): Promise<T> {
@@ -630,8 +632,13 @@ export async function createOrg(
   });
 }
 
-export async function removeOrg(slug: string): Promise<void> {
-  await apiFetch(`/v1/orgs/${slug}`, { method: "DELETE" });
+export async function removeOrg(slug: string, opts?: { hard?: boolean }): Promise<void> {
+  const qs = opts?.hard ? "?hard=true" : "";
+  await apiFetch(`/v1/orgs/${slug}${qs}`, { method: "DELETE" });
+}
+
+export async function getOrgDependents(slug: string): Promise<OrgDependentsResponse> {
+  return apiFetch<OrgDependentsResponse>(`/v1/admin/orgs/${slug}/dependents`);
 }
 
 export async function updateOrg(

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -638,7 +638,13 @@ export async function removeOrg(slug: string, opts?: { hard?: boolean }): Promis
 }
 
 export async function getOrgDependents(slug: string): Promise<OrgDependentsResponse> {
-  return apiFetch<OrgDependentsResponse>(`/v1/admin/orgs/${slug}/dependents`);
+  // apiFetch returns null on GET 404; surface a typed error instead so the
+  // delete flow doesn't dereference `dependents.counts` on a missing org.
+  const result = await apiFetch<OrgDependentsResponse | null>(`/v1/admin/orgs/${slug}/dependents`);
+  if (!result) {
+    throw new Error(`Org dependents preview not available for "${slug}" (org not found).`);
+  }
+  return result;
 }
 
 export async function updateOrg(

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -12,6 +12,26 @@
  */
 export * from "@buildinternet/releases-api-types";
 
+/**
+ * Cascade-scope preview returned by `GET /v1/admin/orgs/:slug/dependents`.
+ * Defined locally until `@buildinternet/releases-api-types` ≥ 0.5.0 ships
+ * the canonical export — bump the pin in `package.json` and drop this block
+ * once the published version is in.
+ */
+export interface OrgDependentsResponse {
+  org: { id: string; slug: string; name: string };
+  counts: {
+    sources: number;
+    releases: number;
+    fetchLog: number;
+    sourceChangelogFiles: number;
+    sourceChangelogChunks: number;
+    releaseSummaries: number;
+    mediaAssets: number;
+    webhookSubscriptions: number;
+  };
+}
+
 export interface EvaluationResult {
   recommendedMethod: "feed" | "github" | "markdown" | "scrape" | "crawl";
   recommendedUrl: string;

--- a/src/cli/commands/org.ts
+++ b/src/cli/commands/org.ts
@@ -18,7 +18,9 @@ import {
   getAliases,
   setAliases,
   getOverview,
+  getOrgDependents,
 } from "../../api/client.js";
+import { promptConfirm } from "../../lib/confirm.js";
 import { stripAnsi } from "../../lib/sanitize.js";
 import { logger } from "@releases/lib/logger";
 import { orgNotFound } from "../suggest.js";
@@ -369,31 +371,101 @@ Examples:
       },
     );
 
-  // ── org remove ──
+  // ── org remove / delete ──
+  // Defaults to a tombstone soft-delete (reversible). With --hard, the row is
+  // purged and the FK cascade also wipes every source, release, fetch_log,
+  // changelog file/chunk, release summary, media asset, and webhook
+  // subscription tied to the org (#690 Phase C). The command surfaces a
+  // typeback prompt before any cascade runs; --yes / -y bypasses it for
+  // scripted ops, and a piped (non-TTY) stdin without --yes errors out
+  // rather than silently confirming.
   org
     .command("remove")
-    .description("Remove an organization")
+    .alias("delete")
+    .description("Remove an organization (soft-delete by default; --hard purges with cascade)")
     .argument("<identifier>", "Org slug, domain, name, or handle")
     .option("--dry-run", "Show what would be removed without deleting")
+    .option("--hard", "Permanently delete the org and cascade-delete all dependent rows")
+    .option("-y, --yes", "Skip the confirmation prompt (required for non-interactive --hard)")
     .option("--json", "Output as JSON")
-    .action(async (identifier: string, opts: { json?: boolean; dryRun?: boolean }) => {
-      const found = await findOrg(identifier);
-      if (!found) return orgNotFound(identifier);
+    .action(
+      async (
+        identifier: string,
+        opts: { json?: boolean; dryRun?: boolean; hard?: boolean; yes?: boolean },
+      ) => {
+        // Fail fast on the obvious misconfiguration: --hard from a piped
+        // stdin without --yes. Catching this before any network call avoids
+        // a misleading API error and saves a round-trip.
+        if (opts.hard && !opts.yes && !opts.dryRun && !process.stdin.isTTY) {
+          console.error(
+            chalk.red(
+              "No interactive TTY available — pass --yes to confirm a hard delete in scripted contexts.",
+            ),
+          );
+          process.exit(1);
+        }
 
-      if (opts.dryRun) {
-        if (opts.json) await writeJson({ wouldRemove: found.slug, name: found.name });
+        const found = await findOrg(identifier);
+        if (!found) return orgNotFound(identifier);
+
+        if (opts.dryRun) {
+          if (opts.json)
+            await writeJson({ wouldRemove: found.slug, name: found.name, hard: !!opts.hard });
+          else
+            console.log(
+              chalk.yellow(
+                `[dry-run] Would ${opts.hard ? "hard-delete" : "remove"} organization: ${found.name} (${found.slug})`,
+              ),
+            );
+          return;
+        }
+
+        if (opts.hard && !opts.yes) {
+          let dependents;
+          try {
+            dependents = await getOrgDependents(found.slug);
+          } catch (err) {
+            console.error(
+              chalk.red(
+                `Failed to load cascade preview: ${err instanceof Error ? err.message : err}`,
+              ),
+            );
+            process.exit(1);
+          }
+
+          const c = dependents.counts;
+          console.error("");
+          console.error(chalk.bold.red("This will permanently delete:"));
+          console.error(`  - 1 organization (${found.name}, slug: ${found.slug})`);
+          console.error(`  - ${c.sources.toLocaleString()} sources`);
+          console.error(`  - ${c.releases.toLocaleString()} releases`);
+          console.error(`  - ${c.sourceChangelogChunks.toLocaleString()} changelog chunks`);
+          console.error(`  - ${c.sourceChangelogFiles.toLocaleString()} changelog files`);
+          console.error(`  - ${c.fetchLog.toLocaleString()} fetch log entries`);
+          console.error(`  - ${c.releaseSummaries.toLocaleString()} release summaries`);
+          console.error(`  - ${c.mediaAssets.toLocaleString()} media assets`);
+          console.error(`  - ${c.webhookSubscriptions.toLocaleString()} webhook subscriptions`);
+          console.error("");
+          console.error(chalk.red("This is irreversible."));
+
+          const confirmed = await promptConfirm(`Type the org slug to confirm: `, found.slug);
+          if (!confirmed) {
+            console.error(chalk.yellow("Slug did not match. Aborted."));
+            process.exit(1);
+          }
+        }
+
+        await removeOrg(found.slug, { hard: opts.hard });
+
+        if (opts.json) await writeJson({ removed: found.slug, hard: !!opts.hard });
         else
           console.log(
-            chalk.yellow(`[dry-run] Would remove organization: ${found.name} (${found.slug})`),
+            chalk.green(
+              `${opts.hard ? "Hard-deleted" : "Removed"} organization: ${found.name} (${found.slug})`,
+            ),
           );
-        return;
-      }
-
-      await removeOrg(found.slug);
-
-      if (opts.json) await writeJson({ removed: found.slug });
-      else console.log(chalk.green(`Removed organization: ${found.name} (${found.slug})`));
-    });
+      },
+    );
 
   // ── org link ──
   org

--- a/src/cli/commands/org.ts
+++ b/src/cli/commands/org.ts
@@ -394,9 +394,10 @@ Examples:
         opts: { json?: boolean; dryRun?: boolean; hard?: boolean; yes?: boolean },
       ) => {
         // Fail fast on the obvious misconfiguration: --hard from a piped
-        // stdin without --yes. Catching this before any network call avoids
-        // a misleading API error and saves a round-trip.
-        if (opts.hard && !opts.yes && !opts.dryRun && !process.stdin.isTTY) {
+        // stdin without --yes. Applies to --dry-run too — a scripted hard
+        // delete that "works" in dry-run only to error in the real run is
+        // a worse outcome than a single up-front complaint.
+        if (opts.hard && !opts.yes && !process.stdin.isTTY) {
           console.error(
             chalk.red(
               "No interactive TTY available — pass --yes to confirm a hard delete in scripted contexts.",

--- a/src/lib/confirm.ts
+++ b/src/lib/confirm.ts
@@ -1,0 +1,46 @@
+import { createInterface } from "node:readline";
+
+/**
+ * Reader function injected into `promptConfirm`. Returns `null` to signal
+ * "no interactive input available" — the helper interprets that as a
+ * non-confirmation. The default implementation is a TTY-gated `readline`
+ * prompt; tests inject a deterministic reader.
+ */
+export type PromptReader = (question: string) => Promise<string | null>;
+
+/**
+ * Default reader: refuses to read from a non-TTY stdin (returns `null`
+ * without consuming input). Forces scripted callers to bypass the prompt
+ * with an explicit `--yes` flag instead, so a piped `echo` can never
+ * silently auto-confirm a destructive cascade.
+ */
+export const defaultPromptReader: PromptReader = async (question) => {
+  if (!process.stdin.isTTY) return null;
+
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  try {
+    return await new Promise<string>((resolve) => {
+      rl.question(question, (input) => resolve(input));
+    });
+  } finally {
+    rl.close();
+  }
+};
+
+/**
+ * Prompt the user to type back an exact phrase (e.g. an org slug).
+ *
+ * Returns `true` only when the user types the expected value verbatim
+ * (whitespace around the answer is stripped). Anything else — mismatch or a
+ * `null` reader response — returns `false`. The caller decides what to do
+ * on a mismatch (typically: abort with a non-zero exit).
+ */
+export async function promptConfirm(
+  question: string,
+  expected: string,
+  reader: PromptReader = defaultPromptReader,
+): Promise<boolean> {
+  const answer = await reader(question);
+  if (answer === null) return false;
+  return answer.trim() === expected;
+}

--- a/tests/cli/org-delete.test.ts
+++ b/tests/cli/org-delete.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "bun:test";
+import { runCli } from "../utils.js";
+
+/**
+ * Integration coverage for `releases admin org delete --hard`.
+ *
+ * The runCli helper spawns the CLI as a subprocess with piped stdio, so
+ * `process.stdin.isTTY` is `false` inside the child. That gates the two
+ * behaviors we can assert without mocking fetch:
+ *
+ *   1. `--hard` without `--yes` from a non-TTY exits 1 with a clear
+ *      "no interactive TTY" message — before any DELETE is issued.
+ *   2. `org delete <slug>` and `org remove <slug>` are aliases — both must
+ *      surface the new flags in --help output.
+ *
+ * Typeback success / mismatch are unit-tested against `promptConfirm`
+ * directly in tests/unit/confirm.test.ts (the readline path can't be driven
+ * cleanly through spawnSync's piped stdin).
+ */
+describe("admin org delete --hard (CLI integration)", () => {
+  it("rejects --hard without --yes when stdin is not a TTY", () => {
+    const { stderr, exitCode } = runCli(["admin", "org", "delete", "vercel", "--hard"], {
+      env: { RELEASED_API_URL: "https://test.example.com", RELEASED_API_KEY: "test" },
+    });
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("--yes");
+  });
+
+  it("exposes --hard and --yes flags on the delete subcommand", () => {
+    const { stdout, exitCode } = runCli(["admin", "org", "delete", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--hard");
+    expect(stdout).toContain("--yes");
+  });
+
+  it("treats `org remove` as an alias of `org delete`", () => {
+    const { stdout, exitCode } = runCli(["admin", "org", "remove", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--hard");
+  });
+});

--- a/tests/unit/confirm.test.ts
+++ b/tests/unit/confirm.test.ts
@@ -1,29 +1,32 @@
 import { describe, it, expect } from "bun:test";
-import { promptConfirm } from "../../src/lib/confirm.js";
+import { promptConfirm, type PromptReader } from "../../src/lib/confirm.js";
+
+const QUESTION = "Type the org slug to confirm: ";
+
+const readerExact: PromptReader = async () => "vercel";
+const readerWithNewline: PromptReader = async () => "vercel\n";
+const readerMismatch: PromptReader = async () => "wrong-slug";
+const readerNull: PromptReader = async () => null;
+const readerEmpty: PromptReader = async () => "";
 
 describe("promptConfirm", () => {
   it("returns true when the typed slug matches the expected value", async () => {
-    const reader = async () => "vercel";
-    expect(await promptConfirm("Type the org slug to confirm: ", "vercel", reader)).toBe(true);
+    expect(await promptConfirm(QUESTION, "vercel", readerExact)).toBe(true);
   });
 
   it("trims trailing whitespace before comparing (newline tolerated)", async () => {
-    const reader = async () => "vercel\n";
-    expect(await promptConfirm("Type the org slug to confirm: ", "vercel", reader)).toBe(true);
+    expect(await promptConfirm(QUESTION, "vercel", readerWithNewline)).toBe(true);
   });
 
   it("returns false when the typed slug does not match", async () => {
-    const reader = async () => "wrong-slug";
-    expect(await promptConfirm("Type the org slug to confirm: ", "vercel", reader)).toBe(false);
+    expect(await promptConfirm(QUESTION, "vercel", readerMismatch)).toBe(false);
   });
 
   it("returns false when the reader returns null (no TTY available)", async () => {
-    const reader = async () => null;
-    expect(await promptConfirm("Type the org slug to confirm: ", "vercel", reader)).toBe(false);
+    expect(await promptConfirm(QUESTION, "vercel", readerNull)).toBe(false);
   });
 
   it("treats an empty answer as a mismatch", async () => {
-    const reader = async () => "";
-    expect(await promptConfirm("Type the org slug to confirm: ", "vercel", reader)).toBe(false);
+    expect(await promptConfirm(QUESTION, "vercel", readerEmpty)).toBe(false);
   });
 });

--- a/tests/unit/confirm.test.ts
+++ b/tests/unit/confirm.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "bun:test";
+import { promptConfirm } from "../../src/lib/confirm.js";
+
+describe("promptConfirm", () => {
+  it("returns true when the typed slug matches the expected value", async () => {
+    const reader = async () => "vercel";
+    expect(await promptConfirm("Type the org slug to confirm: ", "vercel", reader)).toBe(true);
+  });
+
+  it("trims trailing whitespace before comparing (newline tolerated)", async () => {
+    const reader = async () => "vercel\n";
+    expect(await promptConfirm("Type the org slug to confirm: ", "vercel", reader)).toBe(true);
+  });
+
+  it("returns false when the typed slug does not match", async () => {
+    const reader = async () => "wrong-slug";
+    expect(await promptConfirm("Type the org slug to confirm: ", "vercel", reader)).toBe(false);
+  });
+
+  it("returns false when the reader returns null (no TTY available)", async () => {
+    const reader = async () => null;
+    expect(await promptConfirm("Type the org slug to confirm: ", "vercel", reader)).toBe(false);
+  });
+
+  it("treats an empty answer as a mismatch", async () => {
+    const reader = async () => "";
+    expect(await promptConfirm("Type the org slug to confirm: ", "vercel", reader)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

`releases admin org delete <slug> --hard` now shows a cascade-scope preview and requires the user to type the org slug back to confirm. Backs the post-#690 Phase C schema flip on prod (2026-05-03), where `sources.org_id` switched from `ON DELETE SET NULL` to `ON DELETE CASCADE` — what used to orphan an org's sources now wipes them and every release / fetch_log / changelog file/chunk / release summary / media asset / webhook subscription tied to them.

```
$ releases admin org delete vercel --hard

This will permanently delete:
  - 1 organization (Vercel, slug: vercel)
  - 12 sources
  - 25,400 releases
  - 8,216 changelog chunks
  - 189 changelog files
  - 24,123 fetch log entries
  - 0 release summaries
  - 0 media assets
  - 0 webhook subscriptions

This is irreversible.
Type the org slug to confirm: _
```

- Counts come from `GET /v1/admin/orgs/:slug/dependents` (added in [buildinternet/releases#702](https://github.com/buildinternet/releases/pull/702)) — the preview matches whatever the API would actually drop.
- `--yes` / `-y` skips the prompt for scripted ops.
- Piped (non-TTY) stdin without `--yes` exits 1 with a clear "no interactive TTY" message **before any network call** instead of silently auto-confirming.
- Soft-delete (default, no `--hard`) is unchanged — still tombstones via `deleted_at` with a `<slug>--<id>` rename, no prompt.
- `admin org remove` continues to work as an alias of `admin org delete`.

`OrgDependentsResponse` is defined locally in `src/api/types.ts` as a stop-gap until `@buildinternet/releases-api-types` >= 0.5.0 publishes from the monorepo PR — drop the local block and bump the pin in a follow-up.

**Don't merge until [buildinternet/releases#702](https://github.com/buildinternet/releases/pull/702) is merged and the endpoint is live on `api.releases.sh`.**

## Test plan

- [x] `bun test tests/unit/confirm.test.ts` — typeback success, trailing-newline tolerance, mismatch, null-reader (non-TTY), empty-answer
- [x] `bun test tests/cli/org-delete.test.ts` — non-TTY without `--yes` exits non-zero with the TTY message; `--hard` and `--yes` flags surface on both `org delete --help` and `org remove --help`
- [x] `bun test` — full suite (241 tests) passes
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun run format:check` clean
- [ ] Manual smoke against staging once monorepo PR ships:
  - [ ] `releases admin org delete <slug> --hard` shows preview, mismatched typeback aborts with exit 1
  - [ ] `releases admin org delete <slug> --hard --yes` skips the prompt
  - [ ] `releases admin org delete <slug>` (no flag) continues to soft-delete without prompting

Closes #700.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `admin org delete` supports permanent deletion via `--hard`, shows a dependent-item cascade preview, and accepts `--dry-run`.
  * Requires typing the org slug to confirm hard deletes; `--yes`/`-y` skips the prompt.
  * `admin org remove` remains an alias for `admin org delete`.
* **Behavior**
  * Non-interactive (non-TTY) runs must include `--yes` to permit hard deletes.
* **Tests**
  * Added CLI and unit tests covering hard-delete prompts, help output, and confirmation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->