### PR TITLE
fix: soften not-found UX for read-only get commands

### DIFF
--- a/.changeset/get-not-found-ux.md
+++ b/.changeset/get-not-found-ux.md
@@ -1,0 +1,11 @@
+---
+"@buildinternet/releases": patch
+---
+
+Soften the not-found UX for read-only lookups (`releases get`, `releases release get`) and parallelize `releases get` fallback resolution.
+
+A miss on `releases get <thing>` is a normal answer for a lookup, not a software fault. The output now reads `[releases] No <kind> matching: <input>` (info-level, no red `ERROR:` framing). In `--json` mode the command also writes `null` to stdout before the stderr line, so JSON consumers get parseable output instead of nothing. Exit code stays `1` — the contract for "scripts can detect a miss" doesn't change.
+
+When the identifier doesn't carry a typed-ID prefix, `releases get` previously made up to three sequential API round-trips (`findOrg` → `findProduct` → `findSource`) before giving up. Those now run in parallel via `Promise.all`, so a miss takes ~one round-trip instead of three. Hits behave the same — the first matching kind wins.
+
+Mutating commands (`release delete/update/suppress/unsuppress`, `delete`, `update`, `ignore add/remove`, `product alias`, etc.) keep the louder error treatment; for those, "thing doesn't exist" really is an error.

--- a/src/cli/commands/get.ts
+++ b/src/cli/commands/get.ts
@@ -15,6 +15,12 @@ import { writeJson } from "../../lib/output.js";
 
 export type GetEntityOpts = { json?: boolean };
 
+async function notFound(identifier: string, kind: string, opts: GetEntityOpts): Promise<never> {
+  if (opts.json) await writeJson(null);
+  logger.info(`No ${kind} matching: ${identifier}`);
+  process.exit(1);
+}
+
 /** Shared action for both the canonical `get` command and the deprecated `show` alias. */
 export async function getEntityAction(identifier: string, opts: GetEntityOpts): Promise<void> {
   const type = getEntityType(identifier);
@@ -26,23 +32,21 @@ export async function getEntityAction(identifier: string, opts: GetEntityOpts): 
   if (type === "org") return getOrg(identifier, opts);
   if (type === "product") return await getProduct(identifier, opts);
 
-  const org = await findOrg(identifier);
+  const [org, product, source] = await Promise.all([
+    findOrg(identifier),
+    findProduct(identifier),
+    findSource(identifier),
+  ]);
   if (org) return renderOrg(org, opts);
-  const product = await findProduct(identifier);
   if (product) return await renderProduct(product, opts);
-  const source = await findSource(identifier);
   if (source) return await renderSource(source, opts);
 
-  logger.error(`Not found: ${identifier}`);
-  process.exit(1);
+  return notFound(identifier, "entity", opts);
 }
 
 async function getRelease_(id: string, opts: GetEntityOpts) {
   const result = await getRelease(id);
-  if (!result) {
-    logger.error(`Release not found: ${id}`);
-    process.exit(1);
-  }
+  if (!result) return notFound(id, "release", opts);
   const rel = result;
   if (opts.json) {
     await writeJson(rel);
@@ -70,28 +74,19 @@ async function getRelease_(id: string, opts: GetEntityOpts) {
 
 async function getSource(identifier: string, opts: GetEntityOpts) {
   const source = await findSource(identifier);
-  if (!source) {
-    logger.error(`Source not found: ${identifier}`);
-    process.exit(1);
-  }
+  if (!source) return notFound(identifier, "source", opts);
   await renderSource(source, opts);
 }
 
 async function getOrg(identifier: string, opts: GetEntityOpts) {
   const org = await findOrg(identifier);
-  if (!org) {
-    logger.error(`Organization not found: ${identifier}`);
-    process.exit(1);
-  }
+  if (!org) return notFound(identifier, "organization", opts);
   await renderOrg(org, opts);
 }
 
 async function getProduct(identifier: string, opts: GetEntityOpts) {
   const product = await findProduct(identifier);
-  if (!product) {
-    logger.error(`Product not found: ${identifier}`);
-    process.exit(1);
-  }
+  if (!product) return notFound(identifier, "product", opts);
   await renderProduct(product, opts);
 }
 

--- a/src/cli/commands/release.ts
+++ b/src/cli/commands/release.ts
@@ -14,9 +14,16 @@ import { stripAnsi } from "../../lib/sanitize.js";
 import { normalizeReleaseId } from "@buildinternet/releases-core/id";
 import { writeJson, writeJsonLine } from "../../lib/output.js";
 import { warnDeprecatedAlias } from "../../lib/deprecated-alias.js";
+import { logger } from "@releases/lib/logger";
 
 function releaseNotFound(id: string): never {
   console.error(chalk.red(`Release not found: ${id}`));
+  process.exit(1);
+}
+
+async function releaseLookupMiss(id: string, json: boolean): Promise<never> {
+  if (json) await writeJson(null);
+  logger.info(`No release matching: ${id}`);
   process.exit(1);
 }
 
@@ -28,7 +35,7 @@ async function releaseGetAction(rawId: string, opts: ReleaseGetOpts): Promise<vo
   const id = normalizeReleaseId(rawId);
   const result = await getRelease(id);
 
-  if (!result) releaseNotFound(id);
+  if (!result) return releaseLookupMiss(id, !!opts.json);
 
   const rel = result;
 


### PR DESCRIPTION
## Summary

- `releases get <thing>` (and `releases release get`) now treat misses as normal lookup answers — `[releases] No <kind> matching: …` on stderr instead of the red `[releases] ERROR: Not found: …` line.
- `--json` mode writes `null` to stdout before the stderr line, so JSON consumers get parseable output instead of nothing on a miss. Exit code stays `1`.
- Unknown-type fallback in `get` runs the three identifier resolvers (`findOrg`, `findProduct`, `findSource`) in parallel via `Promise.all` instead of sequentially. A miss now takes ~one round-trip; a hit returns the first matching kind same as before.
- Mutating commands (`release delete/update/suppress/unsuppress`, `delete`, `update`, `ignore add/remove`, `product alias`, etc.) keep the loud red `ERROR:` treatment — for those, "thing doesn't exist" really is an error.

Surfaced from a smoke-test cleanup on prod (`releases admin org delete smoketestorg-107 --hard`); the verification call (`releases get smoketestorg-107`) felt slow and overly alarming for what is fundamentally a "no match" answer.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `bun run lint` clean
- [x] Manual: `releases get smoketestorg-107` → `[releases] No entity matching: smoketestorg-107`, exit 1
- [x] Manual: `releases get smoketestorg-107 --json` → `null` on stdout, soft note on stderr, exit 1
- [ ] Verify hit paths (`releases get <real-org-slug>`, `releases get rel_…`) still render normally
- [ ] Verify mutating commands (`releases release suppress <bad-id>`, etc.) still show the red ERROR line


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Softened "not found" messaging for read-only lookup commands from error-framed text to informational messages while preserving exit code 1
  * Fixed JSON mode to output parseable null value when an entity is not found

* **Performance**
  * Improved lookup speed through parallel resolution of possible match kinds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->