### PR TITLE
fix: respect --json on overview inputs subcommand

### DIFF
--- a/.changeset/overview-inputs-json-flag.md
+++ b/.changeset/overview-inputs-json-flag.md
@@ -1,0 +1,9 @@
+---
+"@buildinternet/releases": patch
+---
+
+Fix `releases admin overview inputs <org> --json` ignoring the flag and printing the chalk-formatted summary instead of JSON.
+
+Root cause was a commander parsing quirk: the deprecated bare `overview <org>` form is registered with `.argument("[org]")` on the same `overview` command that hosts subcommands like `inputs`, `get`, `update`. Without positional option scoping, options that follow a subcommand's positional arg (`overview inputs google --json`) were being swallowed before the subcommand could see them. The same bug affected `--check --json` and silently dropped any subcommand option that appeared after the org slug.
+
+Fixed by enabling `.enablePositionalOptions()` at the program level so each command's options are scoped to their own position. The deprecated `overview <org>` bare form still works.

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -131,6 +131,13 @@ export const program = new Command()
   .name("releases")
   .description("Changelog indexer and registry for AI agents and developers")
   .version(VERSION_DISPLAY, "-v, --version")
+  // `admin overview` declares a deprecated bare form (`overview <org>`) on the
+  // parent command alongside subcommands like `overview inputs <org>`. Without
+  // positional options, commander mis-routes options that follow a
+  // subcommand's positional arg (e.g. `overview inputs google --json` swallows
+  // `--json`). Enable positional parsing so each command's options are scoped
+  // to its own position. (Issue releases-cli#133.)
+  .enablePositionalOptions()
   .hook("preAction", (_thisCommand, actionCommand) => {
     if (actionCommand.name() !== "admin" && isWithinAdminCommand(actionCommand) && !isAdminMode()) {
       adminKeyError("admin");


### PR DESCRIPTION
## Summary

- `releases admin overview inputs <org> --json` was silently dropping the flag and printing the chalk-formatted summary. Same bug affected `--check --json` (the issue title said it worked; it didn't).
- Root cause: the deprecated bare `overview <org>` form registers `.argument("[org]")` on the same Command that hosts subcommands (`inputs`, `get`, `update`, …). Without positional option scoping, commander absorbed subcommand options into the parent and the action handler received `opts: {}`.
- Fix: enable `.enablePositionalOptions()` at the program level so each command's options are scoped to its own position. The deprecated bare `overview <org>` form continues to work.

Closes #133.

## Test plan

- [x] `bun test tests/cli/` — 76 pass
- [x] `bunx tsc --noEmit` clean
- [x] `bun run lint` clean
- [x] `releases admin overview inputs google --json` → emits JSON
- [x] `releases admin overview inputs google --check --json` → emits JSON
- [x] `releases admin overview google --json` (deprecated bare form) → emits JSON with deprecation warning
- [x] Spot-check unrelated `--json` commands (`releases list --json`, `releases search --json`) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed the `--json` flag for the admin overview inputs command. The command now correctly returns JSON output instead of formatted text when the flag is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->