### PR TITLE
chore: drop SessionDetail shim now that api-types 0.8.1 ships the fields

### DIFF
--- a/.changeset/drop-session-detail-shim.md
+++ b/.changeset/drop-session-detail-shim.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": patch
+---
+
+Drop the local `SessionDetail` shim in `task get` now that `@buildinternet/releases-api-types@0.8.1` exposes `agent`, `runner`, `correlationId`, `anthropicSessionId`, `usage`, `warnings`, and `result` natively on `Session`.

--- a/src/cli/commands/task.ts
+++ b/src/cli/commands/task.ts
@@ -9,30 +9,6 @@ import {
 } from "@buildinternet/releases-core/cli-contracts";
 import type { Session } from "@buildinternet/releases-api-types";
 
-/**
- * Session detail fields surfaced by `task get`. These ship in the next
- * `@buildinternet/releases-api-types` release; this local extension keeps
- * the CLI typecheck green until that bump lands.
- */
-type SessionDetail = Session & {
-  agent?: "sonnet" | "haiku" | "coordinator";
-  runner?: string;
-  correlationId?: string;
-  anthropicSessionId?: string;
-  sourcesFound?: number;
-  sourcesValidated?: number;
-  warnings?: string[];
-  usage?: {
-    inputTokens?: number;
-    outputTokens?: number;
-    cacheWriteTokens?: number;
-    cacheReadTokens?: number;
-    model?: string;
-    estimatedUsd?: number;
-  };
-  result?: Record<string, unknown>;
-};
-
 const fmtTimestamp = (n: number) => new Date(n).toISOString();
 
 function statusChalk(status: string) {
@@ -166,7 +142,7 @@ export function registerTaskCommand(program: Command) {
     .action(async (sessionIdArg: string, opts: { json?: boolean }) => {
       const sessionId = await resolveSessionIdFromPrefix(sessionIdArg);
 
-      const session = (await apiClient.getSession(sessionId)) as SessionDetail | null;
+      const session = (await apiClient.getSession(sessionId)) as Session | null;
       if (!session) {
         console.error(chalk.red(`Session not found: ${sessionId}`));
         process.exit(1);


### PR DESCRIPTION
## Summary

- Drop the local `SessionDetail` type alias from `src/cli/commands/task.ts`.
- The fields it added (`agent`, `runner`, `correlationId`, `anthropicSessionId`, `sourcesFound`, `sourcesValidated`, `warnings`, `usage`, `result`) all ship natively on `Session` in `@buildinternet/releases-api-types@0.8.1`, which is already pinned in `package.json`.
- This was the transitional shim landed in #137 to keep typecheck green before the api-types bump made it through the publish workflow.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `bun run lint` passes
- [ ] CI confirms the same on the PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed local session type definition in the task retrieval command, now using the `Session` type directly from the API types package for improved type consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->