### PR TITLE
feat(#105): add --limit/--page pagination to org list, task list, block list, ignore list

### DIFF
--- a/.changeset/list-pagination.md
+++ b/.changeset/list-pagination.md
@@ -1,0 +1,19 @@
+---
+"@buildinternet/releases": minor
+---
+
+Add `--limit <n>` / `--page <n>` pagination to four list commands and consume the
+`{ items, pagination }` envelope the API now returns for `/v1/orgs`,
+`/v1/admin/blocklist`, `/v1/orgs/:slug/ignored-urls`, and `/v1/sessions`
+(monorepo PR #723):
+
+- `releases org list`
+- `releases admin discovery task list`
+- `releases admin policy block list`
+- `releases admin policy ignore list`
+
+All four pass `?limit=&page=` through to the API and read the server's
+pagination metadata directly — no more client-side `Array.slice()`. Each prints
+a `warning: results may be truncated` message to stderr when more pages are
+available and no explicit `--limit` was supplied, mirroring `releases list`.
+Closes #105.

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ npm/releases/README.md
 .context
 .superpowers
 .worktrees
+.claude/skills
+.claude/worktrees/

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -166,8 +166,12 @@ async function suggestEntities(
   term: string,
   limit: number,
 ): Promise<Array<{ slug: string; name: string }>> {
-  const all =
-    (await apiFetch<Array<{ slug: string; name: string }>>(`${endpoint}?limit=200`)) ?? [];
+  type Row = { slug: string; name: string };
+  // /v1/orgs always returns a paginated envelope (#723); /v1/sources is bare
+  // unless ?envelope=true. Accept either shape so this helper stays valid as
+  // more list endpoints adopt always-envelope.
+  const raw = (await apiFetch<Row[] | ListResponse<Row>>(`${endpoint}?limit=200`)) ?? ([] as Row[]);
+  const all: Row[] = Array.isArray(raw) ? raw : raw.items;
   const lower = term.toLowerCase();
   return all
     .filter((e) => e.slug.includes(lower) || e.name.toLowerCase().includes(lower))
@@ -186,12 +190,16 @@ export async function getSourcesByOrg(orgId: string): Promise<Source[]> {
 export async function listOrgs(opts?: {
   query?: string;
   platform?: string;
-}): Promise<Organization[]> {
+  limit?: number;
+  page?: number;
+}): Promise<ListResponse<Organization>> {
   const params = new URLSearchParams();
   if (opts?.query) params.set("q", opts.query);
   if (opts?.platform) params.set("platform", opts.platform);
+  if (opts?.limit != null) params.set("limit", String(opts.limit));
+  if (opts?.page != null) params.set("page", String(opts.page));
   const qs = params.toString();
-  return apiFetch<Organization[]>(`/v1/orgs${qs ? `?${qs}` : ""}`);
+  return apiFetch<ListResponse<Organization>>(`/v1/orgs${qs ? `?${qs}` : ""}`);
 }
 
 export async function getOrgAccountByPlatform(
@@ -215,8 +223,15 @@ export async function addIgnoredUrl(url: string, orgId: string, reason?: string)
   });
 }
 
-export async function listIgnoredUrls(orgId: string): Promise<IgnoredUrl[]> {
-  return apiFetch<IgnoredUrl[]>(`/v1/orgs/${orgId}/ignored-urls`);
+export async function listIgnoredUrls(
+  orgId: string,
+  opts?: { limit?: number; page?: number },
+): Promise<ListResponse<IgnoredUrl>> {
+  const params = new URLSearchParams();
+  if (opts?.limit != null) params.set("limit", String(opts.limit));
+  if (opts?.page != null) params.set("page", String(opts.page));
+  const qs = params.toString();
+  return apiFetch<ListResponse<IgnoredUrl>>(`/v1/orgs/${orgId}/ignored-urls${qs ? `?${qs}` : ""}`);
 }
 
 export async function removeIgnoredUrl(url: string, orgId: string): Promise<void> {
@@ -241,8 +256,15 @@ export async function addBlockedUrl(
   });
 }
 
-export async function listBlockedUrls(): Promise<BlockedUrl[]> {
-  return apiFetch<BlockedUrl[]>("/v1/admin/blocklist");
+export async function listBlockedUrls(opts?: {
+  limit?: number;
+  page?: number;
+}): Promise<ListResponse<BlockedUrl>> {
+  const params = new URLSearchParams();
+  if (opts?.limit != null) params.set("limit", String(opts.limit));
+  if (opts?.page != null) params.set("page", String(opts.page));
+  const qs = params.toString();
+  return apiFetch<ListResponse<BlockedUrl>>(`/v1/admin/blocklist${qs ? `?${qs}` : ""}`);
 }
 
 export async function removeBlockedUrl(pattern: string): Promise<void> {
@@ -1029,8 +1051,21 @@ export async function queryReleasesWithMedia(): Promise<
 
 // ── Sessions ──
 
-export async function listSessions(): Promise<Session[]> {
-  return apiFetch<Session[]>("/v1/sessions");
+export async function listSessions(opts?: {
+  limit?: number;
+  page?: number;
+  type?: string;
+  status?: string;
+  recentMinutes?: number;
+}): Promise<ListResponse<Session>> {
+  const params = new URLSearchParams();
+  if (opts?.limit != null) params.set("limit", String(opts.limit));
+  if (opts?.page != null) params.set("page", String(opts.page));
+  if (opts?.type) params.set("type", opts.type);
+  if (opts?.status) params.set("status", opts.status);
+  if (opts?.recentMinutes != null) params.set("recent_minutes", String(opts.recentMinutes));
+  const qs = params.toString();
+  return apiFetch<ListResponse<Session>>(`/v1/sessions${qs ? `?${qs}` : ""}`);
 }
 
 export async function getSession(sessionId: string): Promise<Session | null> {

--- a/src/cli/commands/admin/overview/list.ts
+++ b/src/cli/commands/admin/overview/list.ts
@@ -57,9 +57,19 @@ Staleness check (--stale):
       const graceDays = parsePositiveIntFlag("stale-grace-days", opts.staleGraceDays);
 
       // listOrgs returns OrgListItem[] at runtime (includes recentReleaseCount + lastActivity)
-      // The client types it as Organization[] — cast here until upstream type is updated.
-      const rawOrgs = await listOrgs({ query: opts.query });
-      const orgs = rawOrgs as unknown as OrgListItem[];
+      // but the API types model the row as Organization. Cast through unknown
+      // here until upstream type is updated. Pull every page so the
+      // overview-stale scan doesn't miss orgs past the default page.
+      const orgs: OrgListItem[] = [];
+      let page = 1;
+      let hasMore = true;
+      while (hasMore) {
+        // eslint-disable-next-line no-await-in-loop
+        const result = await listOrgs({ query: opts.query, page, limit: 200 });
+        orgs.push(...(result.items as unknown as OrgListItem[]));
+        hasMore = result.pagination.hasMore;
+        page += 1;
+      }
 
       if (orgs.length === 0) {
         if (opts.json) await writeJson([]);

--- a/src/cli/commands/block.ts
+++ b/src/cli/commands/block.ts
@@ -3,6 +3,11 @@ import chalk from "chalk";
 import { listBlockedUrls, addBlockedUrl, removeBlockedUrl } from "../../api/client.js";
 import { logger } from "@releases/lib/logger";
 import { writeJson } from "../../lib/output.js";
+import {
+  DEFAULT_PAGE_SIZE,
+  formatTruncationWarning,
+  type ListResponse,
+} from "@buildinternet/releases-core/cli-contracts";
 
 export function registerBlockCommand(program: Command) {
   const block = program.command("block").description("Manage globally blocked URLs and domains");
@@ -11,6 +16,8 @@ export function registerBlockCommand(program: Command) {
     .command("list")
     .description("List all globally blocked patterns")
     .option("--json", "Output as JSON")
+    .option("--limit <n>", `Limit the number of results (default ${DEFAULT_PAGE_SIZE})`)
+    .option("--page <n>", "Page number for paginated results")
     .addHelpText(
       "after",
       `
@@ -18,11 +25,36 @@ Examples:
   releases admin policy block list
   releases admin policy block list --json`,
     )
-    .action(async (opts: { json?: boolean }) => {
-      const rows = await listBlockedUrls();
+    .action(async (opts: { json?: boolean; limit?: string; page?: string }) => {
+      const parsedLimit = opts.limit === undefined ? undefined : Number(opts.limit);
+      if (parsedLimit !== undefined && (!Number.isInteger(parsedLimit) || parsedLimit <= 0)) {
+        logger.error("--limit must be a positive integer");
+        process.exit(1);
+      }
+      const explicitLimit = parsedLimit !== undefined;
+      const pageSize = explicitLimit ? parsedLimit : DEFAULT_PAGE_SIZE;
+
+      const parsedPage = opts.page === undefined ? 1 : Number(opts.page);
+      if (!Number.isInteger(parsedPage) || parsedPage <= 0) {
+        logger.error("--page must be a positive integer");
+        process.exit(1);
+      }
+      const page = parsedPage;
+
+      const { items: rows, pagination } = await listBlockedUrls({ limit: pageSize, page });
 
       if (opts.json) {
-        await writeJson(rows);
+        const response: ListResponse<(typeof rows)[number]> = { items: rows, pagination };
+        await writeJson(response);
+        if (!explicitLimit && pagination.hasMore) {
+          logger.warn(
+            formatTruncationWarning({
+              returned: rows.length,
+              pageSize,
+              commandExample: `releases admin policy block list --json --limit <n> --page <p>`,
+            }),
+          );
+        }
         return;
       }
 
@@ -35,6 +67,15 @@ Examples:
         const typeLabel = row.type === "domain" ? chalk.blue("[domain]") : chalk.gray("[exact]");
         const reasonLabel = row.reason ? chalk.gray(` — ${row.reason}`) : "";
         logger.info(`${typeLabel} ${chalk.yellow(row.pattern)}${reasonLabel}`);
+      }
+      if (!explicitLimit && pagination.hasMore) {
+        logger.warn(
+          formatTruncationWarning({
+            returned: rows.length,
+            pageSize,
+            commandExample: `releases admin policy block list --limit <n> --page <p>`,
+          }),
+        );
       }
     });
 

--- a/src/cli/commands/ignore.ts
+++ b/src/cli/commands/ignore.ts
@@ -3,6 +3,11 @@ import chalk from "chalk";
 import { findOrg, listIgnoredUrls, addIgnoredUrl, removeIgnoredUrl } from "../../api/client.js";
 import { logger } from "@releases/lib/logger";
 import { writeJson } from "../../lib/output.js";
+import {
+  DEFAULT_PAGE_SIZE,
+  formatTruncationWarning,
+  type ListResponse,
+} from "@buildinternet/releases-core/cli-contracts";
 
 export function registerIgnoreCommand(program: Command) {
   const ignore = program
@@ -14,6 +19,8 @@ export function registerIgnoreCommand(program: Command) {
     .description("List ignored URLs for an organization")
     .requiredOption("--org <org>", "Organization slug, domain, or name")
     .option("--json", "Output as JSON")
+    .option("--limit <n>", `Limit the number of results (default ${DEFAULT_PAGE_SIZE})`)
+    .option("--page <n>", "Page number for paginated results")
     .addHelpText(
       "after",
       `
@@ -21,17 +28,45 @@ Examples:
   releases admin policy ignore list --org acme
   releases admin policy ignore list --org acme --json`,
     )
-    .action(async (opts: { org: string; json?: boolean }) => {
+    .action(async (opts: { org: string; json?: boolean; limit?: string; page?: string }) => {
       const org = await findOrg(opts.org);
       if (!org) {
         logger.error(`Organization not found: ${opts.org}`);
         process.exit(1);
       }
 
-      const rows = await listIgnoredUrls(org.id);
+      const parsedLimit = opts.limit === undefined ? undefined : Number(opts.limit);
+      if (parsedLimit !== undefined && (!Number.isInteger(parsedLimit) || parsedLimit <= 0)) {
+        logger.error("--limit must be a positive integer");
+        process.exit(1);
+      }
+      const explicitLimit = parsedLimit !== undefined;
+      const pageSize = explicitLimit ? parsedLimit : DEFAULT_PAGE_SIZE;
+
+      const parsedPage = opts.page === undefined ? 1 : Number(opts.page);
+      if (!Number.isInteger(parsedPage) || parsedPage <= 0) {
+        logger.error("--page must be a positive integer");
+        process.exit(1);
+      }
+      const page = parsedPage;
+
+      const { items: rows, pagination } = await listIgnoredUrls(org.id, {
+        limit: pageSize,
+        page,
+      });
 
       if (opts.json) {
-        await writeJson(rows);
+        const response: ListResponse<(typeof rows)[number]> = { items: rows, pagination };
+        await writeJson(response);
+        if (!explicitLimit && pagination.hasMore) {
+          logger.warn(
+            formatTruncationWarning({
+              returned: rows.length,
+              pageSize,
+              commandExample: `releases admin policy ignore list --org ${opts.org} --json --limit <n> --page <p>`,
+            }),
+          );
+        }
         return;
       }
 
@@ -43,6 +78,15 @@ Examples:
       for (const row of rows) {
         const reasonLabel = row.reason ? chalk.gray(` — ${row.reason}`) : "";
         logger.info(`${chalk.yellow(row.url)}${reasonLabel}`);
+      }
+      if (!explicitLimit && pagination.hasMore) {
+        logger.warn(
+          formatTruncationWarning({
+            returned: rows.length,
+            pageSize,
+            commandExample: `releases admin policy ignore list --org ${opts.org} --limit <n> --page <p>`,
+          }),
+        );
       }
     });
 

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -5,6 +5,7 @@ import { listSourcesWithOrg, findSource } from "../../api/client.js";
 import { sourceNotFound } from "../suggest.js";
 import { stripAnsi } from "../../lib/sanitize.js";
 import { writeJson } from "../../lib/output.js";
+import { logger } from "@releases/lib/logger";
 import {
   DEFAULT_PAGE_SIZE,
   parseMetadataObject,
@@ -57,6 +58,24 @@ export function registerListCommand(program: Command) {
           flat?: boolean;
         },
       ) => {
+        // Validate pagination flags before the slug fast path so malformed
+        // --limit / --page still error consistently, even when ignored by the
+        // single-source branch.
+        const parsedLimit = opts.limit === undefined ? undefined : Number(opts.limit);
+        if (parsedLimit !== undefined && (!Number.isInteger(parsedLimit) || parsedLimit <= 0)) {
+          logger.error("--limit must be a positive integer");
+          process.exit(1);
+        }
+        const explicitLimit = parsedLimit !== undefined;
+        const pageSize = explicitLimit ? parsedLimit : DEFAULT_PAGE_SIZE;
+
+        const parsedPage = opts.page === undefined ? 1 : Number(opts.page);
+        if (!Number.isInteger(parsedPage) || parsedPage <= 0) {
+          logger.error("--page must be a positive integer");
+          process.exit(1);
+        }
+        const page = parsedPage;
+
         if (slug) {
           const source = await findSource(slug);
           if (!source) return sourceNotFound(slug);
@@ -86,11 +105,6 @@ export function registerListCommand(program: Command) {
           console.log("");
           return;
         }
-
-        const limitOpt = opts.limit ? parseInt(opts.limit, 10) : undefined;
-        const explicitLimit = limitOpt != null && limitOpt > 0;
-        const pageSize = explicitLimit ? limitOpt : DEFAULT_PAGE_SIZE;
-        const page = opts.page ? Math.max(1, parseInt(opts.page, 10)) : 1;
 
         const { items: pageItems, pagination: apiPagination } = await listSourcesWithOrg({
           orgSlug: opts.org,
@@ -147,7 +161,7 @@ export function registerListCommand(program: Command) {
           }
 
           if (warnTruncated) {
-            console.error(
+            logger.warn(
               formatTruncationWarning({
                 returned: items.length,
                 pageSize,
@@ -179,7 +193,7 @@ export function registerListCommand(program: Command) {
 
         console.log(table.toString());
         if (!explicitLimit && apiPagination.hasMore) {
-          console.error(
+          logger.warn(
             formatTruncationWarning({
               returned: pageItems.length,
               pageSize,

--- a/src/cli/commands/org.ts
+++ b/src/cli/commands/org.ts
@@ -28,7 +28,12 @@ import { toSlug } from "@buildinternet/releases-core/slug";
 import { isValidCategory, CATEGORIES } from "@buildinternet/releases-core/categories";
 import { timeAgo } from "@buildinternet/releases-core/dates";
 import { writeJson } from "../../lib/output.js";
-import { computePagination, type ListResponse } from "@buildinternet/releases-core/cli-contracts";
+import {
+  DEFAULT_PAGE_SIZE,
+  computePagination,
+  formatTruncationWarning,
+  type ListResponse,
+} from "@buildinternet/releases-core/cli-contracts";
 import {
   OVERVIEW_STALE_DAYS,
   overviewAgeDays,
@@ -333,30 +338,91 @@ export function registerOrgCommand(program: Command) {
     .option("--query <text>", "Filter by name, slug, domain, or handle")
     .option("--platform <platform>", "Filter to orgs with an account on this platform")
     .option("--json", "Output as JSON")
-    .action(async (opts: { query?: string; platform?: string; json?: boolean }) => {
-      const allOrgs = await listOrgs({ query: opts.query, platform: opts.platform });
+    .option("--limit <n>", `Limit the number of results (default ${DEFAULT_PAGE_SIZE})`)
+    .option("--page <n>", "Page number for paginated results")
+    .action(
+      async (opts: {
+        query?: string;
+        platform?: string;
+        json?: boolean;
+        limit?: string;
+        page?: string;
+      }) => {
+        const parsedLimit = opts.limit === undefined ? undefined : Number(opts.limit);
+        if (parsedLimit !== undefined && (!Number.isInteger(parsedLimit) || parsedLimit <= 0)) {
+          logger.error("--limit must be a positive integer");
+          process.exit(1);
+        }
+        const explicitLimit = parsedLimit !== undefined;
+        const pageSize = explicitLimit ? parsedLimit : DEFAULT_PAGE_SIZE;
 
-      if (allOrgs.length === 0) {
-        if (opts.json) await writeJson([]);
-        else console.log(chalk.yellow("No organizations found."));
-        return;
-      }
+        const parsedPage = opts.page === undefined ? 1 : Number(opts.page);
+        if (!Number.isInteger(parsedPage) || parsedPage <= 0) {
+          logger.error("--page must be a positive integer");
+          process.exit(1);
+        }
+        const page = parsedPage;
 
-      if (opts.json) {
-        await writeJson(allOrgs);
-        return;
-      }
+        const { items: pageItems, pagination } = await listOrgs({
+          query: opts.query,
+          platform: opts.platform,
+          limit: pageSize,
+          page,
+        });
 
-      const table = new Table({
-        head: [chalk.cyan("Name"), chalk.cyan("Slug"), chalk.cyan("Domain"), chalk.cyan("Updated")],
-      });
+        if (pageItems.length === 0) {
+          if (opts.json) {
+            const response: ListResponse<(typeof pageItems)[number]> = { items: [], pagination };
+            await writeJson(response);
+          } else {
+            logger.info(chalk.yellow("No organizations found."));
+          }
+          return;
+        }
 
-      for (const o of allOrgs) {
-        table.push([o.name, o.slug, o.domain ?? chalk.dim("—"), o.updatedAt]);
-      }
+        if (opts.json) {
+          const response: ListResponse<(typeof pageItems)[number]> = {
+            items: pageItems,
+            pagination,
+          };
+          await writeJson(response);
+          if (!explicitLimit && pagination.hasMore) {
+            logger.warn(
+              formatTruncationWarning({
+                returned: pageItems.length,
+                pageSize,
+                commandExample: `releases org list --json --limit <n> --page <p>`,
+              }),
+            );
+          }
+          return;
+        }
 
-      console.log(table.toString());
-    });
+        const table = new Table({
+          head: [
+            chalk.cyan("Name"),
+            chalk.cyan("Slug"),
+            chalk.cyan("Domain"),
+            chalk.cyan("Updated"),
+          ],
+        });
+
+        for (const o of pageItems) {
+          table.push([o.name, o.slug, o.domain ?? chalk.dim("—"), o.updatedAt]);
+        }
+
+        console.log(table.toString());
+        if (!explicitLimit && pagination.hasMore) {
+          logger.warn(
+            formatTruncationWarning({
+              returned: pageItems.length,
+              pageSize,
+              commandExample: `releases org list --limit <n> --page <p>`,
+            }),
+          );
+        }
+      },
+    );
 
   // ── org get (canonical) / org show (deprecated) ──
   org

--- a/src/cli/commands/task.ts
+++ b/src/cli/commands/task.ts
@@ -2,6 +2,11 @@ import { Command } from "commander";
 import chalk from "chalk";
 import * as apiClient from "../../api/client.js";
 import { writeJson } from "../../lib/output.js";
+import { logger } from "@releases/lib/logger";
+import {
+  DEFAULT_PAGE_SIZE,
+  formatTruncationWarning,
+} from "@buildinternet/releases-core/cli-contracts";
 
 export function registerTaskCommand(program: Command) {
   const task = program.command("task").description("Manage remote fetch and discovery sessions");
@@ -10,11 +15,40 @@ export function registerTaskCommand(program: Command) {
     .command("list")
     .description("List active and recent sessions")
     .option("--json", "Output as JSON")
-    .action(async (opts: { json?: boolean }) => {
-      const sessions = await apiClient.listSessions();
+    .option("--limit <n>", `Limit the number of results (default ${DEFAULT_PAGE_SIZE})`)
+    .option("--page <n>", "Page number for paginated results")
+    .action(async (opts: { json?: boolean; limit?: string; page?: string }) => {
+      const parsedLimit = opts.limit === undefined ? undefined : Number(opts.limit);
+      if (parsedLimit !== undefined && (!Number.isInteger(parsedLimit) || parsedLimit <= 0)) {
+        logger.error("--limit must be a positive integer");
+        process.exit(1);
+      }
+      const explicitLimit = parsedLimit !== undefined;
+      const pageSize = explicitLimit ? parsedLimit : DEFAULT_PAGE_SIZE;
+
+      const parsedPage = opts.page === undefined ? 1 : Number(opts.page);
+      if (!Number.isInteger(parsedPage) || parsedPage <= 0) {
+        logger.error("--page must be a positive integer");
+        process.exit(1);
+      }
+      const page = parsedPage;
+
+      const { items: sessions, pagination } = await apiClient.listSessions({
+        limit: pageSize,
+        page,
+      });
 
       if (opts.json) {
-        await writeJson(sessions);
+        await writeJson({ items: sessions, pagination });
+        if (!explicitLimit && pagination.hasMore) {
+          logger.warn(
+            formatTruncationWarning({
+              returned: sessions.length,
+              pageSize,
+              commandExample: `releases admin discovery task list --json --limit <n> --page <p>`,
+            }),
+          );
+        }
         return;
       }
 
@@ -48,6 +82,15 @@ export function registerTaskCommand(program: Command) {
           `  ${statusColor(s.status.padEnd(10))} ${s.company.padEnd(30)} ${chalk.gray(s.sessionId.slice(0, 8))}  ${chalk.gray(ageStr + " ago")}${detailStr}`,
         );
       }
+      if (!explicitLimit && pagination.hasMore) {
+        logger.warn(
+          formatTruncationWarning({
+            returned: sessions.length,
+            pageSize,
+            commandExample: `releases admin discovery task list --limit <n> --page <p>`,
+          }),
+        );
+      }
     });
 
   task
@@ -57,7 +100,7 @@ export function registerTaskCommand(program: Command) {
     .action(async (sessionIdArg: string) => {
       let sessionId = sessionIdArg;
       if (sessionId.length < 36) {
-        const sessions = await apiClient.listSessions();
+        const { items: sessions } = await apiClient.listSessions();
         const matches = sessions.filter((s) => s.sessionId.startsWith(sessionId));
         if (matches.length === 0) {
           console.error(chalk.red(`No session found matching "${sessionId}".`));

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -321,7 +321,18 @@ server.registerTool(
     },
   },
   async ({ query, platform }) => {
-    const allOrgs = await listOrgs({ query, platform });
+    // /v1/orgs is paginated server-side post-#723; page through every result so
+    // the tool truly lists all indexed organizations, not just the first page.
+    const allOrgs: Awaited<ReturnType<typeof listOrgs>>["items"] = [];
+    let page = 1;
+    let hasMore = true;
+    while (hasMore) {
+      // eslint-disable-next-line no-await-in-loop
+      const result = await listOrgs({ query, platform, page, limit: 200 });
+      allOrgs.push(...result.items);
+      hasMore = result.pagination.hasMore;
+      page += 1;
+    }
 
     if (allOrgs.length === 0) {
       return textResult("No organizations found.");


### PR DESCRIPTION
## Summary

Adds `--limit <n>` / `--page <n>` to five list commands and consumes the `{ items, pagination }` envelope the API now returns from monorepo PR #723:

- `releases list` (sources)
- `releases org list`
- `releases admin policy block list`
- `releases admin policy ignore list`
- `releases admin discovery task list`

All five pass `?limit=` / `?page=` through to the API and read the server's pagination metadata directly — no client-side `Array.slice()`. Each prints a `warning: results may be truncated` to stderr when more pages are available and no explicit `--limit` was supplied.

Closes #105.

## API client changes (`src/api/client.ts`)

Four list functions are now typed as `ListResponse<T>` to match the always-envelope shape monorepo PR #723 ships:

| Function | Endpoint | Notes |
|---|---|---|
| `listOrgs()` | `GET /v1/orgs` | accepts `query`, `platform`, `limit`, `page` |
| `listBlockedUrls()` | `GET /v1/admin/blocklist` | accepts `limit`, `page` |
| `listIgnoredUrls(orgId)` | `GET /v1/orgs/:slug/ignored-urls` | accepts `limit`, `page` |
| `listSessions()` | `GET /v1/sessions` | accepts `limit`, `page`, `type`, `status`, `recentMinutes` |

`suggestEntities()` tolerates either bare-array or envelope shape so it stays valid as `/v1/orgs` envelopes today and `/v1/sources` may follow.

## Implementation notes

**Validation order** — pagination flag validation runs before the `slug` fast path in `releases list <slug>`, so malformed `--limit`/`--page` still error consistently regardless of whether the slug branch returns early.

**Truncation warnings** route through the shared logger (`logger.warn` / `logger.error`) rather than `console.error`, so they go to stderr via the same `[releases]` prefix the rest of the CLI uses. The "No organizations found" empty-state message in `org list` similarly uses `logger.info` for consistency with `block list` and `ignore list`.

**`admin overview-list`** now pages through every result (200/page) so the stale-overview scan does not miss orgs past page 1.

**`mcp/server.ts` `list_organizations`** pages through every result so the MCP tool truly lists all indexed organizations rather than just the first server-side page (default 50 post-#723).

**`.gitignore`** adds `.claude/skills` and `.claude/worktrees/` (matching the monorepo's targeted pattern), keeping the rest of `.claude/` trackable for agent / plugin config.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run format:check` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `bun test` — 255 pass
- [x] CodeRabbit review feedback addressed (validation order, truncation logger routing, server-side wiring, `org list` empty-state logger consistency, MCP `list_organizations` pagination)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
