### PR TITLE
feat(api): adopt org-scoped paths + bare-slug lookup resolver

### DIFF
--- a/.changeset/bare-slug-rejection-adoption.md
+++ b/.changeset/bare-slug-rejection-adoption.md
@@ -1,0 +1,11 @@
+---
+"@buildinternet/releases": minor
+---
+
+Adopt the org-scoped API path shape so the CLI keeps working after the monorepo rejects bare-slug source/product paths with 400 (#698).
+
+- `findSource(identifier)` and `findProduct(identifier)` now branch on the input shape: typed `src_…`/`prod_…` IDs hit the legacy bare path (still safe — IDs are globally unique), `org/slug` coordinates split into the org-scoped form, and bare slugs round-trip through the new `GET /v1/lookups/{source,product}-by-slug` resolver to pick a canonical home before fetching.
+- Mutation helpers (`updateSource`, `deleteSource`, `deleteSources`, `deleteReleasesForSource`, `insertReleasesBatch`, `checkContentHash`, `updateSourceMeta`, `updateProduct`) now take a typed-ID-bearing entity object instead of a slug string and target the bare path with `id`, which the API still accepts.
+- `getKnownReleasesForSource(identifier, …)` accepts the same identifier shapes as `findSource`.
+
+No CLI command surface changes — operators continue to type slugs, IDs, or `org/slug` coordinates wherever an identifier is accepted. The slug branch costs one extra round-trip to the lookup endpoint per command (cached aggressively at the network layer), which is the price for unambiguous resolution after #690 made slugs per-org.

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -81,15 +81,63 @@ export async function apiFetch<T>(path: string, opts?: RequestInit): Promise<T> 
 
 // ── Source queries ──
 
+/**
+ * Resolves an operator-supplied source identifier to a `{ orgSlug, sourceSlug }`
+ * pair the API can match without ambiguity. Accepts:
+ *
+ *   - `src_…` typed IDs: pass straight through; the bare API path still
+ *     accepts globally-unique IDs.
+ *   - `org/slug` coordinates: split locally; the API takes the org-scoped
+ *     pair directly.
+ *   - bare slugs: round-trip through `GET /v1/lookups/source-by-slug` to
+ *     pick the canonical org for the slug. The lookup endpoint returns the
+ *     oldest match so repeated calls land on the same row when a slug
+ *     exists under multiple orgs (a side effect of #690 per-org slug
+ *     uniqueness).
+ *
+ * Returns `null` when no matching source exists. Throws on API errors.
+ */
+async function resolveSourceTarget(
+  identifier: string,
+): Promise<{ pathSegment: string; sourceId: string } | null> {
+  if (identifier.startsWith("src_")) {
+    return { pathSegment: `/v1/sources/${encodeURIComponent(identifier)}`, sourceId: identifier };
+  }
+  const slash = identifier.indexOf("/");
+  if (slash > 0 && slash < identifier.length - 1) {
+    const orgSlug = identifier.slice(0, slash);
+    const sourceSlug = identifier.slice(slash + 1);
+    return {
+      pathSegment: `/v1/orgs/${encodeURIComponent(orgSlug)}/sources/${encodeURIComponent(sourceSlug)}`,
+      sourceId: "", // unknown until we hydrate via findSource — callers that need the ID re-read source.id from the result
+    };
+  }
+  // Bare slug — bounce through the lookup resolver to get an unambiguous home.
+  const resolved = await apiFetch<{
+    sourceId: string;
+    sourceSlug: string;
+    orgSlug: string;
+  } | null>(`/v1/lookups/source-by-slug?slug=${encodeURIComponent(identifier)}`);
+  if (!resolved) return null;
+  return {
+    pathSegment: `/v1/orgs/${encodeURIComponent(resolved.orgSlug)}/sources/${encodeURIComponent(resolved.sourceSlug)}`,
+    sourceId: resolved.sourceId,
+  };
+}
+
 export async function findSource(identifier: string): Promise<Source | null> {
   // API returns enriched data — extra fields are harmlessly ignored by callers expecting Source
-  return apiFetch<Source | null>(`/v1/sources/${identifier}`);
+  const target = await resolveSourceTarget(identifier);
+  if (!target) return null;
+  return apiFetch<Source | null>(target.pathSegment);
 }
 
 export async function sourceChangelog(
-  slug: string,
+  identifier: string,
   range?: { path?: string; offset?: number; limit?: number; tokens?: number },
 ): Promise<SourceChangelogResponse | null> {
+  const target = await resolveSourceTarget(identifier);
+  if (!target) return null;
   const params = new URLSearchParams();
   if (range?.path !== undefined) params.set("path", range.path);
   if (range?.offset !== undefined) params.set("offset", String(range.offset));
@@ -97,7 +145,7 @@ export async function sourceChangelog(
   if (range?.tokens !== undefined) params.set("tokens", String(range.tokens));
   const qs = params.toString();
   return apiFetch<SourceChangelogResponse | null>(
-    `/v1/sources/${slug}/changelog${qs ? `?${qs}` : ""}`,
+    `${target.pathSegment}/changelog${qs ? `?${qs}` : ""}`,
   );
 }
 
@@ -244,8 +292,9 @@ export async function unsuppressRelease(releaseId: string): Promise<boolean> {
 // ── Content hash ──
 
 export async function checkContentHash(source: Source, contentHash: string): Promise<boolean> {
+  // Use the stable typed ID — slug-form bare paths return 400 after #698.
   const result = await apiFetch<{ unchanged: boolean } | null>(
-    `/v1/sources/${source.slug}/content-hash`,
+    `/v1/sources/${encodeURIComponent(source.id)}/content-hash`,
     {
       method: "POST",
       body: JSON.stringify({ contentHash }),
@@ -504,12 +553,14 @@ export async function getLatestReleases(opts: {
 // ── Known releases for incremental parsing ──
 
 export async function getKnownReleasesForSource(
-  sourceSlug: string,
+  sourceIdentifier: string,
   limit: number,
 ): Promise<Array<{ version: string | null; title: string; publishedAt: string | null }>> {
+  const target = await resolveSourceTarget(sourceIdentifier);
+  if (!target) return [];
   const data = await apiFetch<
     Array<{ version: string | null; title: string; publishedAt: string | null }>
-  >(`/v1/sources/${sourceSlug}/known-releases?limit=${limit}`);
+  >(`${target.pathSegment}/known-releases?limit=${limit}`);
   return data ?? [];
 }
 
@@ -534,19 +585,22 @@ export async function listSourcesWithChanges(): Promise<Source[]> {
 
 // ── Source CRUD ──
 
-export async function updateSource(slug: string, data: Record<string, unknown>): Promise<Source> {
-  return apiFetch<Source>(`/v1/sources/${slug}`, {
+export async function updateSource(
+  source: Pick<Source, "id">,
+  data: Record<string, unknown>,
+): Promise<Source> {
+  return apiFetch<Source>(`/v1/sources/${encodeURIComponent(source.id)}`, {
     method: "PATCH",
     body: JSON.stringify(data),
   });
 }
 
-export async function deleteSource(slug: string): Promise<void> {
-  await apiFetch(`/v1/sources/${slug}`, { method: "DELETE" });
+export async function deleteSource(source: Pick<Source, "id">): Promise<void> {
+  await apiFetch(`/v1/sources/${encodeURIComponent(source.id)}`, { method: "DELETE" });
 }
 
 export async function insertReleasesBatch(
-  sourceSlug: string,
+  source: Pick<Source, "id">,
   releaseRows: Array<{
     version?: string | null;
     title: string;
@@ -561,9 +615,10 @@ export async function insertReleasesBatch(
   for (let i = 0; i < releaseRows.length; i += 5) {
     chunks.push(releaseRows.slice(i, i + 5));
   }
+  const path = `/v1/sources/${encodeURIComponent(source.id)}/releases/batch`;
   const settled = await Promise.allSettled(
     chunks.map((chunk) =>
-      apiFetch<{ inserted: number; total: number }>(`/v1/sources/${sourceSlug}/releases/batch`, {
+      apiFetch<{ inserted: number; total: number }>(path, {
         method: "POST",
         body: JSON.stringify({ releases: chunk }),
       }),
@@ -579,7 +634,7 @@ export async function insertReleasesBatch(
 
   if (failures.length > 0) {
     logger.warn(
-      `insertReleasesBatch(${sourceSlug}): ${failures.length}/${chunks.length} chunk(s) failed — ${failures.map(String).join("; ")}`,
+      `insertReleasesBatch(${source.id}): ${failures.length}/${chunks.length} chunk(s) failed — ${failures.map(String).join("; ")}`,
     );
   }
 
@@ -588,8 +643,10 @@ export async function insertReleasesBatch(
   return { inserted, total };
 }
 
-export async function deleteReleasesForSource(sourceSlug: string): Promise<{ deleted: number }> {
-  return apiFetch(`/v1/sources/${sourceSlug}/releases`, { method: "DELETE" });
+export async function deleteReleasesForSource(
+  source: Pick<Source, "id">,
+): Promise<{ deleted: number }> {
+  return apiFetch(`/v1/sources/${encodeURIComponent(source.id)}/releases`, { method: "DELETE" });
 }
 
 export async function createSource(data: {
@@ -710,8 +767,41 @@ export async function createProduct(
   });
 }
 
+/** Sibling of `resolveSourceTarget` for products. Same identifier shapes. */
+async function resolveProductTarget(
+  identifier: string,
+): Promise<{ pathSegment: string; productId: string } | null> {
+  if (identifier.startsWith("prod_")) {
+    return {
+      pathSegment: `/v1/products/${encodeURIComponent(identifier)}`,
+      productId: identifier,
+    };
+  }
+  const slash = identifier.indexOf("/");
+  if (slash > 0 && slash < identifier.length - 1) {
+    const orgSlug = identifier.slice(0, slash);
+    const productSlug = identifier.slice(slash + 1);
+    return {
+      pathSegment: `/v1/orgs/${encodeURIComponent(orgSlug)}/products/${encodeURIComponent(productSlug)}`,
+      productId: "",
+    };
+  }
+  const resolved = await apiFetch<{
+    productId: string;
+    productSlug: string;
+    orgSlug: string;
+  } | null>(`/v1/lookups/product-by-slug?slug=${encodeURIComponent(identifier)}`);
+  if (!resolved) return null;
+  return {
+    pathSegment: `/v1/orgs/${encodeURIComponent(resolved.orgSlug)}/products/${encodeURIComponent(resolved.productSlug)}`,
+    productId: resolved.productId,
+  };
+}
+
 export async function findProduct(identifier: string): Promise<Product | null> {
-  return apiFetch<Product | null>(`/v1/products/${identifier}`);
+  const target = await resolveProductTarget(identifier);
+  if (!target) return null;
+  return apiFetch<Product | null>(target.pathSegment);
 }
 
 export async function getProductsByOrg(
@@ -720,8 +810,11 @@ export async function getProductsByOrg(
   return apiFetch<Array<Product & { sourceCount: number }>>(`/v1/products?orgId=${orgId}`);
 }
 
-export async function updateProduct(slug: string, data: Record<string, unknown>): Promise<Product> {
-  return apiFetch<Product>(`/v1/products/${slug}`, {
+export async function updateProduct(
+  product: Pick<Product, "id">,
+  data: Record<string, unknown>,
+): Promise<Product> {
+  return apiFetch<Product>(`/v1/products/${encodeURIComponent(product.id)}`, {
     method: "PATCH",
     body: JSON.stringify(data),
   });
@@ -1052,7 +1145,7 @@ export async function updateSourceMeta(
     else merged[k] = v;
   }
   const serialized = JSON.stringify(merged);
-  await apiFetch(`/v1/sources/${source.slug}`, {
+  await apiFetch(`/v1/sources/${encodeURIComponent(source.id)}`, {
     method: "PATCH",
     body: JSON.stringify({ metadata: serialized }),
   });
@@ -1067,8 +1160,8 @@ export async function findSourcesBySlugs(slugs: string[]): Promise<Source[]> {
   return results.filter((r): r is Source => r !== null);
 }
 
-export async function deleteSources(slugs: string[]): Promise<void> {
-  await Promise.all(slugs.map((s) => deleteSource(s)));
+export async function deleteSources(sources: Array<Pick<Source, "id">>): Promise<void> {
+  await Promise.all(sources.map((s) => deleteSource(s)));
 }
 
 // ── Exclusion check (compose blocked + ignored) ──

--- a/src/cli/commands/edit.ts
+++ b/src/cli/commands/edit.ts
@@ -237,7 +237,7 @@ export function registerEditCommand(program: Command) {
         }
 
         if (Object.keys(updates).length > 0) {
-          const updated = await updateSource(source.slug, updates);
+          const updated = await updateSource(source, updates);
           if (opts.slug && updated.slug !== opts.slug) {
             const idx = changes.findIndex((c) => c.startsWith("slug →"));
             if (idx !== -1) changes.splice(idx, 1);

--- a/src/cli/commands/product.ts
+++ b/src/cli/commands/product.ts
@@ -190,7 +190,7 @@ export function registerProductCommand(program: Command) {
           process.exit(1);
         }
 
-        const updated = await updateProduct(found.slug, updates);
+        const updated = await updateProduct(found, updates);
 
         if (opts.json) await writeJson(updated);
         else console.log(chalk.green(`Product updated: ${updated.name} (${updated.slug})`));
@@ -297,7 +297,7 @@ export function registerProductCommand(program: Command) {
 
         await Promise.all(
           sources.map((source) =>
-            updateSource(source.slug, { orgId: targetOrg.id, productId: created.id }),
+            updateSource(source, { orgId: targetOrg.id, productId: created.id }),
           ),
         );
 

--- a/src/cli/commands/release.ts
+++ b/src/cli/commands/release.ts
@@ -137,7 +137,7 @@ export function registerReleaseCommand(program: Command) {
           }
           let result: Awaited<ReturnType<typeof deleteReleasesForSource>>;
           try {
-            result = await deleteReleasesForSource(resolvedSource.slug);
+            result = await deleteReleasesForSource(resolvedSource);
           } catch (err) {
             console.error(chalk.red(err instanceof Error ? err.message : String(err)));
             process.exit(1);

--- a/src/cli/commands/remove.ts
+++ b/src/cli/commands/remove.ts
@@ -84,8 +84,7 @@ export function registerRemoveCommand(program: Command) {
         }
 
         if (existing.length > 0) {
-          const foundSlugList = existing.map((s) => s.slug);
-          await deleteSources(foundSlugList);
+          await deleteSources(existing);
 
           for (const source of existing) {
             results.push({


### PR DESCRIPTION
Coordinated client adoption for monorepo PR [buildinternet/releases#710](https://github.com/buildinternet/releases/pull/710), which rejects bare-slug source/product paths with `400 bare_slug_rejected` once merged. Without this PR, every operator command that takes a slug — `show`, `edit`, `check`, `tail`, `fetch`, `remove`, `changelog`, `product remove`, etc. — would 400 against the new API behavior the moment monorepo `#710` ships.

**Both PRs need to ship together** — this CLI version first (or simultaneously), then `#710`.

## Resolution strategy

`findSource(identifier)` / `findProduct(identifier)` now branch on the operator-supplied input shape:

| Input | Path |
|-------|------|
| `src_…` / `prod_…` typed ID | Legacy bare path — still safe, IDs stay globally unique post-#690 |
| `org/slug` coordinate | Split locally, hit the org-scoped path directly |
| Bare slug | Round-trip through the new `GET /v1/lookups/{source,product}-by-slug` to resolve to a canonical home, then fetch via the org-scoped path |

`sourceChangelog(identifier, …)` and `getKnownReleasesForSource(identifier, …)` share the same resolution path.

The lookup endpoint returns the **oldest match by `createdAt`** when a slug exists under multiple orgs — a deterministic answer for the same input across calls (rather than first-row-wins or random).

## Mutation helpers

Helpers that previously took `slug: string` now take a typed-ID-bearing entity (a `Source` or `{ id }`) and POST/PATCH/DELETE against the bare path with `id` — which the API still accepts because IDs are unambiguous. Affects:

- `updateSource(source, data)` (was `updateSource(slug, data)`)
- `deleteSource(source)` (was `deleteSource(slug)`)
- `deleteSources(sources)` (was `deleteSources(slugs)`)
- `deleteReleasesForSource(source)` (was `deleteReleasesForSource(slug)`)
- `insertReleasesBatch(source, rows)` (was `insertReleasesBatch(slug, rows)`)
- `checkContentHash(source, hash)` — already took a Source; now uses `source.id` instead of `source.slug` internally
- `updateSourceMeta(source, meta)` — same as above
- `updateProduct(product, data)` (was `updateProduct(slug, data)`)

Call sites in `cli/commands/{edit,product,release,remove}.ts` already had a hydrated entity object in scope (post-`findSource` / `findProduct`), so each call site swap is mechanical: pass the entity instead of `entity.slug`.

## Operator surface

**Zero CLI command surface changes.** Operators continue to type slugs, IDs, or `org/slug` coordinates wherever an identifier is accepted. The slug branch costs **one** extra round-trip to the lookup endpoint per command — well below the typical fetch budget; typed-ID and coordinate forms skip the lookup entirely.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test` — 241/241 pass
- [x] `bun run lint` clean
- [x] `bun run format:check` clean
- [ ] After merge: smoke-test `releases show <bare-slug>`, `releases edit <bare-slug> --priority low`, `releases product remove <bare-slug>` against a deployment that has monorepo #710 applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced CLI identifier resolution to handle multiple identifier formats (typed IDs, org/slug coordinates, and bare slugs) for source and product operations across edit, delete, and adopt commands.

* **Chores**
  * Updated internal identifier handling patterns for API requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->