### PR TITLE
chore: bump api-types to 0.7.0, drop local EvaluationResult + OrgDependentsResponse

### DIFF
--- a/.changeset/569-evaluation-result-from-api-types.md
+++ b/.changeset/569-evaluation-result-from-api-types.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": patch
+---
+
+Drop the local `EvaluationResult` and `OrgDependentsResponse` declarations from `src/api/types.ts` and pull both from `@buildinternet/releases-api-types` 0.7.0 instead. The carve-outs were only there because the canonical types lived in private monorepo packages; both have been upstreamed (`OrgDependentsResponse` since api-types 0.5.0, `EvaluationResult` in 0.7.0 — buildinternet/releases#569). No surface change for CLI consumers — the same shapes are now imported via `export * from "@buildinternet/releases-api-types"`.

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "releases-cli",
       "dependencies": {
-        "@buildinternet/releases-api-types": "^0.6.0",
+        "@buildinternet/releases-api-types": "^0.7.0",
         "@buildinternet/releases-core": "^0.17.0",
         "@buildinternet/releases-lib": "workspace:*",
         "@buildinternet/releases-skills": "workspace:*",
@@ -73,7 +73,7 @@
 
     "@buildinternet/releases": ["@buildinternet/releases@workspace:npm/releases"],
 
-    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.6.0", "", {}, "sha512-rz2WT/uAfuUaguoLuttP7zftJnAFYYtWKxdeDo8MD7rzGS7lZ0N9DN6AK8+FGp5IciyRamA6uUYlH1tzt4dvZA=="],
+    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.7.0", "", {}, "sha512-B0+5w3UKHMg92MnhFpwwZqpWh7WjTAGf/53jHVope1flwqB/svhwwBOwq/lyC9bWu8ONqKW5aC3efm8cxlIrvg=="],
 
     "@buildinternet/releases-core": ["@buildinternet/releases-core@0.17.0", "", { "dependencies": { "drizzle-orm": "^0.45.2", "js-tiktoken": "^1.0.21", "nanoid": "^5.1.7" } }, "sha512-ijIcgPHqAG7Jb2dFD83l6FRXN0XPLi02bqWomQneM+tkes9vfENg7WXx++rNPyMaHoe5Y1Gb0eZn6evNUr/rnA=="],
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "homepage": "https://releases.sh",
   "dependencies": {
-    "@buildinternet/releases-api-types": "^0.6.0",
+    "@buildinternet/releases-api-types": "^0.7.0",
     "@buildinternet/releases-core": "^0.17.0",
     "@buildinternet/releases-lib": "workspace:*",
     "@buildinternet/releases-skills": "workspace:*",

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -4,43 +4,5 @@
  * Wire protocol shapes are re-exported from `@buildinternet/releases-api-types`
  * (published from the monorepo `buildinternet/releases`, `packages/api-types/`);
  * bump the pin in `package.json` when adopting new response shapes.
- *
- * `EvaluationResult` stays local — it's returned by `/v1/evaluate` but the
- * monorepo defines it inside the private `@releases/ai-internal` package.
- * Upstream it into `@buildinternet/releases-api-types` later to remove the
- * duplicate.
  */
 export * from "@buildinternet/releases-api-types";
-
-/**
- * Cascade-scope preview returned by `GET /v1/admin/orgs/:slug/dependents`.
- * Defined locally until `@buildinternet/releases-api-types` ≥ 0.5.0 ships
- * the canonical export — bump the pin in `package.json` and drop this block
- * once the published version is in.
- */
-export interface OrgDependentsResponse {
-  org: { id: string; slug: string; name: string };
-  counts: {
-    sources: number;
-    releases: number;
-    fetchLog: number;
-    sourceChangelogFiles: number;
-    sourceChangelogChunks: number;
-    releaseSummaries: number;
-    mediaAssets: number;
-    webhookSubscriptions: number;
-  };
-}
-
-export interface EvaluationResult {
-  recommendedMethod: "feed" | "github" | "markdown" | "scrape" | "crawl";
-  recommendedUrl: string;
-  feedUrl?: string;
-  feedType?: "rss" | "atom" | "jsonfeed";
-  githubRepo?: string;
-  pageStructure: "single-page" | "index" | "unknown";
-  alternatives: Array<{ url: string; method: string; note: string }>;
-  confidence: "high" | "medium" | "low";
-  provider?: string;
-  notes?: string;
-}

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -154,7 +154,7 @@ export function sourceToMarkdown(source: SourceDetail, opts: FormatOptions = {})
   }
 
   // ── Pagination ──
-  if (source.pagination.totalPages > 1) {
+  if ((source.pagination.totalPages ?? 0) > 1) {
     const paginationAttrs = [
       `page="${source.pagination.page}"`,
       `total-pages="${source.pagination.totalPages}"`,


### PR DESCRIPTION
Follow-up to [buildinternet/releases#569](https://github.com/buildinternet/releases/issues/569) (monorepo PR [#742](https://github.com/buildinternet/releases/pull/742)).

## Summary

- Bump `@buildinternet/releases-api-types` pin `^0.6.0` → `^0.7.0`.
- Delete the local `EvaluationResult` declaration in `src/api/types.ts` — now imported via `export * from "@buildinternet/releases-api-types"`.
- Delete the local `OrgDependentsResponse` declaration too. Already in api-types since 0.5.0; the carve-out comment was stale and never cleaned up.

## Precursor fix folded in

`src/lib/formatters.ts:157` dereferenced `source.pagination.totalPages` as required, but the field has been **optional** on the wire since [buildinternet/releases#733](https://github.com/buildinternet/releases/pull/740). The CLI was lock-pinned at a 0.6.x build that still had `totalPages: number` required, so the type-error never surfaced. Bumping the dep refreshed `bun.lock` and exposed it. Coalescing to `0` before the `> 1` comparison preserves existing behavior (don't render Pagination block when no paging info).

## Gating

This PR depends on `@buildinternet/releases-api-types@0.7.0` being published — that ships when buildinternet/releases#742 merges. **Do not merge this PR until that publish completes,** or `bun install` will fail in CI.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `bun test` (277 pass)
- [x] `bun run lint` (0 warnings, 0 errors)
- [x] `bun run format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pagination display to properly handle cases where page count data is unavailable.

* **Chores**
  * Updated internal type dependencies to consolidate shared type definitions and reduce redundancy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->