### PR TITLE
feat(update): --category-allow flag for source feed filtering

### DIFF
--- a/.changeset/category-allow-flag.md
+++ b/.changeset/category-allow-flag.md
@@ -1,0 +1,7 @@
+---
+"@buildinternet/releases": minor
+---
+
+Add `--category-allow <list>` and `--no-category-allow` flags to `releases admin source update` for setting per-source `metadata.categoryAllow` directly. Drops feed items whose `<category>` doesn't intersect the allowlist (case-insensitive); items with no category are dropped too. Useful on mixed-topic feeds where the upstream tags every entry — `openai.com/news/rss.xml` is the motivating case. Worker-side filter ships in buildinternet/releases#821.
+
+Also adds `scripts/bulk-suppress.ts`, an operator utility that reads `{id, reason}` NDJSON on stdin and runs `releases.suppress` with bounded concurrency (default 8). Used to clean up the existing noise on a source after enabling `categoryAllow`.

--- a/scripts/bulk-suppress.ts
+++ b/scripts/bulk-suppress.ts
@@ -34,6 +34,7 @@ async function worker(queue: typeof rows) {
     const row = queue.shift();
     if (!row) break;
     try {
+      // oxlint-disable-next-line no-await-in-loop -- worker drains shared queue; concurrency comes from running N workers in parallel
       await suppressRelease(row.id, row.reason);
       ok++;
     } catch (err) {

--- a/scripts/bulk-suppress.ts
+++ b/scripts/bulk-suppress.ts
@@ -1,0 +1,57 @@
+#!/usr/bin/env bun
+// One-off operator script: bulk-suppress releases listed as NDJSON on stdin.
+// Each line: {"id": "rel_…", "reason": "…"}.
+// Runs with bounded concurrency to be polite to the API.
+//
+// Usage:
+//   cat suppressions.ndjson | bun scripts/bulk-suppress.ts [--concurrency 8]
+
+import { suppressRelease } from "../src/api/client.ts";
+
+const CONCURRENCY = (() => {
+  const idx = process.argv.indexOf("--concurrency");
+  if (idx !== -1 && process.argv[idx + 1]) {
+    const n = Number(process.argv[idx + 1]);
+    if (Number.isFinite(n) && n > 0 && n <= 32) return n;
+  }
+  return 8;
+})();
+
+const stdin = await new Response(Bun.stdin.stream()).text();
+const rows = stdin
+  .split("\n")
+  .filter((l) => l.trim())
+  .map((l) => JSON.parse(l) as { id: string; reason?: string });
+
+console.error(`Suppressing ${rows.length} releases (concurrency=${CONCURRENCY})…`);
+
+let ok = 0;
+let fail = 0;
+const errors: Array<{ id: string; err: string }> = [];
+
+async function worker(queue: typeof rows) {
+  while (queue.length > 0) {
+    const row = queue.shift();
+    if (!row) break;
+    try {
+      await suppressRelease(row.id, row.reason);
+      ok++;
+    } catch (err) {
+      fail++;
+      errors.push({ id: row.id, err: err instanceof Error ? err.message : String(err) });
+    }
+    if ((ok + fail) % 25 === 0) {
+      console.error(`  progress: ok=${ok} fail=${fail}`);
+    }
+  }
+}
+
+const queue = [...rows];
+await Promise.all(Array.from({ length: CONCURRENCY }, () => worker(queue)));
+
+console.error(`DONE. ok=${ok} fail=${fail}`);
+if (errors.length) {
+  console.error("Errors (first 5):");
+  for (const e of errors.slice(0, 5)) console.error(`  ${e.id}: ${e.err}`);
+}
+process.exit(fail > 0 ? 1 : 0);

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -38,6 +38,7 @@ export type UpdateSourceOpts = {
   fetchMethod?: string;
   parseInstructions?: string | boolean;
   parseInstructionsFile?: string;
+  categoryAllow?: string | boolean;
   render?: boolean;
   primary?: boolean;
   priority?: string;
@@ -234,6 +235,24 @@ export async function updateSourceAction(
     changes.push(`parse instructions → "${preview}"`);
   }
 
+  if (opts.categoryAllow === false) {
+    metaUpdates.categoryAllow = undefined;
+    changes.push("category allowlist removed");
+  } else if (typeof opts.categoryAllow === "string") {
+    const allow = opts.categoryAllow
+      .split(",")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+    if (allow.length === 0) {
+      logger.error(
+        "--category-allow requires at least one category (use --no-category-allow to clear)",
+      );
+      process.exit(1);
+    }
+    metaUpdates.categoryAllow = allow;
+    changes.push(`category allowlist → ${allow.join(", ")}`);
+  }
+
   if (opts.render === true) {
     metaUpdates.renderRequired = true;
     changes.push("rendering → required (headless browser)");
@@ -312,6 +331,11 @@ export function attachUpdateOptions(cmd: Command): Command {
       "Path to file with AI parsing instructions (use - for stdin; empty file clears)",
     )
     .option("--no-parse-instructions", "Remove AI parsing instructions")
+    .option(
+      "--category-allow <list>",
+      "Comma-separated allowlist of feed `<category>` values to keep (case-insensitive). Items whose categories don't intersect — and items with no category at all — are dropped at ingest. Example: 'Product,Release'",
+    )
+    .option("--no-category-allow", "Remove the feed category allowlist")
     .option("--render", "Force headless browser rendering for this source")
     .option("--no-render", "Allow fast fetch without headless browser rendering")
     .option("--provider <provider>", "Set the detected provider")


### PR DESCRIPTION
## Summary

- Add `--category-allow <list>` and `--no-category-allow` flags to `releases admin source update`
- Add `scripts/bulk-suppress.ts` operator utility for batch-suppressing releases via NDJSON on stdin

`--category-allow` mirrors the `--parse-instructions` shape (string-sets, false-clears, comma-separated parsed into an array). Sets `SourceMetadata.categoryAllow`, which the API worker uses to drop feed items whose `<category>` doesn't intersect the allowlist. Worker support lives in [buildinternet/releases#821](https://github.com/buildinternet/releases/pull/821).

`scripts/bulk-suppress.ts` is the practical follow-up tool: after rolling `categoryAllow` onto a noisy source, you've got existing rows to clean up. Reads NDJSON `{id, reason}` rows on stdin and calls `suppressRelease` with bounded concurrency (default 8). Used it to sweep 238 noise rows out of `openai-news` after enabling the filter; ~25s end-to-end.

## Test plan

- [x] `releases admin source update <slug> --category-allow "Product,Release" --dry-run` shows the right diff
- [x] Apply for real → `metadata.categoryAllow` persists on the source
- [x] `--no-category-allow` clears the field
- [x] `bun scripts/bulk-suppress.ts < /tmp/foo.ndjson` runs the batch with progress logging
- [ ] Worker-side filter behavior verified once buildinternet/releases#821 deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)
