### PR TITLE
feat(cli): admin collection command tree

### DIFF
--- a/.changeset/collection-admin-commands.md
+++ b/.changeset/collection-admin-commands.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": minor
+---
+
+Add `releases admin collection` command tree for managing curated cross-org collections (the playlists rendered at `/collections/<slug>` on the registry web app). Subcommands: `list`, `get <slug>`, `create <name>`, `update <slug>`, `delete <slug>`, plus `members add | set | remove` for membership management. Wraps the new admin write endpoints introduced in the registry API (#813); requires `@buildinternet/releases-api-types@^0.9.0`.

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "releases-cli",
       "dependencies": {
-        "@buildinternet/releases-api-types": "^0.8.1",
+        "@buildinternet/releases-api-types": "^0.9.0",
         "@buildinternet/releases-core": "^0.17.0",
         "@buildinternet/releases-lib": "workspace:*",
         "@buildinternet/releases-skills": "workspace:*",
@@ -27,7 +27,7 @@
     },
     "npm/releases": {
       "name": "@buildinternet/releases",
-      "version": "0.29.0",
+      "version": "0.30.0",
       "bin": {
         "releases": "bin/releases",
       },
@@ -41,31 +41,31 @@
     },
     "npm/releases-darwin-arm64": {
       "name": "@buildinternet/releases-darwin-arm64",
-      "version": "0.29.0",
+      "version": "0.30.0",
     },
     "npm/releases-darwin-x64": {
       "name": "@buildinternet/releases-darwin-x64",
-      "version": "0.29.0",
+      "version": "0.30.0",
     },
     "npm/releases-linux-arm64": {
       "name": "@buildinternet/releases-linux-arm64",
-      "version": "0.29.0",
+      "version": "0.30.0",
     },
     "npm/releases-linux-x64": {
       "name": "@buildinternet/releases-linux-x64",
-      "version": "0.29.0",
+      "version": "0.30.0",
     },
     "npm/releases-windows-x64": {
       "name": "@buildinternet/releases-windows-x64",
-      "version": "0.29.0",
+      "version": "0.30.0",
     },
     "packages/lib": {
       "name": "@buildinternet/releases-lib",
-      "version": "0.29.0",
+      "version": "0.30.0",
     },
     "packages/skills": {
       "name": "@buildinternet/releases-skills",
-      "version": "0.29.0",
+      "version": "0.30.0",
     },
   },
   "packages": {
@@ -73,7 +73,7 @@
 
     "@buildinternet/releases": ["@buildinternet/releases@workspace:npm/releases"],
 
-    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.8.1", "", { "dependencies": { "@buildinternet/releases-core": "^0.18.0", "zod": "^4.3.6" } }, "sha512-BspmjASii7wDeERatzZY/7c+iZPxlDlG0o+cY9Zc99JrPPhTkxC+qATrSOf8ZzvqkR8+9SEJrZcpmR2olbp64A=="],
+    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.9.0", "", { "dependencies": { "@buildinternet/releases-core": "^0.18.0", "zod": "^4.3.6" } }, "sha512-bGubh5jlDs9Hl4oyRmGbKTlVmKpg5auvDN3vUg+ay5Jz/p6Vy5yOjOu0d4P492lVuzJTDIYYbLJhJ1do3o8mhQ=="],
 
     "@buildinternet/releases-core": ["@buildinternet/releases-core@0.17.0", "", { "dependencies": { "drizzle-orm": "^0.45.2", "js-tiktoken": "^1.0.21", "nanoid": "^5.1.7" } }, "sha512-ijIcgPHqAG7Jb2dFD83l6FRXN0XPLi02bqWomQneM+tkes9vfENg7WXx++rNPyMaHoe5Y1Gb0eZn6evNUr/rnA=="],
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "homepage": "https://releases.sh",
   "dependencies": {
-    "@buildinternet/releases-api-types": "^0.8.1",
+    "@buildinternet/releases-api-types": "^0.9.0",
     "@buildinternet/releases-core": "^0.17.0",
     "@buildinternet/releases-lib": "workspace:*",
     "@buildinternet/releases-skills": "workspace:*",

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -41,6 +41,10 @@ import type {
   OverviewManifestRow,
   OverviewPlanAction,
   OverviewStaleness,
+  CollectionListItem,
+  CollectionDetail,
+  CollectionMemberInput,
+  CollectionRow,
 } from "@buildinternet/releases-api-types";
 export type {
   DomainLookupResponse,
@@ -49,6 +53,10 @@ export type {
   OverviewManifestRow,
   OverviewPlanAction,
   OverviewStaleness,
+  CollectionListItem,
+  CollectionDetail,
+  CollectionMemberInput,
+  CollectionRow,
 };
 export type {
   SourceWithOrg,
@@ -878,6 +886,67 @@ export async function updateProduct(
 
 export async function deleteProduct(productId: string): Promise<void> {
   await apiFetch(`/v1/products/${productId}`, { method: "DELETE" });
+}
+
+// ── Collections ──
+
+export async function listCollections(): Promise<CollectionListItem[]> {
+  return apiFetch<CollectionListItem[]>("/v1/collections");
+}
+
+export async function getCollection(slug: string): Promise<CollectionDetail | null> {
+  return apiFetch<CollectionDetail | null>(`/v1/collections/${encodeURIComponent(slug)}`);
+}
+
+export async function createCollection(input: {
+  name: string;
+  slug?: string;
+  description?: string | null;
+}): Promise<CollectionRow> {
+  return apiFetch<CollectionRow>("/v1/collections", {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
+}
+
+export async function updateCollection(
+  slug: string,
+  input: { name?: string; slug?: string; description?: string | null },
+): Promise<CollectionRow> {
+  return apiFetch<CollectionRow>(`/v1/collections/${encodeURIComponent(slug)}`, {
+    method: "PATCH",
+    body: JSON.stringify(input),
+  });
+}
+
+export async function deleteCollection(slug: string): Promise<void> {
+  await apiFetch(`/v1/collections/${encodeURIComponent(slug)}`, { method: "DELETE" });
+}
+
+export async function replaceCollectionMembers(
+  slug: string,
+  orgs: CollectionMemberInput[],
+): Promise<{ collectionSlug: string; members: { orgId: string; position: number }[] }> {
+  return apiFetch(`/v1/collections/${encodeURIComponent(slug)}/members`, {
+    method: "PUT",
+    body: JSON.stringify({ orgs }),
+  });
+}
+
+export async function addCollectionMember(
+  slug: string,
+  member: CollectionMemberInput,
+): Promise<{ collectionSlug: string; orgId: string; position: number }> {
+  return apiFetch(`/v1/collections/${encodeURIComponent(slug)}/members`, {
+    method: "POST",
+    body: JSON.stringify(member),
+  });
+}
+
+export async function removeCollectionMember(slug: string, org: string): Promise<void> {
+  await apiFetch(`/v1/collections/${encodeURIComponent(slug)}/members/${encodeURIComponent(org)}`, {
+    method: "DELETE",
+  });
 }
 
 // ── Tags ──

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -45,6 +45,10 @@ import type {
   CollectionDetail,
   CollectionMemberInput,
   CollectionRow,
+  CreateCollectionRequest,
+  UpdateCollectionRequest,
+  ReplaceCollectionMembersRequest,
+  AddCollectionMemberRequest,
 } from "@buildinternet/releases-api-types";
 export type {
   DomainLookupResponse,
@@ -898,11 +902,7 @@ export async function getCollection(slug: string): Promise<CollectionDetail | nu
   return apiFetch<CollectionDetail | null>(`/v1/collections/${encodeURIComponent(slug)}`);
 }
 
-export async function createCollection(input: {
-  name: string;
-  slug?: string;
-  description?: string | null;
-}): Promise<CollectionRow> {
+export async function createCollection(input: CreateCollectionRequest): Promise<CollectionRow> {
   return apiFetch<CollectionRow>("/v1/collections", {
     method: "POST",
     body: JSON.stringify(input),
@@ -911,7 +911,7 @@ export async function createCollection(input: {
 
 export async function updateCollection(
   slug: string,
-  input: { name?: string; slug?: string; description?: string | null },
+  input: UpdateCollectionRequest,
 ): Promise<CollectionRow> {
   return apiFetch<CollectionRow>(`/v1/collections/${encodeURIComponent(slug)}`, {
     method: "PATCH",
@@ -925,17 +925,18 @@ export async function deleteCollection(slug: string): Promise<void> {
 
 export async function replaceCollectionMembers(
   slug: string,
-  orgs: CollectionMemberInput[],
+  orgs: ReplaceCollectionMembersRequest["orgs"],
 ): Promise<{ collectionSlug: string; members: { orgId: string; position: number }[] }> {
+  const payload: ReplaceCollectionMembersRequest = { orgs };
   return apiFetch(`/v1/collections/${encodeURIComponent(slug)}/members`, {
     method: "PUT",
-    body: JSON.stringify({ orgs }),
+    body: JSON.stringify(payload),
   });
 }
 
 export async function addCollectionMember(
   slug: string,
-  member: CollectionMemberInput,
+  member: AddCollectionMemberRequest,
 ): Promise<{ collectionSlug: string; orgId: string; position: number }> {
   return apiFetch(`/v1/collections/${encodeURIComponent(slug)}/members`, {
     method: "POST",

--- a/src/cli/commands/collection.ts
+++ b/src/cli/commands/collection.ts
@@ -1,0 +1,207 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import Table from "cli-table3";
+import {
+  listCollections,
+  getCollection,
+  createCollection,
+  updateCollection,
+  deleteCollection,
+  replaceCollectionMembers,
+  addCollectionMember,
+  removeCollectionMember,
+} from "../../api/client.js";
+import { writeJson } from "../../lib/output.js";
+
+type GlobalOpts = { json?: boolean };
+
+function refToInput(ref: string): { orgId: string } | { orgSlug: string } {
+  return ref.startsWith("org_") ? { orgId: ref } : { orgSlug: ref };
+}
+
+async function listAction(opts: GlobalOpts): Promise<void> {
+  const rows = await listCollections();
+  if (opts.json) {
+    await writeJson(rows);
+    return;
+  }
+  if (rows.length === 0) {
+    console.log(chalk.yellow("No collections."));
+    return;
+  }
+  const table = new Table({
+    head: [
+      chalk.cyan("Slug"),
+      chalk.cyan("Name"),
+      chalk.cyan("Members"),
+      chalk.cyan("Description"),
+    ],
+  });
+  for (const r of rows) {
+    table.push([r.slug, r.name, String(r.memberCount), r.description ?? chalk.dim("—")]);
+  }
+  console.log(table.toString());
+}
+
+async function getAction(slug: string, opts: GlobalOpts): Promise<void> {
+  const detail = await getCollection(slug);
+  if (!detail) {
+    console.error(chalk.red(`Collection not found: ${slug}`));
+    process.exit(1);
+  }
+  if (opts.json) {
+    await writeJson(detail);
+    return;
+  }
+  console.log(chalk.bold(detail.name) + chalk.dim(` (${detail.slug})`));
+  if (detail.description) console.log(detail.description);
+  console.log("");
+  if (detail.orgs.length === 0) {
+    console.log(chalk.dim("No member orgs."));
+    return;
+  }
+  console.log(chalk.cyan(`${detail.orgs.length} ${detail.orgs.length === 1 ? "org" : "orgs"}:`));
+  for (const o of detail.orgs) console.log(`  - ${o.name} ${chalk.dim(`(${o.slug})`)}`);
+}
+
+type CreateOpts = GlobalOpts & { slug?: string; description?: string };
+async function createAction(name: string, opts: CreateOpts): Promise<void> {
+  const created = await createCollection({
+    name,
+    slug: opts.slug,
+    description: opts.description,
+  });
+  if (opts.json) await writeJson(created);
+  else console.log(chalk.green(`Created collection: ${created.name} (${created.slug})`));
+}
+
+type UpdateOpts = GlobalOpts & { name?: string; slug?: string; description?: string };
+async function updateAction(slug: string, opts: UpdateOpts): Promise<void> {
+  const patch: { name?: string; slug?: string; description?: string | null } = {};
+  if (opts.name !== undefined) patch.name = opts.name;
+  if (opts.slug !== undefined) patch.slug = opts.slug;
+  if (opts.description !== undefined) patch.description = opts.description;
+  if (Object.keys(patch).length === 0) {
+    console.error(chalk.red("Nothing to update — pass --name, --slug, or --description."));
+    process.exit(1);
+  }
+  const updated = await updateCollection(slug, patch);
+  if (opts.json) await writeJson(updated);
+  else console.log(chalk.green(`Updated collection: ${updated.name} (${updated.slug})`));
+}
+
+async function deleteAction(slug: string, opts: GlobalOpts): Promise<void> {
+  await deleteCollection(slug);
+  if (opts.json) await writeJson({ removed: slug });
+  else console.log(chalk.green(`Deleted collection: ${slug}`));
+}
+
+async function memberAddAction(
+  slug: string,
+  org: string,
+  opts: GlobalOpts & { position?: string },
+): Promise<void> {
+  const position = opts.position !== undefined ? Number(opts.position) : undefined;
+  const result = await addCollectionMember(slug, { ...refToInput(org), position });
+  if (opts.json) await writeJson(result);
+  else
+    console.log(
+      chalk.green(`Added ${org} to ${slug}`) + chalk.dim(` (position ${result.position})`),
+    );
+}
+
+async function memberSetAction(slug: string, orgList: string, opts: GlobalOpts): Promise<void> {
+  const orgs = orgList
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((ref) => refToInput(ref));
+  if (orgs.length === 0) {
+    console.error(chalk.red("Provide at least one org (comma-separated org_… or slug)."));
+    process.exit(1);
+  }
+  const result = await replaceCollectionMembers(slug, orgs);
+  if (opts.json) await writeJson(result);
+  else
+    console.log(
+      chalk.green(`Set ${result.members.length} members on ${slug}`) + chalk.dim(` (in order)`),
+    );
+}
+
+async function memberRemoveAction(slug: string, org: string, opts: GlobalOpts): Promise<void> {
+  await removeCollectionMember(slug, org);
+  if (opts.json) await writeJson({ removed: org });
+  else console.log(chalk.green(`Removed ${org} from ${slug}`));
+}
+
+export function registerCollectionCommand(program: Command) {
+  const collection = program
+    .command("collection")
+    .description("Manage curated collections (cross-org playlists)");
+
+  collection
+    .command("list")
+    .description("List collections")
+    .option("--json", "Output as JSON")
+    .action(listAction);
+
+  collection
+    .command("get")
+    .description("Show a collection's detail and member orgs")
+    .argument("<slug>", "Collection slug")
+    .option("--json", "Output as JSON")
+    .action(getAction);
+
+  collection
+    .command("create")
+    .description("Create a collection")
+    .argument("<name>", "Display name")
+    .option("--slug <slug>", "Custom slug (defaults to name → kebab)")
+    .option("--description <text>", "Optional description")
+    .option("--json", "Output as JSON")
+    .action(createAction);
+
+  collection
+    .command("update")
+    .description("Update a collection's name, slug, or description")
+    .argument("<slug>", "Current slug")
+    .option("--name <name>", "New name")
+    .option("--slug <slug>", "New slug (rotates the URL)")
+    .option("--description <text>", "New description (pass empty string to clear)")
+    .option("--json", "Output as JSON")
+    .action(updateAction);
+
+  collection
+    .command("delete")
+    .description("Delete a collection (cascade-removes membership)")
+    .argument("<slug>", "Collection slug")
+    .option("--json", "Output as JSON")
+    .action(deleteAction);
+
+  const members = collection.command("members").description("Manage collection membership");
+
+  members
+    .command("add")
+    .description("Add an org to a collection")
+    .argument("<slug>", "Collection slug")
+    .argument("<org>", "Org id (org_…) or slug")
+    .option("--position <n>", "Position (default 0)")
+    .option("--json", "Output as JSON")
+    .action(memberAddAction);
+
+  members
+    .command("set")
+    .description("Replace full membership atomically (positions follow input order)")
+    .argument("<slug>", "Collection slug")
+    .argument("<orgs>", "Comma-separated org refs (org_… or slugs)")
+    .option("--json", "Output as JSON")
+    .action(memberSetAction);
+
+  members
+    .command("remove")
+    .description("Remove an org from a collection")
+    .argument("<slug>", "Collection slug")
+    .argument("<org>", "Org id (org_…) or slug")
+    .option("--json", "Output as JSON")
+    .action(memberRemoveAction);
+}

--- a/src/cli/commands/collection.ts
+++ b/src/cli/commands/collection.ts
@@ -101,7 +101,17 @@ async function memberAddAction(
   org: string,
   opts: GlobalOpts & { position?: string },
 ): Promise<void> {
-  const position = opts.position !== undefined ? Number(opts.position) : undefined;
+  let position: number | undefined;
+  if (opts.position !== undefined) {
+    const parsed = Number(opts.position);
+    if (!Number.isInteger(parsed) || parsed < 0) {
+      console.error(
+        chalk.red(`Invalid --position "${opts.position}" (need a non-negative integer)`),
+      );
+      process.exit(1);
+    }
+    position = parsed;
+  }
   const result = await addCollectionMember(slug, { ...refToInput(org), position });
   if (opts.json) await writeJson(result);
   else

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -14,6 +14,7 @@ import { registerTailCommand } from "./commands/tail.js";
 import { registerUsageCommand } from "./commands/usage.js";
 import { registerOrgCommand } from "./commands/org.js";
 import { registerProductCommand } from "./commands/product.js";
+import { registerCollectionCommand } from "./commands/collection.js";
 import { registerStatsCommand } from "./commands/stats.js";
 import { registerReleaseCommand } from "./commands/release.js";
 import { registerCheckCommand } from "./commands/check.js";
@@ -211,6 +212,7 @@ registerChangelogCommand(sourceAdmin);
 
 registerOrgCommand(admin);
 registerProductCommand(admin);
+registerCollectionCommand(admin);
 registerReleaseCommand(admin);
 
 const discoveryAdmin = admin


### PR DESCRIPTION
## Summary

Adds the `releases admin collection` command tree, wrapping the new admin write endpoints introduced in [buildinternet/releases#813](https://github.com/buildinternet/releases/pull/813). Operators can now create / update / delete collections and manage their membership without dropping into SQL migrations.

```
releases admin collection list
releases admin collection get <slug>
releases admin collection create <name> [--slug] [--description]
releases admin collection update <slug> [--name | --slug | --description]
releases admin collection delete <slug>
releases admin collection members add <slug> <org> [--position]
releases admin collection members set <slug> <org1,org2,...>     # atomic replace
releases admin collection members remove <slug> <org>
```

Org refs accept typed ids (`org_…`) or slugs. `members set` replaces the full membership atomically (positions follow input order). The whole tree sits under `admin`, so it inherits the existing admin-key gate via `gateAdminSubtree`.

## Blocked on

This PR pins `@buildinternet/releases-api-types@^0.9.0`, which ships the new wire types (`CreateCollectionRequest`, `UpdateCollectionRequest`, `CollectionMemberInput`, `ReplaceCollectionMembersRequest`, `CollectionRow`). That version is queued for publish via [buildinternet/releases#814](https://github.com/buildinternet/releases/pull/814) — CI here will go green once #814 merges and the publish workflow ships 0.9.0 to npm.

## Test plan

- [x] `bun run lint` clean on changed files locally
- [x] `bun run format:check` clean
- [ ] `bun run typecheck` — fails locally until 0.9.0 is on npm; CI will retry
- [ ] Smoke test against staging once published: `releases admin collection create "Smoke" --slug smoke && releases admin collection members add smoke openai && releases admin collection get smoke && releases admin collection delete smoke`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add admin commands to manage curated cross-org collections: list, fetch, create, update, delete.
  * Add membership management: add, remove, or replace members (supports ordering and bulk replace via comma-separated refs).
  * CLI admin group now exposes these commands with optional JSON output.
  * API type updates to support collection management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->