### PR TITLE
feat(cli): lookup and search by domain

### DIFF
--- a/.changeset/lookup-by-domain.md
+++ b/.changeset/lookup-by-domain.md
@@ -1,0 +1,5 @@
+---
+"releases-cli": minor
+---
+
+Add `releases lookup domain <domain>` for resolving any URL-shaped input to its registry org/products, and `--domain <domain>` on `releases search` for scoping a search to a single org by domain. Mirrors the new `GET /v1/lookups/by-domain` API endpoint and `lookup_domain` MCP tool.

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "releases-cli",
       "dependencies": {
-        "@buildinternet/releases-api-types": "^0.7.0",
+        "@buildinternet/releases-api-types": "^0.8.1",
         "@buildinternet/releases-core": "^0.17.0",
         "@buildinternet/releases-lib": "workspace:*",
         "@buildinternet/releases-skills": "workspace:*",
@@ -27,7 +27,7 @@
     },
     "npm/releases": {
       "name": "@buildinternet/releases",
-      "version": "0.28.1",
+      "version": "0.29.0",
       "bin": {
         "releases": "bin/releases",
       },
@@ -41,31 +41,31 @@
     },
     "npm/releases-darwin-arm64": {
       "name": "@buildinternet/releases-darwin-arm64",
-      "version": "0.28.1",
+      "version": "0.29.0",
     },
     "npm/releases-darwin-x64": {
       "name": "@buildinternet/releases-darwin-x64",
-      "version": "0.28.1",
+      "version": "0.29.0",
     },
     "npm/releases-linux-arm64": {
       "name": "@buildinternet/releases-linux-arm64",
-      "version": "0.28.1",
+      "version": "0.29.0",
     },
     "npm/releases-linux-x64": {
       "name": "@buildinternet/releases-linux-x64",
-      "version": "0.28.1",
+      "version": "0.29.0",
     },
     "npm/releases-windows-x64": {
       "name": "@buildinternet/releases-windows-x64",
-      "version": "0.28.1",
+      "version": "0.29.0",
     },
     "packages/lib": {
       "name": "@buildinternet/releases-lib",
-      "version": "0.28.1",
+      "version": "0.29.0",
     },
     "packages/skills": {
       "name": "@buildinternet/releases-skills",
-      "version": "0.28.1",
+      "version": "0.29.0",
     },
   },
   "packages": {
@@ -73,7 +73,7 @@
 
     "@buildinternet/releases": ["@buildinternet/releases@workspace:npm/releases"],
 
-    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.7.0", "", {}, "sha512-B0+5w3UKHMg92MnhFpwwZqpWh7WjTAGf/53jHVope1flwqB/svhwwBOwq/lyC9bWu8ONqKW5aC3efm8cxlIrvg=="],
+    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.8.1", "", { "dependencies": { "@buildinternet/releases-core": "^0.18.0", "zod": "^4.3.6" } }, "sha512-BspmjASii7wDeERatzZY/7c+iZPxlDlG0o+cY9Zc99JrPPhTkxC+qATrSOf8ZzvqkR8+9SEJrZcpmR2olbp64A=="],
 
     "@buildinternet/releases-core": ["@buildinternet/releases-core@0.17.0", "", { "dependencies": { "drizzle-orm": "^0.45.2", "js-tiktoken": "^1.0.21", "nanoid": "^5.1.7" } }, "sha512-ijIcgPHqAG7Jb2dFD83l6FRXN0XPLi02bqWomQneM+tkes9vfENg7WXx++rNPyMaHoe5Y1Gb0eZn6evNUr/rnA=="],
 
@@ -558,6 +558,8 @@
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "@buildinternet/releases-api-types/@buildinternet/releases-core": ["@buildinternet/releases-core@0.18.0", "", { "dependencies": { "drizzle-orm": "^0.45.2", "js-tiktoken": "^1.0.21", "nanoid": "^5.1.7" } }, "sha512-L4CdqRwg+73OAYKJdByvfDqqF2i86q3aTuRdjgBaa3KHwd123pYi65pwd8Qyq3rS9nw3I0fmkqmQKrQHle2xUw=="],
 
     "@changesets/apply-release-plan/prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "homepage": "https://releases.sh",
   "dependencies": {
-    "@buildinternet/releases-api-types": "^0.7.0",
+    "@buildinternet/releases-api-types": "^0.8.1",
     "@buildinternet/releases-core": "^0.17.0",
     "@buildinternet/releases-lib": "workspace:*",
     "@buildinternet/releases-skills": "workspace:*",

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -35,6 +35,7 @@ import type {
 } from "./types.js";
 import type { ListResponse } from "@buildinternet/releases-core/cli-contracts";
 import type {
+  DomainLookupResponse,
   OverviewInputsCheck,
   OverviewManifestResponse,
   OverviewManifestRow,
@@ -42,6 +43,7 @@ import type {
   OverviewStaleness,
 } from "@buildinternet/releases-api-types";
 export type {
+  DomainLookupResponse,
   OverviewInputsCheck,
   OverviewManifestResponse,
   OverviewManifestRow,
@@ -344,12 +346,25 @@ export async function checkContentHash(source: Source, contentHash: string): Pro
 export async function unifiedSearch(
   query: string,
   limit: number,
-  opts?: { org?: string; mode?: "lexical" | "semantic" | "hybrid" },
+  opts?: {
+    org?: string;
+    domain?: string;
+    mode?: "lexical" | "semantic" | "hybrid";
+  },
 ): Promise<UnifiedSearchResponse> {
   const params = new URLSearchParams({ q: query, limit: String(limit) });
   if (opts?.org) params.set("org", opts.org);
+  if (opts?.domain) params.set("domain", opts.domain);
   if (opts?.mode) params.set("mode", opts.mode);
   return apiFetch<UnifiedSearchResponse>(`/v1/search?${params}`);
+}
+
+// ── Domain lookup ──
+
+export async function lookupDomain(domain: string): Promise<DomainLookupResponse | null> {
+  return apiFetch<DomainLookupResponse | null>(
+    `/v1/lookups/by-domain?domain=${encodeURIComponent(domain)}`,
+  );
 }
 
 // ── List sources with org ──

--- a/src/cli/commands/lookup.ts
+++ b/src/cli/commands/lookup.ts
@@ -1,0 +1,85 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { lookupDomain } from "../../api/client.js";
+import { stripAnsi } from "../../lib/sanitize.js";
+import { logger } from "@releases/lib/logger";
+import { writeJson } from "../../lib/output.js";
+
+export function registerLookupCommand(program: Command): void {
+  const lookup = program
+    .command("lookup")
+    .description("Resolve a domain (or other coordinate) to its registry entry")
+    .showSuggestionAfterError(true)
+    .action(() => {
+      // Bare `releases lookup` — print sub-help.
+      lookup.help();
+    });
+
+  lookup
+    .command("domain")
+    .description("Find the org or product that owns a given domain")
+    .argument("<domain>", "Domain to resolve (URL-shaped forms are normalized)")
+    .option("--json", "Output as JSON")
+    .action(async (domain: string, opts: { json?: boolean }) => {
+      let result;
+      try {
+        result = await lookupDomain(domain);
+      } catch (err) {
+        if (err instanceof Error && err.message.includes("(400)")) {
+          // The API returns 400 when the domain doesn't normalize. Surface
+          // it as a clear validation failure rather than a stack trace.
+          logger.error(
+            `"${domain}" doesn't look like a valid hostname (need at least \`example.com\`).`,
+          );
+          process.exit(1);
+        }
+        throw err;
+      }
+
+      if (!result) {
+        if (opts.json) {
+          await writeJson(null);
+          return;
+        }
+        console.log(chalk.dim(`No org or product owns the domain ${chalk.bold(domain)}.`));
+        process.exit(1);
+      }
+
+      if (opts.json) {
+        await writeJson(result);
+        return;
+      }
+
+      console.log(chalk.bold(`Domain: ${chalk.cyan(result.domain)}`));
+      console.log("");
+
+      if (result.org) {
+        const matchLabel =
+          result.org.matchedVia === "primary" ? chalk.green("primary") : chalk.yellow("alias");
+        console.log(chalk.bold.underline("Organization"));
+        console.log(
+          `  ${chalk.cyan.bold(stripAnsi(result.org.name))} ${chalk.dim(`(${result.org.slug})`)} — matched via ${matchLabel}`,
+        );
+        if (result.org.matchedVia === "alias" && result.org.domain) {
+          console.log(chalk.dim(`  Primary domain: ${result.org.domain}`));
+        }
+        if (result.org.category) {
+          console.log(chalk.dim(`  Category: ${result.org.category}`));
+        }
+        if (result.org.description) {
+          console.log(chalk.dim(`  ${stripAnsi(result.org.description)}`));
+        }
+        console.log("");
+      }
+
+      if (result.products.length > 0) {
+        console.log(chalk.bold.underline("Products"));
+        for (const p of result.products) {
+          const cat = p.category ? chalk.dim(` | ${p.category}`) : "";
+          console.log(
+            `  ${chalk.cyan.bold(stripAnsi(p.name))} ${chalk.dim(`(${p.orgSlug}/${p.slug})`)} — by ${stripAnsi(p.orgName)}${cat}`,
+          );
+        }
+      }
+    });
+}

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -118,11 +118,21 @@ export function registerSearchCommand(program: Command) {
     .option("-l, --limit <n>", "Max results per type", "10")
     .option("--type <type>", "Limit to a result type: orgs, catalog, releases")
     .option("--mode <mode>", `Search mode: ${SEARCH_MODES.join(" | ")}`)
+    .option(
+      "--domain <domain>",
+      "Scope to the org owning this domain (URL-shaped input is normalized)",
+    )
     .option("--json", "Output as JSON")
     .action(
       async (
         query: string,
-        opts: { limit: string; type?: string; mode?: string; json?: boolean },
+        opts: {
+          limit: string;
+          type?: string;
+          mode?: string;
+          domain?: string;
+          json?: boolean;
+        },
       ) => {
         const limit = parseInt(opts.limit, 10);
 
@@ -144,7 +154,20 @@ export function registerSearchCommand(program: Command) {
           process.exit(1);
         }
 
-        const response = await unifiedSearch(query, limit, mode ? { mode } : undefined);
+        const searchOpts: { mode?: SearchMode; domain?: string } = {};
+        if (mode) searchOpts.mode = mode;
+        if (opts.domain) searchOpts.domain = opts.domain;
+        const response = await unifiedSearch(
+          query,
+          limit,
+          Object.keys(searchOpts).length > 0 ? searchOpts : undefined,
+        );
+
+        if (response.domainStatus === "not_found" && !opts.json) {
+          logger.warn(
+            `No org owns the domain "${response.domain ?? opts.domain}". Showing no results.`,
+          );
+        }
 
         // Read the new `catalog` field, falling back to the deprecated `products`
         // alias so older API deployments keep working. Drop the fallback once

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -163,14 +163,13 @@ export function registerSearchCommand(program: Command) {
           Object.keys(searchOpts).length > 0 ? searchOpts : undefined,
         );
 
-        if (!opts.json) {
+        if (!opts.json && response.domainStatus !== undefined) {
+          const scopedDomain = response.domain ?? opts.domain;
           if (response.domainStatus === "not_found") {
-            logger.warn(
-              `No org owns the domain "${response.domain ?? opts.domain}". Showing no results.`,
-            );
+            logger.warn(`No org owns the domain "${scopedDomain}". Showing no results.`);
           } else if (response.domainStatus === "matched") {
-            const scopedOrgName = response.orgs[0]?.name ?? response.domain;
-            logger.info(`Scoped to ${scopedOrgName} (${response.domain}).`);
+            const scopedOrgName = response.orgs[0]?.name ?? scopedDomain;
+            logger.info(`Scoped to ${scopedOrgName} (${scopedDomain}).`);
           }
         }
 

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -163,10 +163,15 @@ export function registerSearchCommand(program: Command) {
           Object.keys(searchOpts).length > 0 ? searchOpts : undefined,
         );
 
-        if (response.domainStatus === "not_found" && !opts.json) {
-          logger.warn(
-            `No org owns the domain "${response.domain ?? opts.domain}". Showing no results.`,
-          );
+        if (!opts.json) {
+          if (response.domainStatus === "not_found") {
+            logger.warn(
+              `No org owns the domain "${response.domain ?? opts.domain}". Showing no results.`,
+            );
+          } else if (response.domainStatus === "matched") {
+            const scopedOrgName = response.orgs[0]?.name ?? response.domain;
+            logger.info(`Scoped to ${scopedOrgName} (${response.domain}).`);
+          }
         }
 
         // Read the new `catalog` field, falling back to the deprecated `products`
@@ -187,6 +192,8 @@ export function registerSearchCommand(program: Command) {
           if (response.degraded !== undefined) filtered.degraded = response.degraded;
           if (response.degradedReason !== undefined)
             filtered.degradedReason = response.degradedReason;
+          if (response.domain !== undefined) filtered.domain = response.domain;
+          if (response.domainStatus !== undefined) filtered.domainStatus = response.domainStatus;
           if (response.lookup != null) filtered.lookup = response.lookup;
           await writeJson(filtered);
           return;

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -9,6 +9,7 @@ import { registerDeleteCommand } from "./commands/delete.js";
 import { registerListCommand } from "./commands/list.js";
 import { registerFetchCommand } from "./commands/fetch.js";
 import { registerSearchCommand } from "./commands/search.js";
+import { registerLookupCommand } from "./commands/lookup.js";
 import { registerTailCommand } from "./commands/tail.js";
 import { registerUsageCommand } from "./commands/usage.js";
 import { registerOrgCommand } from "./commands/org.js";
@@ -166,6 +167,7 @@ export const program = new Command()
 
 // Public commands — available to all users
 registerSearchCommand(program);
+registerLookupCommand(program);
 registerTailCommand(program);
 registerStatsCommand(program);
 registerListCommand(program);


### PR DESCRIPTION
## Summary

Adds CLI surfaces for the domain-resolution primitives shipped in `buildinternet/releases#802`:

- **`releases lookup domain <domain>`** — resolves a URL-shaped input (`vercel.com`, `https://www.vercel.com/about`, `vercel.com:443`, etc.) to its registry org plus any products whose alias targets the same domain. Pure resolution — unknown domains return `not_found`, nothing is probed or materialized. (The GitHub coordinate path on `POST /v1/lookups` is still the only path that materializes new sources.)
- **`releases search --domain <domain>`** — scopes a search to the org owning the domain. Prints a `Scoped to <org>` line (or `No org owns <domain>`) above the rest of the output so users see the resolution status without scanning section headers.

## Wire details

Pulls `@buildinternet/releases-api-types@^0.8.1`, which exports the new `DomainLookupResponse` type and adds `domain` / `domainStatus` to `UnifiedSearchResponse`. (0.8.0 was published with a broken manifest pinning `releases-core` to `workspace:*`; 0.8.1 fixes that — see `buildinternet/releases#808`.)

## Test plan

- [x] `bun test` — 277/277 pass.
- [x] `oxlint` — 0 warnings, 0 errors.
- [x] `tsc --noEmit` — clean.
- [ ] Smoke: `releases lookup domain vercel.com` against prod once published — expect a printed org block plus any products.
- [ ] Smoke: `releases search login --domain vercel.com` — expect "Scoped to <org>" header and Vercel-only results.
- [ ] Smoke: `releases search anything --domain nope.example` — expect "No org owns" warning + empty results.
- [ ] Smoke: `releases lookup domain --json https://www.vercel.com/about | jq` — expect `org.matchedVia: "primary"` and a normalized `domain: "vercel.com"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "lookup domain" command to resolve a domain into its organization and matched products (supports JSON output and friendly messages on no-match or validation errors).
  * Search gained a --domain option to scope results to an organization by domain; CLI now reports domain match status (warnings/info) and includes domain/domainStatus in JSON responses.

* **Chores**
  * Updated API types dependency version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->