### PR TITLE
feat(onboard,create): scope flags + mismatch detection (#794)

### DIFF
--- a/.changeset/onboard-scope-source-mismatch.md
+++ b/.changeset/onboard-scope-source-mismatch.md
@@ -1,0 +1,9 @@
+---
+"@buildinternet/releases": minor
+---
+
+Add `--into-org` / `--into-product` flags to `releases admin discovery onboard` and exit non-zero when `releases admin source create` finds a URL collision with mismatched org/product attribution. Both surfaced during the multi-product Google onboarding (#794).
+
+`--into-org <slug>` (and optionally `--into-product <slug>`) pin the discovery agent to attach every source it adds to that existing org/product, instead of the default behavior of letting the agent auto-create new ones. Eliminates the manual cleanup of orphan orgs that used to follow multi-product onboarding under an existing org. Server-side scope plumbing lands in the monorepo PR; the API surface is `intoOrgSlug` / `intoProductSlug` on `POST /v1/workflows/discover`.
+
+`source create` previously soft-warned and returned `existed: true` when the URL was already attached to a different org/product than the one passed via `--org` / `--product`. It now exits non-zero with the current attribution and a `releases admin source update` hint. `--strict` continues to reject any URL collision regardless of attribution.

--- a/src/cli/commands/create.ts
+++ b/src/cli/commands/create.ts
@@ -112,34 +112,17 @@ async function createSingleSource(input: CreateSourceInput): Promise<CreateSourc
     // and the existing row is attached to a *different* one, exit non-zero
     // with the current attribution and the update hint. Pre-fix this was a
     // silent no-op that made multi-product onboarding need manual cleanup.
-    let mismatch = false;
-    let requestedProductId: string | null = null;
-    if (input.org) {
-      const requestedOrg = await findOrg(input.org);
-      if (requestedOrg && existingOrg && requestedOrg.id !== existingOrg.id) {
-        mismatch = true;
-      }
-    }
-    if (input.product) {
-      const requestedProduct = await findProduct(input.product);
-      if (requestedProduct) requestedProductId = requestedProduct.id;
-      const existingProductId = (src as { productId?: string | null }).productId ?? null;
-      if (requestedProductId && requestedProductId !== existingProductId) {
-        mismatch = true;
-      }
-    }
-    if (mismatch) {
-      const reqLabel = [
-        input.org ? `org=${input.org}` : null,
-        input.product ? `product=${input.product}` : null,
-      ]
-        .filter(Boolean)
-        .join(", ");
+    const requestedOrg = input.org ? await findOrg(input.org) : null;
+    const requestedProduct = input.product ? await findProduct(input.product) : null;
+    const orgMismatch = Boolean(requestedOrg && existingOrg && requestedOrg.id !== existingOrg.id);
+    const productMismatch = Boolean(
+      requestedProduct && requestedProduct.id !== (src.productId ?? null),
+    );
+    if (orgMismatch || productMismatch) {
+      const reqLabel = [`org=${input.org ?? "∅"}`, `product=${input.product ?? "∅"}`].join(", ");
       const curLabel = [
-        existingOrg?.slug ? `org=${existingOrg.slug}` : "org=∅",
-        (src as { productId?: string | null }).productId
-          ? `productId=${(src as { productId?: string | null }).productId}`
-          : "product=∅",
+        `org=${existingOrg?.slug ?? "∅"}`,
+        `productId=${src.productId ?? "∅"}`,
       ].join(", ");
       return {
         name: src.name,

--- a/src/cli/commands/create.ts
+++ b/src/cli/commands/create.ts
@@ -108,6 +108,50 @@ async function createSingleSource(input: CreateSourceInput): Promise<CreateSourc
     // caller passed in — passing --org=wrong-org should not relabel a source
     // that already belongs to right-org in the response payload.
     const existingOrg = src.orgId ? await findOrg(src.orgId) : null;
+    // #794 item 3: when the operator requested a specific --org / --product
+    // and the existing row is attached to a *different* one, exit non-zero
+    // with the current attribution and the update hint. Pre-fix this was a
+    // silent no-op that made multi-product onboarding need manual cleanup.
+    let mismatch = false;
+    let requestedProductId: string | null = null;
+    if (input.org) {
+      const requestedOrg = await findOrg(input.org);
+      if (requestedOrg && existingOrg && requestedOrg.id !== existingOrg.id) {
+        mismatch = true;
+      }
+    }
+    if (input.product) {
+      const requestedProduct = await findProduct(input.product);
+      if (requestedProduct) requestedProductId = requestedProduct.id;
+      const existingProductId = (src as { productId?: string | null }).productId ?? null;
+      if (requestedProductId && requestedProductId !== existingProductId) {
+        mismatch = true;
+      }
+    }
+    if (mismatch) {
+      const reqLabel = [
+        input.org ? `org=${input.org}` : null,
+        input.product ? `product=${input.product}` : null,
+      ]
+        .filter(Boolean)
+        .join(", ");
+      const curLabel = [
+        existingOrg?.slug ? `org=${existingOrg.slug}` : "org=∅",
+        (src as { productId?: string | null }).productId
+          ? `productId=${(src as { productId?: string | null }).productId}`
+          : "product=∅",
+      ].join(", ");
+      return {
+        name: src.name,
+        slug: src.slug,
+        type: src.type,
+        url: src.url,
+        org: existingOrg?.name ?? undefined,
+        status: "error",
+        existed: true,
+        error: `Source URL already exists with different attribution. requested {${reqLabel}}; current {${curLabel}}. Run \`releases admin source update ${src.slug} --org <slug> --product <slug>\` to re-attach.`,
+      };
+    }
     logger.info(`Source already exists: ${src.name} (${src.slug}) — returning existing`);
     return {
       name: src.name,

--- a/src/cli/commands/onboard.ts
+++ b/src/cli/commands/onboard.ts
@@ -9,6 +9,8 @@ import { writeJson } from "../../lib/output.js";
 interface OnboardOpts {
   domain?: string;
   githubOrg?: string;
+  intoOrg?: string;
+  intoProduct?: string;
   json?: boolean;
   managedAgents?: boolean;
   sandbox?: boolean;
@@ -50,12 +52,24 @@ export function registerOnboardCommand(program: Command) {
     .argument("<company>", "Company or product name to discover sources for")
     .option("--domain <domain>", "Seed with the company's domain")
     .option("--github-org <org>", "Seed with the company's GitHub organization")
+    .option(
+      "--into-org <slug>",
+      "Attach discovered sources to this existing org (skips org creation; agent will not call manage_org(add))",
+    )
+    .option(
+      "--into-product <slug>",
+      "Attach discovered sources to this existing product (requires --into-org; product slug is per-org)",
+    )
     .option("--managed-agents", "Use the managed-agents discovery engine (default)")
     .option("--sandbox", "Use the legacy sandbox discovery engine")
     .option("--json", "Output results as JSON")
     .action(async (company: string, opts: OnboardOpts) => {
       if (opts.managedAgents && opts.sandbox) {
         logger.error("Cannot specify both --managed-agents and --sandbox");
+        process.exit(1);
+      }
+      if (opts.intoProduct && !opts.intoOrg) {
+        logger.error("--into-product requires --into-org (product slugs are per-org)");
         process.exit(1);
       }
 
@@ -82,7 +96,14 @@ async function runRemoteDiscovery(
   try {
     const result = await apiFetch<{ sessionId: string }>("/v1/workflows/discover", {
       method: "POST",
-      body: JSON.stringify({ company, domain: opts.domain, githubOrg: opts.githubOrg, engine }),
+      body: JSON.stringify({
+        company,
+        domain: opts.domain,
+        githubOrg: opts.githubOrg,
+        intoOrgSlug: opts.intoOrg,
+        intoProductSlug: opts.intoProduct,
+        engine,
+      }),
     });
     sessionId = result.sessionId;
   } catch (err) {


### PR DESCRIPTION
## Summary

Two #794 items, both CLI-side. The server-side scope plumbing lands in [buildinternet/releases#796](https://github.com/buildinternet/releases/pull/796); this PR adds the surface agents/operators actually invoke.

- **Item 4 — `--into-org` / `--into-product`** on `releases admin discovery onboard`. Pins the discovery agent to attach every source it adds to the supplied org/product, instead of the default "auto-create on demand" behavior that was leaving orphan orgs after multi-product onboards under an existing org. `--into-product` requires `--into-org` (product slugs are per-org). The flags forward as `intoOrgSlug` / `intoProductSlug` on `POST /v1/workflows/discover`; the discovery worker amends the agent's user-message task block with an authoritative SCOPE OVERRIDE.

- **Item 3 — `source create` exits non-zero on attribution mismatch.** Pre-fix the create endpoint silently returned the existing source when the URL was already attached to a different org/product than the one passed via `--org` / `--product`. Now: when `existed && (currentOrgId != requested || currentProductId != requested)`, the CLI returns an `error` status with the current attribution and a `releases admin source update <slug> --org … --product …` hint. `--strict` continues to reject any URL collision regardless of attribution.

## Test plan

- [x] `bun test tests/cli/` — 76 pass
- [x] `bunx tsc --noEmit` clean
- [x] `releases admin discovery onboard --help` shows the new flags
- [x] `releases onboard "Foo" --into-product chrome` (without `--into-org`) errors with `--into-product requires --into-org`
- [ ] After releases#796 merges + a staging deploy: end-to-end `--into-org` onboard does not create a fresh org
- [ ] After release: `source create --org wrong --product chrome` against an existing URL exits non-zero with the hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --into-org and --into-product flags to onboarding to attach discovered sources to an existing org/product.
  * Validation now requires --into-org when using --into-product.

* **Improvements**
  * Source creation now detects and reports org/product attribution mismatches on URL collisions.
  * Error messages include detailed "requested vs current" attribution and suggested remediation commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->