### PR TITLE
feat(#106): add agent-context command for machine-readable CLI schema

### DIFF
--- a/.changeset/agent-context.md
+++ b/.changeset/agent-context.md
@@ -1,0 +1,9 @@
+---
+"@buildinternet/releases": minor
+---
+
+Add `releases agent-context` command that emits a versioned JSON document describing every command, argument, option, and exit code in the CLI.
+
+This is the L2 introspection layer described in the [10-principle agent-native CLI guide](https://trevinsays.com/p/10-principles-for-agent-native-clis): agents driving the CLI can answer questions like "does this flag accept stdin?" or "what commands are deprecated?" without spawning `--help` per command and parsing prose.
+
+The schema is generated at runtime by walking Commander's program tree — it stays automatically in sync with the implementation. `schemaVersion` is a string that bumps only on breaking field renames or removals; additive changes (new commands, new options, new fields) are silent.

--- a/src/cli/commands/agent-context.ts
+++ b/src/cli/commands/agent-context.ts
@@ -1,0 +1,243 @@
+import { Command } from "commander";
+import { writeJson } from "../../lib/output.js";
+import { VERSION } from "../version.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface AgentContextArg {
+  name: string;
+  required: boolean;
+  variadic: boolean;
+  description: string;
+  acceptsStdin: boolean;
+}
+
+export interface AgentContextOption {
+  flags: string;
+  description: string;
+  required: boolean;
+  default: unknown;
+  acceptsStdin: boolean;
+}
+
+export interface AgentContextCommand {
+  path: string[];
+  summary: string;
+  deprecated: boolean;
+  deprecatedReplacement: string | null;
+  args: AgentContextArg[];
+  options: AgentContextOption[];
+}
+
+export interface AgentContextDocument {
+  schemaVersion: "1";
+  binary: "releases";
+  version: string;
+  exitCodes: Array<{ code: number; meaning: string }>;
+  commands: AgentContextCommand[];
+}
+
+// ---------------------------------------------------------------------------
+// Stdin-accepting flags allowlist
+//
+// Commander has no generic signal for "this flag accepts - for stdin". The
+// pairs below are (command-path-suffix, flag-long-name) tuples that we know
+// accept "-" to mean stdin. Extend this list whenever a new stdin-capable
+// flag is added to the CLI.
+// ---------------------------------------------------------------------------
+const STDIN_FLAGS: Array<{ pathSuffix: string[]; flagName: string }> = [
+  // releases import <file>
+  { pathSuffix: ["import"], flagName: "<file>" },
+  // releases admin source add --batch <file>
+  { pathSuffix: ["add"], flagName: "--batch" },
+  // releases admin source create --batch <file>
+  { pathSuffix: ["create"], flagName: "--batch" },
+  // releases admin webhook verify --body-file <path>
+  { pathSuffix: ["verify"], flagName: "--body-file" },
+  // releases admin overview-write --content-file <path>
+  { pathSuffix: ["overview-write"], flagName: "--content-file" },
+];
+
+// ---------------------------------------------------------------------------
+// Deprecated command detection
+//
+// Commands whose action is wrapped by warnDeprecatedAlias() are considered
+// deprecated. We detect this via the command description, which always starts
+// with "(deprecated — use <verb>)" per the pattern established across the
+// codebase. This avoids needing to introspect the action function closure.
+// ---------------------------------------------------------------------------
+const DEPRECATED_DESCRIPTION_PREFIX = "(deprecated — use ";
+
+function parseDeprecationFromDescription(description: string): {
+  deprecated: boolean;
+  deprecatedReplacement: string | null;
+} {
+  if (!description.startsWith(DEPRECATED_DESCRIPTION_PREFIX)) {
+    return { deprecated: false, deprecatedReplacement: null };
+  }
+  // e.g. "(deprecated — use create) Add a new changelog source"
+  const inner = description.slice(DEPRECATED_DESCRIPTION_PREFIX.length);
+  const closeIdx = inner.indexOf(")");
+  const replacement = closeIdx >= 0 ? inner.slice(0, closeIdx).trim() : null;
+  return { deprecated: true, deprecatedReplacement: replacement };
+}
+
+// ---------------------------------------------------------------------------
+// Introspection helpers
+// ---------------------------------------------------------------------------
+
+function pathEndsWith(path: string[], suffix: string[]): boolean {
+  if (suffix.length > path.length) return false;
+  for (let i = 0; i < suffix.length; i++) {
+    if (path[path.length - suffix.length + i] !== suffix[i]) return false;
+  }
+  return true;
+}
+
+function isStdinFlag(commandPath: string[], flagString: string): boolean {
+  // flagString is the option's flags string, e.g. "--batch <file>" or "<file>"
+  // We check if either the long flag name appears, or if it's a positional.
+  return STDIN_FLAGS.some(({ pathSuffix, flagName }) => {
+    if (!pathEndsWith(commandPath, pathSuffix)) return false;
+    return flagString.includes(flagName);
+  });
+}
+
+function introspectCommand(cmd: Command, parentPath: string[]): AgentContextCommand[] {
+  const name = cmd.name();
+  // Skip the root program and pure group nodes that have no name or are the
+  // root "releases" program (parent === null).
+  if (!name || cmd.parent === null) {
+    // Still descend into children for the root program.
+    const results: AgentContextCommand[] = [];
+    for (const sub of cmd.commands) {
+      results.push(...introspectCommand(sub, parentPath));
+    }
+    return results;
+  }
+
+  const path = [...parentPath, name];
+
+  const { deprecated, deprecatedReplacement } = parseDeprecationFromDescription(
+    cmd.description() ?? "",
+  );
+
+  // Positional arguments
+  // Commander exposes these via the public registeredArguments accessor (added
+  // in Commander 10; the old ._args private field was removed in v12).
+  const args: AgentContextArg[] = cmd.registeredArguments.map((a) => ({
+    name: a.name(),
+    required: a.required,
+    variadic: a.variadic,
+    description: a.description ?? "",
+    acceptsStdin: false, // filled in below
+  }));
+
+  // Options — Commander stores these on .options[]
+  const options: AgentContextOption[] = cmd.options.map((opt) => {
+    // acceptsStdin: check both the flags string and the command path.
+    const acceptsStdin = isStdinFlag(path, opt.flags);
+    return {
+      flags: opt.flags,
+      description: opt.description ?? "",
+      required: opt.mandatory ?? false,
+      default: opt.defaultValue ?? null,
+      acceptsStdin,
+    };
+  });
+
+  // Also check positional args for stdin acceptance (e.g. `import <file>`)
+  const argsWithStdin: AgentContextArg[] = args.map((a) => {
+    // Positionals use the arg name as the "flag" key in the allowlist
+    const syntheticFlagStr = `<${a.name}>`;
+    if (isStdinFlag(path, syntheticFlagStr)) {
+      // Set acceptsStdin structurally and annotate the description so agents
+      // can discover stdin support both programmatically and in prose.
+      const note = " (use - for stdin)";
+      const description = a.description.includes("stdin") ? a.description : a.description + note;
+      return {
+        name: a.name,
+        required: a.required,
+        variadic: a.variadic,
+        description,
+        acceptsStdin: true,
+      };
+    }
+    return a;
+  });
+
+  const result: AgentContextCommand = {
+    path,
+    summary: cmd.description() ?? "",
+    deprecated,
+    deprecatedReplacement,
+    args: argsWithStdin,
+    options,
+  };
+
+  const results: AgentContextCommand[] = [result];
+
+  // Recurse into subcommands
+  for (const sub of cmd.commands) {
+    results.push(...introspectCommand(sub, path));
+  }
+
+  return results;
+}
+
+/**
+ * Walk the Commander program tree and produce the agent-context document.
+ * Exported for unit testing.
+ */
+export function buildAgentContext(program: Command): AgentContextDocument {
+  const commands: AgentContextCommand[] = [];
+  for (const sub of program.commands) {
+    commands.push(...introspectCommand(sub, []));
+  }
+
+  return {
+    schemaVersion: "1",
+    binary: "releases",
+    version: VERSION,
+    exitCodes: [
+      // TODO: source from EXIT_CODES constant once #111 lands.
+      { code: 0, meaning: "success" },
+      { code: 1, meaning: "application error" },
+      { code: 2, meaning: "usage / provider error" },
+      { code: 130, meaning: "cancellation (SIGINT)" },
+    ],
+    commands,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Command registration
+// ---------------------------------------------------------------------------
+
+export function registerAgentContextCommand(program: Command): void {
+  program
+    .command("agent-context")
+    .description("Emit a versioned JSON document describing every command, argument, and option")
+    .addHelpText(
+      "after",
+      `
+Emit a versioned JSON document describing every command, argument, option,
+and exit code in this CLI.
+
+Designed for agents that need machine-readable command metadata without
+parsing per-command --help output.
+
+Schema version: 1 (bumps on breaking field renames/removals; additive
+changes are silent).
+
+Examples:
+  releases agent-context | jq '.commands[] | select(.deprecated)'
+  releases agent-context | jq '.exitCodes'`,
+    )
+    .action(async () => {
+      const doc = buildAgentContext(program);
+      await writeJson(doc);
+    });
+}

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -36,6 +36,7 @@ import { registerTelemetryCommand } from "./commands/telemetry.js";
 import { registerServeCommand } from "./commands/serve.js";
 import { registerWhoamiCommand } from "./commands/whoami.js";
 import { registerWebhookCommand } from "./commands/webhook.js";
+import { registerAgentContextCommand } from "./commands/agent-context.js";
 import { CATEGORIES } from "@buildinternet/releases-core/categories";
 import { isAdminMode } from "../lib/mode.js";
 import { VERSION } from "./version.js";
@@ -169,6 +170,7 @@ registerGetCommand(program);
 registerShowCommand(program);
 registerTelemetryCommand(program);
 registerWhoamiCommand(program);
+registerAgentContextCommand(program);
 
 const admin = program
   .command("admin")

--- a/tests/unit/agent-context.test.ts
+++ b/tests/unit/agent-context.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "bun:test";
+import { program } from "../../src/cli/program.js";
+import { buildAgentContext } from "../../src/cli/commands/agent-context.js";
+
+describe("buildAgentContext", () => {
+  const doc = buildAgentContext(program);
+
+  it("has schemaVersion === '1'", () => {
+    expect(doc.schemaVersion).toBe("1");
+  });
+
+  it("has binary === 'releases'", () => {
+    expect(doc.binary).toBe("releases");
+  });
+
+  it("has a non-empty version string", () => {
+    expect(typeof doc.version).toBe("string");
+    expect(doc.version.length).toBeGreaterThan(0);
+  });
+
+  it("has exit codes including 0 and 1", () => {
+    const codes = doc.exitCodes.map((e) => e.code);
+    expect(codes).toContain(0);
+    expect(codes).toContain(1);
+    expect(codes).toContain(2);
+    expect(codes).toContain(130);
+  });
+
+  it("has more than 20 commands (covers the full CLI tree)", () => {
+    expect(doc.commands.length).toBeGreaterThan(20);
+  });
+
+  it("every command has a non-empty path array", () => {
+    for (const cmd of doc.commands) {
+      expect(Array.isArray(cmd.path)).toBe(true);
+      expect(cmd.path.length).toBeGreaterThan(0);
+      for (const segment of cmd.path) {
+        expect(typeof segment).toBe("string");
+        expect(segment.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("every command has deprecated as a boolean (never undefined)", () => {
+    for (const cmd of doc.commands) {
+      expect(typeof cmd.deprecated).toBe("boolean");
+      // Must be strictly true or false — never undefined.
+      expect(cmd.deprecated === true || cmd.deprecated === false).toBe(true);
+    }
+  });
+
+  it("every option has flags and description strings, with boolean invariants", () => {
+    for (const cmd of doc.commands) {
+      for (const opt of cmd.options) {
+        expect(typeof opt.flags).toBe("string");
+        expect(opt.flags.length).toBeGreaterThan(0);
+        expect(typeof opt.description).toBe("string");
+        expect(opt.description.length).toBeGreaterThan(0);
+        expect(typeof opt.acceptsStdin).toBe("boolean");
+        expect(typeof opt.required).toBe("boolean");
+      }
+    }
+  });
+
+  it("includes admin source create with correct shape", () => {
+    const cmd = doc.commands.find(
+      (c) =>
+        c.path.length === 3 &&
+        c.path[0] === "admin" &&
+        c.path[1] === "source" &&
+        c.path[2] === "create",
+    );
+    expect(cmd).toBeDefined();
+    expect(cmd!.deprecated).toBe(false);
+    expect(cmd!.deprecatedReplacement).toBeNull();
+    const batchOpt = cmd!.options.find((o) => o.flags.includes("--batch"));
+    expect(batchOpt).toBeDefined();
+    expect(batchOpt!.acceptsStdin).toBe(true);
+  });
+
+  it("deprecated alias commands are marked with deprecated: true and a replacement", () => {
+    // The `add` command under admin source is a deprecated alias for `create`.
+    const addCmd = doc.commands.find(
+      (c) =>
+        c.path.length === 3 &&
+        c.path[0] === "admin" &&
+        c.path[1] === "source" &&
+        c.path[2] === "add",
+    );
+    expect(addCmd).toBeDefined();
+    expect(addCmd!.deprecated).toBe(true);
+    expect(addCmd!.deprecatedReplacement).toBe("create");
+
+    // The `show` top-level command is a deprecated alias for `get`.
+    const showCmd = doc.commands.find((c) => c.path.length === 1 && c.path[0] === "show");
+    expect(showCmd).toBeDefined();
+    expect(showCmd!.deprecated).toBe(true);
+    expect(showCmd!.deprecatedReplacement).toBe("get");
+  });
+
+  it("webhook verify --body-file is marked acceptsStdin", () => {
+    const cmd = doc.commands.find((c) => c.path.at(-1) === "verify" && c.path.includes("webhook"));
+    expect(cmd).toBeDefined();
+    const opt = cmd!.options.find((o) => o.flags.includes("--body-file"));
+    expect(opt).toBeDefined();
+    expect(opt!.acceptsStdin).toBe(true);
+  });
+
+  it("overview-write --content-file is marked acceptsStdin", () => {
+    const cmd = doc.commands.find((c) => c.path.at(-1) === "overview-write");
+    expect(cmd).toBeDefined();
+    const opt = cmd!.options.find((o) => o.flags.includes("--content-file"));
+    expect(opt).toBeDefined();
+    expect(opt!.acceptsStdin).toBe(true);
+  });
+
+  it("import <file> positional is annotated with stdin note", () => {
+    const cmd = doc.commands.find((c) => c.path.at(-1) === "import");
+    expect(cmd).toBeDefined();
+    const fileArg = cmd!.args.find((a) => a.name === "file");
+    expect(fileArg).toBeDefined();
+    expect(fileArg!.description).toContain("stdin");
+  });
+
+  it("every arg has acceptsStdin as a boolean (never undefined)", () => {
+    for (const cmd of doc.commands) {
+      for (const arg of cmd.args) {
+        expect(typeof arg.acceptsStdin).toBe("boolean");
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds `releases agent-context` — a top-level command that emits a versioned JSON document describing every command, subcommand, argument, option, exit code, and stdin convention the CLI exposes. The schema is generated at runtime by walking Commander's program tree, so it stays in sync with the implementation without a parallel hand-maintained file.

`schemaVersion: "1"` bumps only on breaking field renames/removals; additive changes are silent.

Closes #106. Implements the L2 introspection layer per the [10-principle agent-native CLI guide](https://trevinsays.com/p/10-principles-for-agent-native-clis).

## Output shape

```json
{
  "schemaVersion": "1",
  "binary": "releases",
  "version": "0.24.0",
  "exitCodes": [...],
  "commands": [
    {
      "path": ["admin", "source", "create"],
      "summary": "Add a new changelog source",
      "deprecated": false,
      "deprecatedReplacement": null,
      "args": [...],
      "options": [
        { "flags": "--batch <file>", "description": "...", "required": false, "default": null, "acceptsStdin": true }
      ]
    }
  ]
}
```

## Implementation notes

**Deprecated alias detection** — Commander has no first-class deprecated flag. The introspection code checks if a command's description starts with `(deprecated — use <verb>)` — the pattern used consistently across the codebase since #113. This yields `deprecated: true` and `deprecatedReplacement: "create"` for the 13 deprecated alias commands.

**Stdin allowlist** — Commander has no generic signal for "this flag accepts `-` for stdin". A small explicit allowlist marks the five currently-known stdin-capable positions:
- `import <file>` (positional, with a "(use - for stdin)" prose hint appended to the description)
- `admin source create --batch <file>`
- `admin source add --batch <file>` (deprecated alias)
- `admin webhook verify --body-file <path>`
- `admin overview-write --content-file <path>`

The allowlist also feeds an `acceptsStdin: true` boolean on positional args.

**Public Commander API only** — uses `cmd.registeredArguments` (added in Commander 10) and `argument.name()` / `opt.flags` / `opt.mandatory` / `opt.defaultValue` rather than reaching into private `._args` / `._name`.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run format:check` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `bun test` — full suite passes (13 new tests in `tests/unit/agent-context.test.ts` covering schemaVersion, exit codes, deprecation flags, stdin coverage, and per-arg/option invariants)
- [x] `bun src/index.ts agent-context | jq '.schemaVersion'` → `"1"`
- [x] `bun src/index.ts agent-context | jq '.commands | length'` → `106`
- [x] `bun src/index.ts agent-context | jq '.commands[] | select(.path == ["admin", "source", "create"])'` → correct shape with `acceptsStdin: true` on `--batch`
- [x] `bun src/index.ts agent-context | jq '.commands[] | select(.deprecated == true) | .path'` → 13 deprecated aliases listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `releases agent-context` command that outputs comprehensive CLI documentation in JSON format, enabling external tools and automated agents to programmatically discover all available commands, their arguments, options, and capabilities without invoking individual help commands. The documentation schema remains automatically synchronized with CLI implementation changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->