### PR TITLE
feat(#103): add --notes-file / --parse-instructions-file flags

### DIFF
--- a/.changeset/notes-and-parse-instructions-file.md
+++ b/.changeset/notes-and-parse-instructions-file.md
@@ -1,0 +1,14 @@
+---
+"@buildinternet/releases": minor
+---
+
+Add `--notes-file` and `--parse-instructions-file` flags for AI-generated multi-paragraph content (#103 workstream 3). The inline `--notes` and `--parse-instructions` forms are quote-hostile and silently truncate at unescaped newlines, which is exactly the shape of content these flags get fed.
+
+- `releases admin playbook <org> --notes-file <path>` (use `-` for stdin) replaces inline notes.
+- `releases admin source update <id> --parse-instructions-file <path>` (use `-` for stdin) replaces inline parse instructions. The deprecated `edit` alias gets the same flag.
+- An empty file clears, matching the existing inline empty-string semantics.
+- Passing both forms together errors: `--notes and --notes-file are mutually exclusive` / `--parse-instructions and --parse-instructions-file are mutually exclusive`.
+
+The inline forms still work in this release but emit a stderr deprecation warning per invocation pointing at the file form. They will be removed in a future minor release.
+
+Skill manifests (`skills/managing-sources`, `skills/seeding-playbooks`) and bundled agent docs are updated to use the file form. While in there, the agent docs' stale `releases admin content playbook` path is corrected to the canonical `releases admin playbook`.

--- a/plugins/claude/releases/agents/discovery.md
+++ b/plugins/claude/releases/agents/discovery.md
@@ -39,8 +39,8 @@ Key commands:
 - `releases admin org get <slug> --json` — Full org details
 - `releases admin org tag add <slug> <tags...>` — Add tags
 - `releases admin product create <name> --org <org> [--category <c>] [--tags <t>]` — Create product
-- `releases admin content playbook <org>` — Read playbook
-- `releases admin content playbook <org> --notes "..."` — Update playbook notes
+- `releases admin playbook <org>` — Read playbook
+- `releases admin playbook <org> --notes-file <path>` (use `-` for stdin) — Update playbook notes
 - `releases categories --json` — List valid categories
 - `releases admin policy ignore add --org <org> <url>` — Ignore URL (org-scoped)
 - `releases admin policy block add <url>` — Block URL globally
@@ -54,7 +54,7 @@ Key commands:
 3. **Add** — Add sources with `releases admin source create` using appropriate types. When creating an org, always include `--description` with a brief one-sentence product description.
 4. **Validate** — Fetch each source with `releases admin source fetch <slug> --dry-run` first, then real fetch. Check results with `releases tail <slug> --json`.
 5. **Assess content depth** — For feed sources, check if pages have richer content than feed summaries.
-6. **Write the playbook** — After validating sources, run `releases admin content playbook <org>` to read current state, then update notes with `releases admin content playbook <org> --notes "..."`. Cover extraction patterns, known quirks, and source coverage.
+6. **Write the playbook** — After validating sources, run `releases admin playbook <org>` to read current state, then update notes with `releases admin playbook <org> --notes-file <path>` (use `-` for stdin). Cover extraction patterns, known quirks, and source coverage.
 7. **Report** — Summarize what was found, including how many releases were persisted.
 
 ## Source Selection

--- a/plugins/claude/releases/agents/worker.md
+++ b/plugins/claude/releases/agents/worker.md
@@ -28,8 +28,8 @@ Key commands:
 - `releases admin source update <identifier> [--primary] [--priority <p>]` — Edit source config (accepts ID or slug)
 - `releases admin org update <slug> [--category <c>]` — Edit org
 - `releases admin product create <name> --org <org>` — Create product
-- `releases admin content playbook <org>` — Read playbook
-- `releases admin content playbook <org> --notes "..."` — Update playbook notes
+- `releases admin playbook <org>` — Read playbook
+- `releases admin playbook <org> --notes-file <path>` (use `-` for stdin) — Update playbook notes
 - `releases tail [slug] --json [--org <org>]` — Get latest releases
 - `releases list [slug] --json` — List sources
 
@@ -37,11 +37,11 @@ Key commands:
 
 When asked to fetch sources:
 
-1. **Read the playbook first.** Run `releases admin content playbook <org>` to understand how each source works — extraction patterns, known quirks, and what to expect. If the notes are empty, note this in your output so the discovery agent can populate them later.
+1. **Read the playbook first.** Run `releases admin playbook <org>` to understand how each source works — extraction patterns, known quirks, and what to expect. If the notes are empty, note this in your output so the discovery agent can populate them later.
 2. Run `releases admin source fetch <slug>` for each source.
 3. Report the number of releases fetched per source.
 4. Report any errors encountered.
-5. **Update the playbook** if you encountered something unexpected — errors, changed page structure, new traps. Run `releases admin content playbook <org> --notes "..."` with updated content. Notes use sections: `### Fetch instructions`, `### Traps`, `### Coverage`.
+5. **Update the playbook** if you encountered something unexpected — errors, changed page structure, new traps. Run `releases admin playbook <org> --notes-file <path>` (use `-` for stdin) with updated content. Notes use sections: `### Fetch instructions`, `### Traps`, `### Coverage`.
 6. Do NOT add, remove, or modify sources — only fetch.
 
 ## Update Operations

--- a/plugins/claude/releases/skills/managing-sources/SKILL.md
+++ b/plugins/claude/releases/skills/managing-sources/SKILL.md
@@ -33,7 +33,7 @@ Operations can be performed via CLI commands or typed MCP/agent tools. Use which
 | Ignore URL | `releases admin policy ignore add --org <org> <url>` | `exclude_url` action "ignore" with url, organization |
 | Block URL | `releases admin policy block add <url>` | `exclude_url` action "block" with url |
 | Get playbook | `releases admin playbook <org>` | `manage_playbook` action "get" with organization |
-| Update playbook notes | `releases admin playbook <org> --notes "..."` | `manage_playbook` action "update_notes" with organization, notes |
+| Update playbook notes | `releases admin playbook <org> --notes-file <path>` (use `-` for stdin) | `manage_playbook` action "update_notes" with organization, notes |
 
 Valid categories (pass to `manage_org`/`manage_product`): see the enum in those tool descriptions or your system prompt. `list_categories` (now retired) has been folded into the two tool descriptions.
 

--- a/plugins/claude/releases/skills/seeding-playbooks/SKILL.md
+++ b/plugins/claude/releases/skills/seeding-playbooks/SKILL.md
@@ -112,15 +112,14 @@ Products: {product list or "none"}
 **Coverage**: 2-3 sentences. Which sources are canonical, whether there are gaps.
 
 Save by running:
-releases admin playbook {slug} --notes "$(cat <<'NOTES'
+releases admin playbook {slug} --notes-file - 2>/dev/null <<'NOTES'
 YOUR NOTES HERE
 NOTES
-)" 2>/dev/null
 
 Verify with: releases admin playbook {slug} 2>/dev/null | tail -20
 ```
 
-The playbook header regenerates automatically after any source create/update/delete, and the `--notes` PATCH seeds a fresh header on first write — no separate regenerate step needed.
+The playbook header regenerates automatically after any source create/update/delete, and the `--notes-file` PATCH seeds a fresh header on first write — no separate regenerate step needed.
 
 ### Verified prompt template
 
@@ -159,10 +158,9 @@ Every claim must cite observed data. If uncertain, say so explicitly.
 
 ## Step 4: Save
 
-releases admin playbook {slug} --notes "$(cat <<'NOTES'
+releases admin playbook {slug} --notes-file - 2>/dev/null <<'NOTES'
 YOUR NOTES HERE
 NOTES
-)" 2>/dev/null
 
 Verify with: releases admin playbook {slug} 2>/dev/null | tail -20
 ```
@@ -187,10 +185,9 @@ Sub-agents may be blocked from saving notes via Bash (heredoc permission issues)
 2. The parent agent (you) saves the notes manually:
 
 ```bash
-releases admin playbook {slug} --notes "$(cat <<'NOTES'
+releases admin playbook {slug} --notes-file - 2>/dev/null <<'NOTES'
 {paste notes from agent result}
 NOTES
-)" 2>/dev/null
 ```
 
 This is a known limitation of subagent permissions. Plan for it — check each agent's result and save manually if needed.

--- a/skills/managing-sources/SKILL.md
+++ b/skills/managing-sources/SKILL.md
@@ -30,7 +30,7 @@ Operations can be performed via CLI commands or typed MCP/agent tools. Use which
 | Ignore URL | `releases admin policy ignore add --org <org> <url>` | `exclude_url` action "ignore" with url, organization |
 | Block URL | `releases admin policy block add <url>` | `exclude_url` action "block" with url |
 | Get playbook | `releases admin playbook <org>` | `manage_playbook` action "get" with organization |
-| Update playbook notes | `releases admin playbook <org> --notes "..."` | `manage_playbook` action "update_notes" with organization, notes |
+| Update playbook notes | `releases admin playbook <org> --notes-file <path>` (use `-` for stdin) | `manage_playbook` action "update_notes" with organization, notes |
 
 Valid categories (pass to `manage_org`/`manage_product`): see the enum in those tool descriptions or your system prompt. `list_categories` (now retired) has been folded into the two tool descriptions.
 

--- a/skills/seeding-playbooks/SKILL.md
+++ b/skills/seeding-playbooks/SKILL.md
@@ -109,15 +109,14 @@ Products: {product list or "none"}
 **Coverage**: 2-3 sentences. Which sources are canonical, whether there are gaps.
 
 Save by running:
-releases admin playbook {slug} --notes "$(cat <<'NOTES'
+releases admin playbook {slug} --notes-file - 2>/dev/null <<'NOTES'
 YOUR NOTES HERE
 NOTES
-)" 2>/dev/null
 
 Verify with: releases admin playbook {slug} 2>/dev/null | tail -20
 ```
 
-The playbook header regenerates automatically after any source create/update/delete, and the `--notes` PATCH seeds a fresh header on first write — no separate regenerate step needed.
+The playbook header regenerates automatically after any source create/update/delete, and the `--notes-file` PATCH seeds a fresh header on first write — no separate regenerate step needed.
 
 ### Verified prompt template
 
@@ -156,10 +155,9 @@ Every claim must cite observed data. If uncertain, say so explicitly.
 
 ## Step 4: Save
 
-releases admin playbook {slug} --notes "$(cat <<'NOTES'
+releases admin playbook {slug} --notes-file - 2>/dev/null <<'NOTES'
 YOUR NOTES HERE
 NOTES
-)" 2>/dev/null
 
 Verify with: releases admin playbook {slug} 2>/dev/null | tail -20
 ```
@@ -184,10 +182,9 @@ Sub-agents may be blocked from saving notes via Bash (heredoc permission issues)
 2. The parent agent (you) saves the notes manually:
 
 ```bash
-releases admin playbook {slug} --notes "$(cat <<'NOTES'
+releases admin playbook {slug} --notes-file - 2>/dev/null <<'NOTES'
 {paste notes from agent result}
 NOTES
-)" 2>/dev/null
 ```
 
 This is a known limitation of subagent permissions. Plan for it — check each agent's result and save manually if needed.

--- a/src/cli/commands/admin/playbook.ts
+++ b/src/cli/commands/admin/playbook.ts
@@ -3,11 +3,14 @@ import chalk from "chalk";
 import { findOrg, getPlaybook, updatePlaybookNotes } from "../../../api/client.js";
 import { orgNotFound } from "../../suggest.js";
 import { writeJson } from "../../../lib/output.js";
+import { readContentArg } from "../../../lib/input.js";
+import { logger } from "@releases/lib/logger";
 import { timeAgo } from "@buildinternet/releases-core/dates";
 
 interface PlaybookOpts {
   json?: boolean;
   notes?: string;
+  notesFile?: string;
 }
 
 export function registerPlaybookCommand(program: Command) {
@@ -16,25 +19,53 @@ export function registerPlaybookCommand(program: Command) {
     .description("Read or update an organization's playbook")
     .argument("<org>", "Organization slug or ID")
     .option("--json", "Output as JSON")
-    .option("--notes <text>", "Replace agent notes (pass full notes content; empty string clears)")
+    .option(
+      "--notes <text>",
+      "(deprecated — use --notes-file) Replace agent notes inline; quote-hostile, prefer --notes-file",
+    )
+    .option(
+      "--notes-file <path>",
+      "Path to file with agent notes (use - for stdin; empty file clears)",
+    )
     .addHelpText(
       "after",
       `
 Examples:
   releases admin playbook vercel
   releases admin playbook vercel --json
-  releases admin playbook vercel --notes "### Fetch instructions\\n..."
+  releases admin playbook vercel --notes-file playbook-notes.md
+  cat playbook-notes.md | releases admin playbook vercel --notes-file -
 
 The playbook's header (source list, products) regenerates automatically after
 any source add/edit/remove — no manual regenerate step is needed. The PATCH
-run by --notes also seeds a fresh header on first write.`,
+run by --notes-file also seeds a fresh header on first write.
+
+--notes (inline) is deprecated and will be removed in a future minor release.
+Quoting markdown across newlines is fragile; prefer --notes-file.`,
     )
     .action(async (orgIdentifier: string, opts: PlaybookOpts) => {
+      if (opts.notes !== undefined && opts.notesFile !== undefined) {
+        logger.error("--notes and --notes-file are mutually exclusive");
+        process.exit(1);
+      }
+      if (opts.notes !== undefined) {
+        logger.warn(
+          '"--notes" is deprecated, use "--notes-file <path>" (use - for stdin); the inline form will be removed in a future release.',
+        );
+      }
+
       const org = await findOrg(orgIdentifier);
       if (!org) return orgNotFound(orgIdentifier);
 
-      if (opts.notes !== undefined) {
-        await updatePlaybookNotes(org.slug, opts.notes);
+      let notesPayload: string | undefined;
+      if (opts.notesFile !== undefined) {
+        notesPayload = await readContentArg(opts.notesFile);
+      } else if (opts.notes !== undefined) {
+        notesPayload = opts.notes;
+      }
+
+      if (notesPayload !== undefined) {
+        await updatePlaybookNotes(org.slug, notesPayload);
         if (opts.json) {
           await writeJson({ org: org.slug, notesUpdated: true });
         } else {

--- a/src/cli/commands/admin/playbook.ts
+++ b/src/cli/commands/admin/playbook.ts
@@ -3,8 +3,7 @@ import chalk from "chalk";
 import { findOrg, getPlaybook, updatePlaybookNotes } from "../../../api/client.js";
 import { orgNotFound } from "../../suggest.js";
 import { writeJson } from "../../../lib/output.js";
-import { readContentArg } from "../../../lib/input.js";
-import { logger } from "@releases/lib/logger";
+import { resolveInlineOrFile } from "../../../lib/input.js";
 import { timeAgo } from "@buildinternet/releases-core/dates";
 
 interface PlaybookOpts {
@@ -44,25 +43,15 @@ run by --notes-file also seeds a fresh header on first write.
 Quoting markdown across newlines is fragile; prefer --notes-file.`,
     )
     .action(async (orgIdentifier: string, opts: PlaybookOpts) => {
-      if (opts.notes !== undefined && opts.notesFile !== undefined) {
-        logger.error("--notes and --notes-file are mutually exclusive");
-        process.exit(1);
-      }
-      if (opts.notes !== undefined) {
-        logger.warn(
-          '"--notes" is deprecated, use "--notes-file <path>" (use - for stdin); the inline form will be removed in a future release.',
-        );
-      }
+      const notesPayload = await resolveInlineOrFile({
+        inline: opts.notes,
+        file: opts.notesFile,
+        inlineName: "--notes",
+        fileName: "--notes-file",
+      });
 
       const org = await findOrg(orgIdentifier);
       if (!org) return orgNotFound(orgIdentifier);
-
-      let notesPayload: string | undefined;
-      if (opts.notesFile !== undefined) {
-        notesPayload = await readContentArg(opts.notesFile);
-      } else if (opts.notes !== undefined) {
-        notesPayload = opts.notes;
-      }
 
       if (notesPayload !== undefined) {
         await updatePlaybookNotes(org.slug, notesPayload);

--- a/src/cli/commands/edit.ts
+++ b/src/cli/commands/edit.ts
@@ -1,49 +1,19 @@
 import { Command } from "commander";
 import { warnDeprecatedAlias } from "../../lib/deprecated-alias.js";
-import { updateSourceAction, type UpdateSourceOpts } from "./update.js";
+import { attachUpdateOptions, updateSourceAction, type UpdateSourceOpts } from "./update.js";
 
 /**
  * Registers the deprecated `edit` alias alongside the canonical `update`
  * command. Both share the same action — the alias path emits a deprecation
- * warning first.
+ * warning first. Options are sourced from `attachUpdateOptions` so the alias
+ * stays in lockstep with `update` automatically.
  *
  * @deprecated Use `registerUpdateCommand` instead.
  */
 export function registerEditCommand(program: Command) {
-  program
-    .command("edit")
-    .description("(deprecated — use update) Edit an existing changelog source")
-    .argument("<identifier>", "Source ID (src_...) or slug")
-    .option("--name <name>", "Update display name")
-    .option("--url <url>", "Update source URL")
-    .option("--type <type>", "Update source type (github, scrape, feed, agent)")
-    .option("--slug <newSlug>", "Update slug (requires --confirm-slug-change; breaks web links)")
-    .option("--confirm-slug-change", "Confirm slug rename")
-    .option("--org <org>", "Set organization")
-    .option("--no-org", "Remove organization association")
-    .option("--product <product>", "Set product (slug)")
-    .option("--no-product", "Remove product association")
-    .option("--feed-url <feedUrl>", "Set or update the feed URL")
-    .option("--no-feed-url", "Remove stored feed URL")
-    .option("--markdown-url <markdownUrl>", "Set the raw markdown URL for this source")
-    .option(
-      "--parse-instructions <text>",
-      "(deprecated — use --parse-instructions-file) Set AI parsing instructions inline; quote-hostile, prefer the file form",
-    )
-    .option(
-      "--parse-instructions-file <path>",
-      "Path to file with AI parsing instructions (use - for stdin; empty file clears)",
-    )
-    .option("--no-parse-instructions", "Remove AI parsing instructions")
-    .option("--render", "Force headless browser rendering for this source")
-    .option("--no-render", "Allow fast fetch without headless browser rendering")
-    .option("--provider <provider>", "Set the detected provider")
-    .option("--fetch-method <fetchMethod>", "Set the recommended fetch method")
-    .option("--primary", "Mark as the org's primary changelog source")
-    .option("--no-primary", "Unmark as primary")
-    .option("--priority <level>", "Set fetch priority (normal, low, paused)")
-    .option("--disable", "Disable source")
-    .option("--enable", "Re-enable a disabled source")
-    .option("--json", "Output as JSON")
-    .action(warnDeprecatedAlias<[string, UpdateSourceOpts]>("edit", "update", updateSourceAction));
+  attachUpdateOptions(
+    program
+      .command("edit")
+      .description("(deprecated — use update) Edit an existing changelog source"),
+  ).action(warnDeprecatedAlias<[string, UpdateSourceOpts]>("edit", "update", updateSourceAction));
 }

--- a/src/cli/commands/edit.ts
+++ b/src/cli/commands/edit.ts
@@ -26,7 +26,14 @@ export function registerEditCommand(program: Command) {
     .option("--feed-url <feedUrl>", "Set or update the feed URL")
     .option("--no-feed-url", "Remove stored feed URL")
     .option("--markdown-url <markdownUrl>", "Set the raw markdown URL for this source")
-    .option("--parse-instructions <text>", "Set AI parsing instructions for this source")
+    .option(
+      "--parse-instructions <text>",
+      "(deprecated — use --parse-instructions-file) Set AI parsing instructions inline; quote-hostile, prefer the file form",
+    )
+    .option(
+      "--parse-instructions-file <path>",
+      "Path to file with AI parsing instructions (use - for stdin; empty file clears)",
+    )
     .option("--no-parse-instructions", "Remove AI parsing instructions")
     .option("--render", "Force headless browser rendering for this source")
     .option("--no-render", "Allow fast fetch without headless browser rendering")

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -12,6 +12,7 @@ import { sourceNotFound } from "../suggest.js";
 import { toSlug } from "@buildinternet/releases-core/slug";
 import { logger } from "@releases/lib/logger";
 import { writeJson } from "../../lib/output.js";
+import { readContentArg } from "../../lib/input.js";
 
 const VALID_TYPES = ["github", "scrape", "feed", "agent"] as const;
 
@@ -36,6 +37,7 @@ export type UpdateSourceOpts = {
   provider?: string;
   fetchMethod?: string;
   parseInstructions?: string | boolean;
+  parseInstructionsFile?: string;
   render?: boolean;
   primary?: boolean;
   priority?: string;
@@ -48,6 +50,21 @@ export async function updateSourceAction(
   identifier: string,
   opts: UpdateSourceOpts,
 ): Promise<void> {
+  if (opts.parseInstructions !== undefined && opts.parseInstructionsFile !== undefined) {
+    logger.error("--parse-instructions and --parse-instructions-file are mutually exclusive");
+    process.exit(1);
+  }
+
+  if (opts.parseInstructionsFile !== undefined) {
+    // File contents become the inline value; an empty file clears, matching
+    // the existing `--parse-instructions ""` semantics.
+    opts.parseInstructions = await readContentArg(opts.parseInstructionsFile);
+  } else if (typeof opts.parseInstructions === "string") {
+    logger.warn(
+      '"--parse-instructions" is deprecated, use "--parse-instructions-file <path>" (use - for stdin); the inline form will be removed in a future release.',
+    );
+  }
+
   const source = await findSource(identifier);
   if (!source) return sourceNotFound(identifier);
 
@@ -250,7 +267,14 @@ function attachUpdateOptions(cmd: Command): Command {
     .option("--feed-url <feedUrl>", "Set or update the feed URL")
     .option("--no-feed-url", "Remove stored feed URL")
     .option("--markdown-url <markdownUrl>", "Set the raw markdown URL for this source")
-    .option("--parse-instructions <text>", "Set AI parsing instructions for this source")
+    .option(
+      "--parse-instructions <text>",
+      "(deprecated — use --parse-instructions-file) Set AI parsing instructions inline; quote-hostile, prefer the file form",
+    )
+    .option(
+      "--parse-instructions-file <path>",
+      "Path to file with AI parsing instructions (use - for stdin; empty file clears)",
+    )
     .option("--no-parse-instructions", "Remove AI parsing instructions")
     .option("--render", "Force headless browser rendering for this source")
     .option("--no-render", "Allow fast fetch without headless browser rendering")
@@ -265,7 +289,18 @@ function attachUpdateOptions(cmd: Command): Command {
 }
 
 export function registerUpdateCommand(program: Command) {
-  attachUpdateOptions(
-    program.command("update").description("Update an existing changelog source"),
-  ).action(updateSourceAction);
+  attachUpdateOptions(program.command("update").description("Update an existing changelog source"))
+    .addHelpText(
+      "after",
+      `
+Examples:
+  releases update src_abc123 --primary
+  releases update src_abc123 --parse-instructions-file parse.md
+  cat parse.md | releases update src_abc123 --parse-instructions-file -
+
+--parse-instructions (inline) is deprecated and will be removed in a future
+minor release. Quoting markdown across newlines is fragile; prefer
+--parse-instructions-file.`,
+    )
+    .action(updateSourceAction);
 }

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -12,7 +12,7 @@ import { sourceNotFound } from "../suggest.js";
 import { toSlug } from "@buildinternet/releases-core/slug";
 import { logger } from "@releases/lib/logger";
 import { writeJson } from "../../lib/output.js";
-import { readContentArg } from "../../lib/input.js";
+import { resolveInlineOrFile } from "../../lib/input.js";
 
 const VALID_TYPES = ["github", "scrape", "feed", "agent"] as const;
 
@@ -50,20 +50,23 @@ export async function updateSourceAction(
   identifier: string,
   opts: UpdateSourceOpts,
 ): Promise<void> {
+  // `--no-parse-instructions` produces `false` and is mutually exclusive with
+  // any other parse-instructions flag (mirrors the inline-vs-file mutex below).
+  // The string and file forms collapse via the shared resolver: file contents
+  // become the value, and an empty file clears (matches `--parse-instructions ""`).
   if (opts.parseInstructions !== undefined && opts.parseInstructionsFile !== undefined) {
     logger.error("--parse-instructions and --parse-instructions-file are mutually exclusive");
     process.exit(1);
   }
-
-  if (opts.parseInstructionsFile !== undefined) {
-    // File contents become the inline value; an empty file clears, matching
-    // the existing `--parse-instructions ""` semantics.
-    opts.parseInstructions = await readContentArg(opts.parseInstructionsFile);
-  } else if (typeof opts.parseInstructions === "string") {
-    logger.warn(
-      '"--parse-instructions" is deprecated, use "--parse-instructions-file <path>" (use - for stdin); the inline form will be removed in a future release.',
-    );
-  }
+  const parseInstructions: string | false | undefined =
+    opts.parseInstructions === false
+      ? false
+      : await resolveInlineOrFile({
+          inline: typeof opts.parseInstructions === "string" ? opts.parseInstructions : undefined,
+          file: opts.parseInstructionsFile,
+          inlineName: "--parse-instructions",
+          fileName: "--parse-instructions-file",
+        });
 
   const source = await findSource(identifier);
   if (!source) return sourceNotFound(identifier);
@@ -204,14 +207,14 @@ export async function updateSourceAction(
     changes.push(`fetch method → ${opts.fetchMethod}`);
   }
 
-  if (opts.parseInstructions === false || opts.parseInstructions === "") {
+  if (parseInstructions === false || parseInstructions === "") {
     metaUpdates.parseInstructions = undefined;
     changes.push("parse instructions removed");
-  } else if (typeof opts.parseInstructions === "string") {
-    metaUpdates.parseInstructions = opts.parseInstructions;
-    changes.push(
-      `parse instructions → "${opts.parseInstructions.slice(0, 60)}${opts.parseInstructions.length > 60 ? "..." : ""}"`,
-    );
+  } else if (typeof parseInstructions === "string") {
+    metaUpdates.parseInstructions = parseInstructions;
+    const preview =
+      parseInstructions.length > 60 ? `${parseInstructions.slice(0, 60)}...` : parseInstructions;
+    changes.push(`parse instructions → "${preview}"`);
   }
 
   if (opts.render === true) {
@@ -252,7 +255,7 @@ export async function updateSourceAction(
   }
 }
 
-function attachUpdateOptions(cmd: Command): Command {
+export function attachUpdateOptions(cmd: Command): Command {
   return cmd
     .argument("<identifier>", "Source ID (src_...) or slug")
     .option("--name <name>", "Update display name")

--- a/src/lib/input.ts
+++ b/src/lib/input.ts
@@ -17,3 +17,39 @@ export async function readContentArg(pathOrDash: string): Promise<string> {
     process.exit(1);
   }
 }
+
+/**
+ * Resolve a deprecated inline-string flag and its `--*-file` replacement to a
+ * single payload string.
+ *
+ * - Errors and exits 1 if both forms are provided (mutually exclusive).
+ * - Reads the file (or stdin when `"-"`) when `file` is set.
+ * - Warns once that the inline form is deprecated when only `inline` is set.
+ * - Returns `undefined` if neither form was provided.
+ *
+ * Used by `--notes` / `--notes-file` (admin playbook) and
+ * `--parse-instructions` / `--parse-instructions-file` (source update).
+ */
+export async function resolveInlineOrFile(args: {
+  inline: string | undefined;
+  file: string | undefined;
+  inlineName: string;
+  fileName: string;
+}): Promise<string | undefined> {
+  const { inline, file, inlineName, fileName } = args;
+
+  if (inline !== undefined && file !== undefined) {
+    logger.error(`${inlineName} and ${fileName} are mutually exclusive`);
+    process.exit(1);
+  }
+  if (file !== undefined) {
+    return readContentArg(file);
+  }
+  if (inline !== undefined) {
+    logger.warn(
+      `"${inlineName}" is deprecated, use "${fileName} <path>" (use - for stdin); the inline form will be removed in a future release.`,
+    );
+    return inline;
+  }
+  return undefined;
+}

--- a/tests/cli/notes-and-parse-instructions-file.test.ts
+++ b/tests/cli/notes-and-parse-instructions-file.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "bun:test";
+import { runCli } from "../utils.js";
+
+/**
+ * Coverage for #103 workstream 3: --notes-file / --parse-instructions-file
+ * replace the inline string forms (which are quote-hostile and silently
+ * truncate at unescaped newlines for AI-generated bodies).
+ *
+ * Behavioral coverage uses --help and the mutex error path because
+ * exercising the full flow requires HTTP mocks (per the convention
+ * documented in idempotent-create.test.ts).
+ */
+
+describe("admin playbook --notes-file (#103 ws3)", () => {
+  const adminEnv = { RELEASED_API_KEY: "test-key" };
+
+  it("documents --notes-file in --help", () => {
+    const { stdout, exitCode } = runCli(["admin", "playbook", "--help"], { env: adminEnv });
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--notes-file");
+  });
+
+  it("keeps --notes documented but marks it deprecated", () => {
+    const { stdout, exitCode } = runCli(["admin", "playbook", "--help"], { env: adminEnv });
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--notes");
+    expect(stdout).toContain("deprecated");
+  });
+
+  it("errors when --notes and --notes-file are passed together", () => {
+    const { stderr, exitCode } = runCli(
+      ["admin", "playbook", "acme", "--notes", "x", "--notes-file", "-"],
+      { env: adminEnv },
+    );
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("--notes and --notes-file are mutually exclusive");
+  });
+});
+
+describe("source update --parse-instructions-file (#103 ws3)", () => {
+  const adminEnv = { RELEASED_API_KEY: "test-key" };
+
+  it("documents --parse-instructions-file in update --help", () => {
+    const { stdout, exitCode } = runCli(["admin", "source", "update", "--help"], { env: adminEnv });
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--parse-instructions-file");
+  });
+
+  it("documents --parse-instructions-file in deprecated edit --help", () => {
+    const { stdout, exitCode } = runCli(["admin", "source", "edit", "--help"], { env: adminEnv });
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--parse-instructions-file");
+  });
+
+  it("keeps --parse-instructions documented but marks it deprecated", () => {
+    const { stdout, exitCode } = runCli(["admin", "source", "update", "--help"], { env: adminEnv });
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--parse-instructions");
+    expect(stdout).toContain("deprecated");
+  });
+
+  it("errors when --parse-instructions and --parse-instructions-file are passed together", () => {
+    const { stderr, exitCode } = runCli(
+      [
+        "admin",
+        "source",
+        "update",
+        "src_dummy",
+        "--parse-instructions",
+        "x",
+        "--parse-instructions-file",
+        "-",
+      ],
+      { env: adminEnv },
+    );
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain(
+      "--parse-instructions and --parse-instructions-file are mutually exclusive",
+    );
+  });
+});

--- a/tests/cli/notes-and-parse-instructions-file.test.ts
+++ b/tests/cli/notes-and-parse-instructions-file.test.ts
@@ -23,8 +23,8 @@ describe("admin playbook --notes-file (#103 ws3)", () => {
   it("keeps --notes documented but marks it deprecated", () => {
     const { stdout, exitCode } = runCli(["admin", "playbook", "--help"], { env: adminEnv });
     expect(exitCode).toBe(0);
-    expect(stdout).toContain("--notes");
-    expect(stdout).toContain("deprecated");
+    expect(stdout).toContain("--notes <text>");
+    expect(stdout).toContain("(deprecated — use --notes-file)");
   });
 
   it("errors when --notes and --notes-file are passed together", () => {
@@ -55,8 +55,8 @@ describe("source update --parse-instructions-file (#103 ws3)", () => {
   it("keeps --parse-instructions documented but marks it deprecated", () => {
     const { stdout, exitCode } = runCli(["admin", "source", "update", "--help"], { env: adminEnv });
     expect(exitCode).toBe(0);
-    expect(stdout).toContain("--parse-instructions");
-    expect(stdout).toContain("deprecated");
+    expect(stdout).toContain("--parse-instructions <text>");
+    expect(stdout).toContain("(deprecated — use --parse-instructions-file)");
   });
 
   it("errors when --parse-instructions and --parse-instructions-file are passed together", () => {


### PR DESCRIPTION
## Summary

Workstream 3 of the agent-ergonomics audit (#103). Adds `--notes-file` and `--parse-instructions-file` to replace inline string flags whose content is routinely multi-paragraph markdown — quote-hostile, silently truncated at unescaped newlines, the exact failure mode AI-generated content hits the most.

This PR is **Phase 1**: file flags added, inline flags kept with a one-time stderr deprecation warning per invocation. Phase 2 (a future minor) will drop the inline forms.

### CLI surface

- `releases admin playbook <org> --notes-file <path>` (use `-` for stdin)
- `releases admin source update <id> --parse-instructions-file <path>` (use `-` for stdin); same flag on the deprecated `edit` alias.
- Passing both inline + file forms together errors: `--notes and --notes-file are mutually exclusive` (and the equivalent for `--parse-instructions`).
- An empty file clears, matching the existing inline empty-string semantics.

### Skill / agent doc updates

- `skills/managing-sources/SKILL.md`, `skills/seeding-playbooks/SKILL.md` — update examples to the file form (synced into `plugins/claude/releases/skills/` via `bun scripts/sync-plugin-skills.ts`).
- `plugins/claude/releases/agents/{worker,discovery}.md` — update notes flag references and fix the stale `releases admin content playbook` path to the canonical `releases admin playbook`.

A sister PR in `buildinternet/releases` (the monorepo) will update the equivalent surfaces there: `src/agent/skills/`, `plugins/claude/releases/`, `web/src/content/docs/cli/admin.md`, `.claude/commands/discover-changelog.md`.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun test` (266 pass, 0 fail — adds 7 new tests in `tests/cli/notes-and-parse-instructions-file.test.ts`)
- [x] Manual smoke: `releases admin playbook --help` and `releases admin source update --help` show both flags with deprecation hints; mutex paths produce the expected error.

## Out of scope

- Inline removal — that's Phase 2 (a future minor PR; will file a tracking issue when this lands).
- Tag reconciliation on idempotent retry — already handled in #117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --notes-file and --parse-instructions-file (path or - for stdin) to provide multi-line content; empty file clears content.

* **Deprecated**
  * Inline --notes and --parse-instructions now emit per-invocation deprecation warnings and will be removed in a future minor release; deprecated edit alias now accepts the file-based parse-instructions option.

* **Behavior**
  * File/inline variants are mutually exclusive; supplying both errors.

* **Documentation**
  * Updated playbook and skill docs and corrected playbook command guidance.

* **Tests**
  * Added tests verifying help, deprecation messaging, and mutual-exclusion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->