### PR TITLE
feat(update): --changelog-paths and --no-changelog-paths flags

### DIFF
--- a/.changeset/changelog-paths-flag.md
+++ b/.changeset/changelog-paths-flag.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": minor
+---
+
+Add `--changelog-paths` and `--no-changelog-paths` flags to `releases admin source update` for setting per-source `metadata.changelogPaths` overrides directly. Replaces the previous workflow of dropping to a raw `curl` against `/v1/sources/.../metadata`. Caps at 20 paths client-side to match the API worker's `CHANGELOG_MAX_FILES`.

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -43,8 +43,20 @@ export type UpdateSourceOpts = {
   priority?: string;
   disable?: boolean;
   enable?: boolean;
+  changelogPaths?: string | boolean;
   dryRun?: boolean;
 };
+
+// Match the API worker cap (CHANGELOG_MAX_FILES) so we fail fast instead of
+// silently dropping the tail at fetch time.
+const CHANGELOG_PATHS_MAX = 20;
+
+function parseChangelogPathsFlag(value: string): string[] {
+  return value
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
 
 /** Shared action for both the canonical `update` command and the deprecated `edit` alias. */
 export async function updateSourceAction(
@@ -242,6 +254,27 @@ export async function updateSourceAction(
     changes.push("rendering → disabled (fast fetch)");
   }
 
+  if (opts.changelogPaths === false) {
+    metaUpdates.changelogPaths = undefined;
+    changes.push("changelog paths cleared (auto-discovery only)");
+  } else if (typeof opts.changelogPaths === "string") {
+    const paths = parseChangelogPathsFlag(opts.changelogPaths);
+    if (paths.length === 0) {
+      logger.error(
+        "--changelog-paths requires at least one path (use --no-changelog-paths to clear)",
+      );
+      process.exit(1);
+    }
+    if (paths.length > CHANGELOG_PATHS_MAX) {
+      logger.error(
+        `--changelog-paths accepts at most ${CHANGELOG_PATHS_MAX} entries (got ${paths.length})`,
+      );
+      process.exit(1);
+    }
+    metaUpdates.changelogPaths = paths;
+    changes.push(`changelog paths → ${paths.length} path(s) [${paths.join(", ")}]`);
+  }
+
   if (changes.length === 0) {
     if (!opts.json) logger.warn("No changes specified. Use --help to see options.");
     return;
@@ -321,6 +354,11 @@ export function attachUpdateOptions(cmd: Command): Command {
     .option("--priority <level>", "Set fetch priority (normal, low, paused)")
     .option("--disable", "Disable source")
     .option("--enable", "Re-enable a disabled source")
+    .option(
+      "--changelog-paths <paths>",
+      "Comma-separated list of CHANGELOG paths (relative to repo root) for monorepo sources, e.g. 'packages/core/CHANGELOG.md,packages/cli/CHANGELOG.md'",
+    )
+    .option("--no-changelog-paths", "Clear the changelog paths override (return to auto-discovery)")
     .option("--json", "Output as JSON")
     .option("--dry-run", "Show what would change without writing");
 }

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -51,11 +51,29 @@ export type UpdateSourceOpts = {
 // silently dropping the tail at fetch time.
 const CHANGELOG_PATHS_MAX = 20;
 
+/**
+ * Parse a `--changelog-paths` value into a non-empty, capped list of paths.
+ * Exits the process with a friendly error on empty input or overflow so
+ * callers don't have to repeat the same two checks inline.
+ */
 function parseChangelogPathsFlag(value: string): string[] {
-  return value
+  const paths = value
     .split(",")
     .map((s) => s.trim())
     .filter((s) => s.length > 0);
+  if (paths.length === 0) {
+    logger.error(
+      "--changelog-paths requires at least one path (use --no-changelog-paths to clear)",
+    );
+    process.exit(1);
+  }
+  if (paths.length > CHANGELOG_PATHS_MAX) {
+    logger.error(
+      `--changelog-paths accepts at most ${CHANGELOG_PATHS_MAX} entries (got ${paths.length})`,
+    );
+    process.exit(1);
+  }
+  return paths;
 }
 
 /** Shared action for both the canonical `update` command and the deprecated `edit` alias. */
@@ -259,18 +277,6 @@ export async function updateSourceAction(
     changes.push("changelog paths cleared (auto-discovery only)");
   } else if (typeof opts.changelogPaths === "string") {
     const paths = parseChangelogPathsFlag(opts.changelogPaths);
-    if (paths.length === 0) {
-      logger.error(
-        "--changelog-paths requires at least one path (use --no-changelog-paths to clear)",
-      );
-      process.exit(1);
-    }
-    if (paths.length > CHANGELOG_PATHS_MAX) {
-      logger.error(
-        `--changelog-paths accepts at most ${CHANGELOG_PATHS_MAX} entries (got ${paths.length})`,
-      );
-      process.exit(1);
-    }
     metaUpdates.changelogPaths = paths;
     changes.push(`changelog paths → ${paths.length} path(s) [${paths.join(", ")}]`);
   }


### PR DESCRIPTION
## Summary

Adds `--changelog-paths <a,b,c>` and `--no-changelog-paths` flags to `releases admin source update`. Replaces the previous workflow of dropping to a raw `curl` PATCH against `/v1/sources/.../metadata` to set `metadata.changelogPaths`. Caps at 20 paths client-side to match the API worker's `CHANGELOG_MAX_FILES`.

Pairs with buildinternet/releases#819 — the API-side probe endpoint that lets operators discover candidate paths before committing to an override.

Changeset bumps `@buildinternet/releases` minor (cascades through the fixed group).

## Test plan

- [x] `bun test` — 277 pass / 0 fail
- [x] `npx tsc --noEmit` — clean
- [x] `bun run lint` / `bun run format:check` — clean
- [ ] Manual smoke: `releases update <slug> --changelog-paths "packages/core/CHANGELOG.md,packages/cli/CHANGELOG.md" --json`
- [ ] Manual smoke: `releases update <slug> --no-changelog-paths --json` clears the override


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--changelog-paths` and `--no-changelog-paths` flags to the `releases admin source update` command
  * Enables per-source configuration of changelog paths directly through the CLI
  * Supports up to 20 comma-separated changelog paths per source

<!-- end of auto-generated comment: release notes by coderabbit.ai -->