### PR TITLE
feat(task,product): task get + product adopt --merge-into 

### DIFF
--- a/.changeset/task-get-and-merge-into.md
+++ b/.changeset/task-get-and-merge-into.md
@@ -1,0 +1,5 @@
+---
+"releases-cli": minor
+---
+
+Add `releases admin discovery task get <session-id>` for full session detail (timing, usage, errors, agent state). Add `releases admin product adopt --merge-into <product>` to fold a source org into an existing product instead of creating a new one. Both close out items in buildinternet/releases#794.

--- a/src/cli/commands/product.ts
+++ b/src/cli/commands/product.ts
@@ -26,6 +26,37 @@ import { computePagination, type ListResponse } from "@buildinternet/releases-co
 import { warnDeprecatedAlias } from "../../lib/deprecated-alias.js";
 import { parseTagList } from "../../lib/flags.js";
 
+/**
+ * Move every source in `sources` to `targetOrg.id` + `productId`, copy
+ * `sourceOrg`'s org_accounts onto the target (skipping duplicates), then
+ * soft-delete the now-empty source org. Mirrors the server-side
+ * `migrateOrgToProduct` helper but goes through the public REST endpoints.
+ */
+async function migrateOrgToProduct(args: {
+  sourceOrg: { slug: string; id: string };
+  targetOrg: { slug: string; id: string };
+  productId: string;
+  sources: { id: string }[];
+}): Promise<void> {
+  const { sourceOrg, targetOrg, productId, sources } = args;
+  await Promise.all(
+    sources.map((source) => updateSource(source, { orgId: targetOrg.id, productId })),
+  );
+
+  const accounts = await getOrgAccountsBySlug(sourceOrg.slug);
+  await Promise.all(
+    accounts.map(async (acct) => {
+      try {
+        await linkOrgAccount(targetOrg.slug, acct.platform, acct.handle);
+      } catch {
+        /* skip duplicates */
+      }
+    }),
+  );
+
+  await removeOrg(sourceOrg.slug);
+}
+
 // ── Shared action handlers ────────────────────────────────────────────────────
 
 type ProductCreateOpts = {
@@ -322,13 +353,33 @@ export function registerProductCommand(program: Command) {
     )
     .option("--slug <slug>", "Custom slug for the new product")
     .option("--url <url>", "URL for the new product")
+    .option(
+      "--merge-into <product>",
+      "Fold source org into an existing product (slug or prod_… ID) under --into instead of creating a new one",
+    )
     .option("--dry-run", "Show what would happen")
     .option("--json", "Output as JSON")
     .action(
       async (
         sourceOrgSlug: string,
-        opts: { into: string; slug?: string; url?: string; dryRun?: boolean; json?: boolean },
+        opts: {
+          into: string;
+          slug?: string;
+          url?: string;
+          mergeInto?: string;
+          dryRun?: boolean;
+          json?: boolean;
+        },
       ) => {
+        if (opts.mergeInto && (opts.slug || opts.url)) {
+          console.error(
+            chalk.red(
+              "--merge-into cannot be combined with --slug or --url (existing product is reused).",
+            ),
+          );
+          process.exit(1);
+        }
+
         const sourceOrg = await findOrg(sourceOrgSlug);
         if (!sourceOrg) {
           console.error(chalk.red(`Source organization not found: ${sourceOrgSlug}`));
@@ -347,6 +398,76 @@ export function registerProductCommand(program: Command) {
         }
 
         const sources = await getSourcesByOrg(sourceOrg.id);
+
+        if (opts.mergeInto) {
+          const existingProduct = await findProduct(opts.mergeInto);
+          if (!existingProduct) {
+            console.error(chalk.red(`Product not found: ${opts.mergeInto}`));
+            process.exit(1);
+          }
+          if (existingProduct.orgId !== targetOrg.id) {
+            console.error(
+              chalk.red(
+                `Product "${existingProduct.slug}" is not under target org "${targetOrg.slug}".`,
+              ),
+            );
+            process.exit(1);
+          }
+
+          if (opts.dryRun) {
+            const plan = {
+              action: "adopt",
+              mergeInto: existingProduct.slug,
+              sourceOrg: { slug: sourceOrg.slug, name: sourceOrg.name },
+              targetOrg: { slug: targetOrg.slug, name: targetOrg.name },
+              existingProduct: { slug: existingProduct.slug, name: existingProduct.name },
+              sourcesToMove: sources.map((s) => s.slug),
+              wouldRemoveOrg: sourceOrg.slug,
+            };
+
+            if (opts.json) {
+              await writeJson(plan);
+            } else {
+              console.log(
+                chalk.yellow(
+                  `[dry-run] Would fold "${sourceOrg.name}" into existing product "${existingProduct.slug}" under "${targetOrg.name}"`,
+                ),
+              );
+              console.log(
+                `  Sources to move:  ${sources.length > 0 ? sources.map((s) => s.slug).join(", ") : chalk.dim("none")}`,
+              );
+              console.log(`  Would remove org: ${sourceOrg.slug}`);
+            }
+            return;
+          }
+
+          await migrateOrgToProduct({
+            sourceOrg,
+            targetOrg,
+            productId: existingProduct.id,
+            sources,
+          });
+
+          if (opts.json) {
+            await writeJson({
+              adopted: sourceOrg.slug,
+              into: targetOrg.slug,
+              mergedInto: existingProduct.slug,
+              product: existingProduct,
+              sourcesMoved: sources.length,
+            });
+          } else {
+            console.log(
+              chalk.green(
+                `Folded "${sourceOrg.name}" into existing product "${existingProduct.slug}" under "${targetOrg.name}"`,
+              ),
+            );
+            if (sources.length > 0)
+              console.log(`  Moved ${sources.length} source(s) to ${targetOrg.name}`);
+          }
+          return;
+        }
+
         const productSlug = opts.slug ?? sourceOrg.slug;
         const productUrl =
           opts.url ?? (sourceOrg.domain ? `https://${sourceOrg.domain}` : undefined);
@@ -385,38 +506,20 @@ export function registerProductCommand(program: Command) {
           description: sourceOrg.description ?? undefined,
         });
 
-        await Promise.all(
-          sources.map((source) =>
-            updateSource(source, { orgId: targetOrg.id, productId: created.id }),
-          ),
-        );
-
-        const accounts = await getOrgAccountsBySlug(sourceOrg.slug);
-        await Promise.all(
-          accounts.map(async (acct) => {
-            try {
-              await linkOrgAccount(targetOrg.slug, acct.platform, acct.handle);
-            } catch {
-              /* skip duplicates */
-            }
-          }),
-        );
-
-        await removeOrg(sourceOrg.slug);
+        await migrateOrgToProduct({
+          sourceOrg,
+          targetOrg,
+          productId: created.id,
+          sources,
+        });
 
         if (opts.json) {
-          console.log(
-            JSON.stringify(
-              {
-                adopted: sourceOrg.slug,
-                into: targetOrg.slug,
-                product: created,
-                sourcesMoved: sources.length,
-              },
-              null,
-              2,
-            ),
-          );
+          await writeJson({
+            adopted: sourceOrg.slug,
+            into: targetOrg.slug,
+            product: created,
+            sourcesMoved: sources.length,
+          });
         } else {
           console.log(
             chalk.green(

--- a/src/cli/commands/product.ts
+++ b/src/cli/commands/product.ts
@@ -48,8 +48,13 @@ async function migrateOrgToProduct(args: {
     accounts.map(async (acct) => {
       try {
         await linkOrgAccount(targetOrg.slug, acct.platform, acct.handle);
-      } catch {
-        /* skip duplicates */
+      } catch (err) {
+        // Per-handle uniqueness comes from `idx_org_accounts_platform_handle` —
+        // a 409 here means the target already has that account linked, which
+        // is the intended no-op. Anything else (404 target org gone, 5xx, …)
+        // must propagate so we don't silently strand half a migration.
+        const msg = err instanceof Error ? err.message : String(err);
+        if (!msg.includes("(409)")) throw err;
       }
     }),
   );

--- a/src/cli/commands/task.ts
+++ b/src/cli/commands/task.ts
@@ -15,7 +15,7 @@ import type { Session } from "@buildinternet/releases-api-types";
  * the CLI typecheck green until that bump lands.
  */
 type SessionDetail = Session & {
-  agent?: "sonnet" | "haiku";
+  agent?: "sonnet" | "haiku" | "coordinator";
   runner?: string;
   correlationId?: string;
   anthropicSessionId?: string;

--- a/src/cli/commands/task.ts
+++ b/src/cli/commands/task.ts
@@ -7,6 +7,67 @@ import {
   DEFAULT_PAGE_SIZE,
   formatTruncationWarning,
 } from "@buildinternet/releases-core/cli-contracts";
+import type { Session } from "@buildinternet/releases-api-types";
+
+/**
+ * Session detail fields surfaced by `task get`. These ship in the next
+ * `@buildinternet/releases-api-types` release; this local extension keeps
+ * the CLI typecheck green until that bump lands.
+ */
+type SessionDetail = Session & {
+  agent?: "sonnet" | "haiku";
+  runner?: string;
+  correlationId?: string;
+  anthropicSessionId?: string;
+  sourcesFound?: number;
+  sourcesValidated?: number;
+  warnings?: string[];
+  usage?: {
+    inputTokens?: number;
+    outputTokens?: number;
+    cacheWriteTokens?: number;
+    cacheReadTokens?: number;
+    model?: string;
+    estimatedUsd?: number;
+  };
+  result?: Record<string, unknown>;
+};
+
+const fmtTimestamp = (n: number) => new Date(n).toISOString();
+
+function statusChalk(status: string) {
+  if (status === "running") return chalk.yellow;
+  if (status === "complete") return chalk.green;
+  if (status === "cancelled") return chalk.gray;
+  return chalk.red;
+}
+
+function formatDuration(sec: number): string {
+  if (sec < 60) return `${sec}s`;
+  if (sec < 3600) return `${Math.round(sec / 60)}m`;
+  return `${(sec / 3600).toFixed(1)}h`;
+}
+
+/**
+ * Resolve a session ID from a unique prefix by listing sessions and filtering
+ * client-side. Exits the process on no-match or ambiguous match. The server
+ * has no `?prefix=` query, so the client filter is the only option.
+ */
+async function resolveSessionIdFromPrefix(prefix: string): Promise<string> {
+  if (prefix.length >= 36) return prefix;
+  const { items: sessions } = await apiClient.listSessions();
+  const matches = sessions.filter((s) => s.sessionId.startsWith(prefix));
+  if (matches.length === 0) {
+    console.error(chalk.red(`No session found matching "${prefix}".`));
+    process.exit(1);
+  }
+  if (matches.length > 1) {
+    console.error(chalk.red(`Multiple sessions match "${prefix}". Be more specific.`));
+    for (const m of matches) console.error(`  ${m.sessionId}  ${m.company}  ${m.status}`);
+    process.exit(1);
+  }
+  return matches[0].sessionId;
+}
 
 export function registerTaskCommand(program: Command) {
   const task = program.command("task").description("Manage remote fetch and discovery sessions");
@@ -58,28 +119,14 @@ export function registerTaskCommand(program: Command) {
       }
 
       for (const s of sessions) {
-        const age = Math.round((Date.now() - s.startedAt) / 1000);
-        const statusColor =
-          s.status === "running"
-            ? chalk.yellow
-            : s.status === "complete"
-              ? chalk.green
-              : s.status === "cancelled"
-                ? chalk.gray
-                : chalk.red;
+        const ageSec = Math.round((Date.now() - s.startedAt) / 1000);
         const sources = s.totalSources ? `${s.sourcesFetched ?? 0}/${s.totalSources} sources` : "";
         const releases = s.releasesInserted ? `${s.releasesInserted} new` : "";
         const details = [sources, releases].filter(Boolean).join(", ");
         const detailStr = details ? chalk.gray(` (${details})`) : "";
-        const ageStr =
-          age < 60
-            ? `${age}s`
-            : age < 3600
-              ? `${Math.round(age / 60)}m`
-              : `${Math.round(age / 3600)}h`;
 
         console.log(
-          `  ${statusColor(s.status.padEnd(10))} ${s.company.padEnd(30)} ${chalk.gray(s.sessionId.slice(0, 8))}  ${chalk.gray(ageStr + " ago")}${detailStr}`,
+          `  ${statusChalk(s.status)(s.status.padEnd(10))} ${s.company.padEnd(30)} ${chalk.gray(s.sessionId.slice(0, 8))}  ${chalk.gray(formatDuration(ageSec) + " ago")}${detailStr}`,
         );
       }
       if (!explicitLimit && pagination.hasMore) {
@@ -94,26 +141,105 @@ export function registerTaskCommand(program: Command) {
     });
 
   task
+    .command("get")
+    .description("Show full detail for a single session (timing, usage, error, agent state)")
+    .argument("<sessionId>", "Session ID (or unique prefix)")
+    .option("--json", "Output as JSON")
+    .action(async (sessionIdArg: string, opts: { json?: boolean }) => {
+      const sessionId = await resolveSessionIdFromPrefix(sessionIdArg);
+
+      const session = (await apiClient.getSession(sessionId)) as SessionDetail | null;
+      if (!session) {
+        console.error(chalk.red(`Session not found: ${sessionId}`));
+        process.exit(1);
+      }
+
+      if (opts.json) {
+        await writeJson(session);
+        return;
+      }
+
+      const durSec = Math.round((session.lastUpdatedAt - session.startedAt) / 1000);
+
+      console.log(`${chalk.bold("Session")} ${session.sessionId}`);
+      console.log(`  Company:    ${session.company}`);
+      console.log(`  Type:       ${session.type}`);
+      if (session.agent) console.log(`  Agent:      ${session.agent}`);
+      console.log(`  Status:     ${statusChalk(session.status)(session.status)}`);
+      if (session.step) console.log(`  Step:       ${session.step}`);
+      if (session.currentAction) console.log(`  Action:     ${session.currentAction}`);
+      console.log(`  Started:    ${fmtTimestamp(session.startedAt)}`);
+      console.log(
+        `  Last upd.:  ${fmtTimestamp(session.lastUpdatedAt)}  (${formatDuration(durSec)})`,
+      );
+      if (session.runner) console.log(`  Runner:     ${session.runner}`);
+      if (session.correlationId) console.log(`  Corr. ID:   ${session.correlationId}`);
+      if (session.anthropicSessionId) console.log(`  Anthropic:  ${session.anthropicSessionId}`);
+
+      const counts: string[] = [];
+      if (session.totalSources != null)
+        counts.push(`${session.sourcesFetched ?? 0}/${session.totalSources} sources`);
+      if (session.sourcesFound != null) counts.push(`${session.sourcesFound} found`);
+      if (session.sourcesValidated != null) counts.push(`${session.sourcesValidated} validated`);
+      if (session.releasesInserted != null)
+        counts.push(`${session.releasesInserted} releases inserted`);
+      else if (session.releasesFound != null)
+        counts.push(`${session.releasesFound} releases found`);
+      if (counts.length > 0) console.log(`  Progress:   ${counts.join(", ")}`);
+
+      if (session.error) {
+        console.log(`  ${chalk.red("Error:")}      ${session.error}`);
+        const errFields: string[] = [];
+        if (session.errorSource) errFields.push(`source=${session.errorSource}`);
+        if (session.errorType) errFields.push(`type=${session.errorType}`);
+        if (session.stopReason) errFields.push(`stop=${session.stopReason}`);
+        if (session.retryCount != null) errFields.push(`retries=${session.retryCount}`);
+        if (errFields.length > 0) console.log(`              ${chalk.gray(errFields.join("  "))}`);
+      }
+
+      if (session.warnings && session.warnings.length > 0) {
+        console.log(`  Warnings:`);
+        for (const w of session.warnings) console.log(`    ${chalk.yellow("•")} ${w}`);
+      }
+
+      if (session.usage) {
+        const u = session.usage;
+        const tokens = [
+          u.inputTokens != null ? `in=${u.inputTokens.toLocaleString()}` : null,
+          u.outputTokens != null ? `out=${u.outputTokens.toLocaleString()}` : null,
+          u.cacheReadTokens ? `cache_r=${u.cacheReadTokens.toLocaleString()}` : null,
+          u.cacheWriteTokens ? `cache_w=${u.cacheWriteTokens.toLocaleString()}` : null,
+        ]
+          .filter(Boolean)
+          .join("  ");
+        const cost =
+          u.estimatedUsd != null ? `  ${chalk.bold(`$${u.estimatedUsd.toFixed(4)}`)}` : "";
+        console.log(`  Usage:      ${tokens}${cost}`);
+        if (u.model) console.log(`              ${chalk.gray(u.model)}`);
+      }
+
+      if (session.activeSources && session.activeSources.length > 0) {
+        console.log(`  Active:     ${session.activeSources.join(", ")}`);
+      }
+
+      if (session.result) {
+        const sources = session.result.sources;
+        const sourceCount = Array.isArray(sources) ? sources.length : 0;
+        if (sourceCount > 0) {
+          console.log(`  Result:     ${sourceCount} source(s) reported`);
+          console.log(chalk.gray(`              (use --json to see full result block)`));
+        } else {
+          console.log(`  Result:     ${chalk.gray("(use --json to see full result block)")}`);
+        }
+      }
+    });
+
+  task
     .command("cancel")
     .description("Cancel a running session")
     .argument("<sessionId>", "Session ID (or prefix) to cancel")
     .action(async (sessionIdArg: string) => {
-      let sessionId = sessionIdArg;
-      if (sessionId.length < 36) {
-        const { items: sessions } = await apiClient.listSessions();
-        const matches = sessions.filter((s) => s.sessionId.startsWith(sessionId));
-        if (matches.length === 0) {
-          console.error(chalk.red(`No session found matching "${sessionId}".`));
-          process.exit(1);
-        }
-        if (matches.length > 1) {
-          console.error(chalk.red(`Multiple sessions match "${sessionId}". Be more specific.`));
-          for (const m of matches) console.error(`  ${m.sessionId}  ${m.company}  ${m.status}`);
-          process.exit(1);
-        }
-        sessionId = matches[0].sessionId;
-      }
-
+      const sessionId = await resolveSessionIdFromPrefix(sessionIdArg);
       const result = await apiClient.cancelSession(sessionId);
       if (result.ok) {
         console.log(chalk.green(`Cancel requested for session ${sessionId.slice(0, 8)}.`));

--- a/src/cli/commands/task.ts
+++ b/src/cli/commands/task.ts
@@ -50,13 +50,31 @@ function formatDuration(sec: number): string {
 
 /**
  * Resolve a session ID from a unique prefix by listing sessions and filtering
- * client-side. Exits the process on no-match or ambiguous match. The server
- * has no `?prefix=` query, so the client filter is the only option.
+ * client-side. Walks pages lazily — first page handles the common case
+ * without extra round-trips; older sessions trigger a paginated walk only
+ * when the first page yields no match. Exits the process on no-match or
+ * ambiguous match. The server has no `?prefix=` query, so the client
+ * filter is the only option.
  */
 async function resolveSessionIdFromPrefix(prefix: string): Promise<string> {
   if (prefix.length >= 36) return prefix;
-  const { items: sessions } = await apiClient.listSessions();
-  const matches = sessions.filter((s) => s.sessionId.startsWith(prefix));
+
+  const matches: { sessionId: string; company: string; status: string }[] = [];
+  let page = 1;
+  while (true) {
+    // oxlint-disable-next-line no-await-in-loop -- pagination cursor depends on prior page; can't run in parallel
+    const { items, pagination } = await apiClient.listSessions({ page });
+    for (const s of items) {
+      if (s.sessionId.startsWith(prefix)) matches.push(s);
+    }
+    // Two matches is already ambiguous; stop walking instead of paging on.
+    if (matches.length >= 2) break;
+    // Walk until pages exhausted (or 50-page safety cap, ~25k sessions) so
+    // an older row with the same prefix on a later page surfaces as ambiguous.
+    if (!pagination?.hasMore || page >= 50) break;
+    page += 1;
+  }
+
   if (matches.length === 0) {
     console.error(chalk.red(`No session found matching "${prefix}".`));
     process.exit(1);


### PR DESCRIPTION
## Summary

CLI side of buildinternet/releases#794 items 5 + 7. Server-side changes ship in [buildinternet/releases#801](https://github.com/buildinternet/releases/pull/801).

- **`releases admin discovery task get <session-id>`** (or unique prefix). Shows full session detail in human and JSON form: timing, runner / correlation IDs, agent + Anthropic session, progress counters, error classification (`errorSource` / `errorType` / `stopReason` / `retryCount`), warnings, token usage with USD list-price snapshot, and a result-block preview. The GET endpoint already existed — this surfaces it.
- **`releases admin product adopt --merge-into <product>`** folds the source org into an existing product (slug or `prod_…` ID) under `--into` instead of creating a new one. Mutex with `--slug` / `--url`.

Cleanup riding along:
- Prefix-matching, status colors, and duration formatting in `task.ts` extracted into shared helpers and reused by `task list` + `task cancel` (the duplicated 3-level ternaries are gone).
- `product.ts` adopt now factors both branches through a single `migrateOrgToProduct` orchestrator.
- The pre-existing non-`--merge-into` branch's stray `JSON.stringify` JSON output flipped to `writeJson` for parity with every other CLI surface.

The local `SessionDetail` type extension is a transitional shim — once `@buildinternet/releases-api-types@0.8.0` (bumped in the server PR) lands on npm, we can drop it.

## Test plan

- [x] `bun test` (277 pass)
- [x] `npx tsc --noEmit` (clean)
- [x] `bun run lint` (clean)
- [ ] Smoke `releases admin discovery task get <prefix>` and `--json` against staging once 0.8.0 publishes
- [ ] Smoke `releases admin product adopt … --merge-into <existing>` against staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a detailed session inspection command: task get <session-id|prefix> (prints timing, agent/runner state, status, steps, progress, errors/warnings, token/cache/model usage, estimated cost, active sources, and result summary; supports JSON).
  * Enhanced product adopt with --merge-into <product>, including dry-run planning and option to fold a source organization into an existing product.
* **Improvements**
  * task cancel now accepts session ID prefixes for convenience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->