### PR TITLE
fix(#116): apply --tags on idempotent org create retry

### DIFF
--- a/.changeset/idempotent-create-tags-reconcile.md
+++ b/.changeset/idempotent-create-tags-reconcile.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": patch
+---
+
+Apply `--tags` on idempotent `org create` retry (#116). When `releases admin org create acme --tags react` is followed by `releases admin org create acme --tags typescript`, the second call now adds `typescript` to the existing org instead of silently dropping the flag. Tag merging is additive (no removal), and `--strict` continues to bail on duplicate detection before reconciliation runs.

--- a/src/cli/commands/org.ts
+++ b/src/cli/commands/org.ts
@@ -54,12 +54,13 @@ type OrgCreateOpts = {
   strict?: boolean;
 };
 
-function parseTagList(raw: string | undefined): string[] {
-  if (!raw) return [];
-  return raw
+async function applyTagsToOrg(orgId: string, raw: string | undefined): Promise<void> {
+  if (!raw) return;
+  const tagList = raw
     .split(",")
     .map((t) => t.trim())
     .filter(Boolean);
+  if (tagList.length > 0) await addTagsToOrg(orgId, tagList);
 }
 
 async function orgCreateAction(name: string, opts: OrgCreateOpts): Promise<void> {
@@ -76,10 +77,7 @@ async function orgCreateAction(name: string, opts: OrgCreateOpts): Promise<void>
       logger.error(`Organization with slug "${slug}" already exists.`);
       process.exit(1);
     }
-    const tagList = parseTagList(opts.tags);
-    if (tagList.length > 0) {
-      await addTagsToOrg(existing.id, tagList);
-    }
+    await applyTagsToOrg(existing.id, opts.tags);
     logger.info(`Organization already exists: ${existing.name} (${slug}) — returning existing`);
     if (opts.json) await writeJson({ ...existing, existed: true });
     return;
@@ -115,10 +113,7 @@ async function orgCreateAction(name: string, opts: OrgCreateOpts): Promise<void>
           logger.error(`Organization with slug "${slug}" already exists.`);
           process.exit(1);
         }
-        const tagList = parseTagList(opts.tags);
-        if (tagList.length > 0) {
-          await addTagsToOrg(racedExisting.id, tagList);
-        }
+        await applyTagsToOrg(racedExisting.id, opts.tags);
         logger.info(
           `Organization already exists: ${racedExisting.name} (${slug}) — returning existing`,
         );
@@ -129,10 +124,7 @@ async function orgCreateAction(name: string, opts: OrgCreateOpts): Promise<void>
     throw err;
   }
 
-  const tagList = parseTagList(opts.tags);
-  if (tagList.length > 0) {
-    await addTagsToOrg(created.id, tagList);
-  }
+  await applyTagsToOrg(created.id, opts.tags);
 
   if (opts.json) await writeJson({ ...created, existed: false });
   else logger.info(chalk.green(`Organization created: ${name} (${slug})`));

--- a/src/cli/commands/org.ts
+++ b/src/cli/commands/org.ts
@@ -54,6 +54,14 @@ type OrgCreateOpts = {
   strict?: boolean;
 };
 
+function parseTagList(raw: string | undefined): string[] {
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((t) => t.trim())
+    .filter(Boolean);
+}
+
 async function orgCreateAction(name: string, opts: OrgCreateOpts): Promise<void> {
   const slug = opts.slug ?? toSlug(name);
 
@@ -62,9 +70,15 @@ async function orgCreateAction(name: string, opts: OrgCreateOpts): Promise<void>
   // is the only safe signal that we'd actually collide on slug uniqueness.
   const existing = await findOrg(slug);
   if (existing && existing.slug === slug) {
+    // --strict bails before any reconciliation runs, preserving its original
+    // "fail on duplicate" semantics. Tag reconciliation is a non-strict thing.
     if (opts.strict) {
       logger.error(`Organization with slug "${slug}" already exists.`);
       process.exit(1);
+    }
+    const tagList = parseTagList(opts.tags);
+    if (tagList.length > 0) {
+      await addTagsToOrg(existing.id, tagList);
     }
     logger.info(`Organization already exists: ${existing.name} (${slug}) — returning existing`);
     if (opts.json) await writeJson({ ...existing, existed: true });
@@ -101,6 +115,10 @@ async function orgCreateAction(name: string, opts: OrgCreateOpts): Promise<void>
           logger.error(`Organization with slug "${slug}" already exists.`);
           process.exit(1);
         }
+        const tagList = parseTagList(opts.tags);
+        if (tagList.length > 0) {
+          await addTagsToOrg(racedExisting.id, tagList);
+        }
         logger.info(
           `Organization already exists: ${racedExisting.name} (${slug}) — returning existing`,
         );
@@ -111,14 +129,9 @@ async function orgCreateAction(name: string, opts: OrgCreateOpts): Promise<void>
     throw err;
   }
 
-  if (opts.tags) {
-    const tagList = opts.tags
-      .split(",")
-      .map((t: string) => t.trim())
-      .filter(Boolean);
-    if (tagList.length > 0) {
-      await addTagsToOrg(created.id, tagList);
-    }
+  const tagList = parseTagList(opts.tags);
+  if (tagList.length > 0) {
+    await addTagsToOrg(created.id, tagList);
   }
 
   if (opts.json) await writeJson({ ...created, existed: false });

--- a/tests/cli/idempotent-create.test.ts
+++ b/tests/cli/idempotent-create.test.ts
@@ -23,6 +23,12 @@ describe("idempotent org create (--strict flag)", () => {
     expect(exitCode).toBe(0);
     expect(stdout).toContain("--strict");
   });
+
+  it("documents --tags on org create --help (reconciled on retry, see #116)", () => {
+    const { stdout, exitCode } = runCli(["admin", "org", "create", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--tags");
+  });
 });
 
 describe("idempotent source create (--strict flag)", () => {


### PR DESCRIPTION
## Summary

Closes #116. Wires tag reconciliation into the idempotent `org create` retry path so a second call applies its `--tags` instead of silently dropping the flag.

- `org create acme --tags react` followed by `org create acme --tags typescript` now leaves the org tagged with both.
- `--strict` still bails before reconciliation runs (semantics unchanged).
- Additive only — no tag removal on retry. Reconciling other fields (description, category, domain) is intentionally out of scope per the issue.
- Tag-list parsing lifted into a module-private `parseTagList` helper so the split/trim/filter block doesn't repeat across the three create code paths.

## Acceptance criteria (from #116)

- [x] `org create acme --tags react` then `org create acme --tags typescript` leaves the org with both tags.
- [x] `--strict` still errors on the second call, even if `--tags` matches the first call exactly.
- [x] No new test fixtures — extends `tests/cli/idempotent-create.test.ts` with a `--help` assertion that `--tags` is documented (behavioral coverage requires HTTP mocks per the file's existing docstring rationale).

## Test plan

- [x] `npx tsc --noEmit`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun test` (260 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CLI now preserves and merges --tags across idempotent org creation retries (additive merging; tags are never removed). --strict behavior is unchanged.

* **Tests**
  * Added test coverage ensuring the org creation help includes the --tags flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->