### PR TITLE
fix(changeset): target @buildinternet/releases instead of releases-cli

### DIFF
--- a/.changeset/lookup-by-domain.md
+++ b/.changeset/lookup-by-domain.md
@@ -1,5 +1,5 @@
 ---
-"releases-cli": minor
+"@buildinternet/releases": minor
 ---
 
 Add `releases lookup domain <domain>` for resolving any URL-shaped input to its registry org/products, and `--domain <domain>` on `releases search` for scoping a search to a single org by domain. Mirrors the new `GET /v1/lookups/by-domain` API endpoint and `lookup_domain` MCP tool.

--- a/.changeset/task-get-and-merge-into.md
+++ b/.changeset/task-get-and-merge-into.md
@@ -1,5 +1,5 @@
 ---
-"releases-cli": minor
+"@buildinternet/releases": minor
 ---
 
 Add `releases admin discovery task get <session-id>` for full session detail (timing, usage, errors, agent state). Add `releases admin product adopt --merge-into <product>` to fold a source org into an existing product instead of creating a new one. Both close out items in buildinternet/releases#794.


### PR DESCRIPTION
## Summary

Both changesets currently in `.changeset/` (`task-get-and-merge-into.md` from #137 and `lookup-by-domain.md` from #138) target `releases-cli`, the private root package. The Release CLI workflow has been failing on every merge since:

```
🦋  error Error: Found changeset lookup-by-domain for package releases-cli which is not in the workspace
```

Changesets only assembles release plans for non-private workspace members. `releases-cli` is `"private": true` in the root `package.json` — it's the dev manifest, not a publishable npm package.

The published binary is `@buildinternet/releases` (in `npm/releases/`), which sits in the `fixed` group inside `.changeset/config.json` together with the per-platform npm packages plus `releases-lib` and `releases-skills`. Bumping that name cascades to all eight. That's what the previous changesets all did before #137 (`admin-dry-run-coverage`, `onboard-scope-source-mismatch`, `overview-inputs-json-flag` — all `"@buildinternet/releases"`).

## Verification

```
$ bunx changeset status

🦋  info Packages to be bumped at minor:
🦋  - @buildinternet/releases
🦋  - @buildinternet/releases-darwin-arm64
🦋  - @buildinternet/releases-darwin-x64
🦋  - @buildinternet/releases-linux-arm64
🦋  - @buildinternet/releases-linux-x64
🦋  - @buildinternet/releases-windows-x64
🦋  - @buildinternet/releases-lib
🦋  - @buildinternet/releases-skills
```

## Test plan

- [x] `bunx changeset status` lists all eight fixed-group packages for a minor bump.
- [ ] After merge, the Release CLI workflow succeeds and opens a "chore: version packages" PR rolling both changesets into the next CLI release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added domain lookup command to resolve URLs to their corresponding registry organizations and products
  - Added `--domain` filter option to search command for scoped organization searches
  - New admin discovery task command to retrieve full session details including timing and usage
  - New admin product command to merge source organizations into existing products

<!-- end of auto-generated comment: release notes by coderabbit.ai -->