### PR TITLE
feat(cli): expose collection reads at the top level + show org memberships

### DIFF
--- a/.changeset/collection-reads-public.md
+++ b/.changeset/collection-reads-public.md
@@ -2,7 +2,7 @@
 "@buildinternet/releases": minor
 ---
 
-Collections are now first-class browseable from the CLI.
+Collections are now first-class browsable from the CLI.
 
 - `releases collection list` and `releases collection get <slug>` are public — no API key needed. The same commands also stay under `admin` for back-compat.
 - New `releases collection releases <slug>` shows the cross-org release feed with cursor pagination (`--limit`, `--cursor`, `--include-prereleases`).

--- a/.changeset/collection-reads-public.md
+++ b/.changeset/collection-reads-public.md
@@ -1,0 +1,11 @@
+---
+"@buildinternet/releases": minor
+---
+
+Collections are now first-class browseable from the CLI.
+
+- `releases collection list` and `releases collection get <slug>` are public — no API key needed. The same commands also stay under `admin` for back-compat.
+- New `releases collection releases <slug>` shows the cross-org release feed with cursor pagination (`--limit`, `--cursor`, `--include-prereleases`).
+- `releases get <orgslug>` now lists the collections an org belongs to. Failures degrade silently with a logger warning so an unrelated bug in the collections endpoint never breaks the canonical org card.
+
+The wire shape for `CollectionReleaseItem` isn't published in `@buildinternet/releases-api-types` yet, so the CLI declares it inline. When api-types ships its next minor, the inline type can drop.

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -933,13 +933,13 @@ interface CollectionReleasesResponseCli {
 export async function getCollectionReleases(
   slug: string,
   opts: { limit?: number; cursor?: string | null; includePrereleases?: boolean } = {},
-): Promise<CollectionReleasesResponseCli> {
+): Promise<CollectionReleasesResponseCli | null> {
   const qs = new URLSearchParams();
   if (opts.limit !== undefined) qs.set("limit", String(opts.limit));
   if (opts.cursor) qs.set("cursor", opts.cursor);
   if (opts.includePrereleases) qs.set("include_prereleases", "1");
   const suffix = qs.size > 0 ? `?${qs.toString()}` : "";
-  return apiFetch<CollectionReleasesResponseCli>(
+  return apiFetch<CollectionReleasesResponseCli | null>(
     `/v1/collections/${encodeURIComponent(slug)}/releases${suffix}`,
   );
 }

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -902,6 +902,53 @@ export async function getCollection(slug: string): Promise<CollectionDetail | nu
   return apiFetch<CollectionDetail | null>(`/v1/collections/${encodeURIComponent(slug)}`);
 }
 
+/**
+ * Cross-org release feed for a collection. Cursor-paginated; the API's cursor
+ * format is opaque to the CLI — we just round-trip whatever the server returns.
+ *
+ * `CollectionReleaseItem` isn't published in api-types yet, so the wire shape
+ * is declared inline. When the next api-types release lands, this can switch
+ * to importing the canonical type.
+ */
+export interface CollectionReleaseItemCli {
+  id: string;
+  version: string | null;
+  type: ReleaseType;
+  title: string;
+  summary: string;
+  content: string;
+  publishedAt: string | null;
+  url: string | null;
+  prerelease: boolean;
+  source: { slug: string; name: string; type: string };
+  org: { slug: string; name: string };
+  product: { slug: string; name: string } | null;
+}
+
+interface CollectionReleasesResponseCli {
+  releases: CollectionReleaseItemCli[];
+  pagination: { nextCursor: string | null; limit: number };
+}
+
+export async function getCollectionReleases(
+  slug: string,
+  opts: { limit?: number; cursor?: string | null; includePrereleases?: boolean } = {},
+): Promise<CollectionReleasesResponseCli> {
+  const qs = new URLSearchParams();
+  if (opts.limit !== undefined) qs.set("limit", String(opts.limit));
+  if (opts.cursor) qs.set("cursor", opts.cursor);
+  if (opts.includePrereleases) qs.set("include_prereleases", "1");
+  const suffix = qs.size > 0 ? `?${qs.toString()}` : "";
+  return apiFetch<CollectionReleasesResponseCli>(
+    `/v1/collections/${encodeURIComponent(slug)}/releases${suffix}`,
+  );
+}
+
+/** Collections an org is a member of. Used to indicate membership on `releases get <orgslug>`. */
+export async function getOrgCollections(orgRef: string): Promise<CollectionListItem[]> {
+  return apiFetch<CollectionListItem[]>(`/v1/orgs/${encodeURIComponent(orgRef)}/collections`);
+}
+
 export async function createCollection(input: CreateCollectionRequest): Promise<CollectionRow> {
   return apiFetch<CollectionRow>("/v1/collections", {
     method: "POST",

--- a/src/cli/commands/collection.ts
+++ b/src/cli/commands/collection.ts
@@ -77,8 +77,8 @@ type ReleasesOpts = GlobalOpts & {
 };
 async function releasesAction(slug: string, opts: ReleasesOpts): Promise<void> {
   const limit = opts.limit ? Number(opts.limit) : undefined;
-  if (limit !== undefined && (!Number.isInteger(limit) || limit < 1)) {
-    console.error(chalk.red(`Invalid --limit "${opts.limit}" (need a positive integer)`));
+  if (limit !== undefined && (!Number.isInteger(limit) || limit < 1 || limit > 100)) {
+    console.error(chalk.red(`Invalid --limit "${opts.limit}" (need an integer between 1 and 100)`));
     process.exit(1);
   }
   const result = await getCollectionReleases(slug, {
@@ -86,6 +86,11 @@ async function releasesAction(slug: string, opts: ReleasesOpts): Promise<void> {
     cursor: opts.cursor ?? null,
     includePrereleases: opts.includePrereleases,
   });
+  if (!result) {
+    if (opts.json) await writeJson(null);
+    else console.error(chalk.red(`Collection not found: ${slug}`));
+    process.exit(1);
+  }
   if (opts.json) {
     await writeJson(result);
     return;
@@ -204,6 +209,32 @@ async function memberRemoveAction(slug: string, org: string, opts: GlobalOpts): 
   else console.log(chalk.green(`Removed ${org} from ${slug}`));
 }
 
+/** Wires `list` / `get` / `releases` onto a parent `collection` command. */
+function attachReadSubcommands(collection: Command): void {
+  collection
+    .command("list")
+    .description("List collections")
+    .option("--json", "Output as JSON")
+    .action(listAction);
+
+  collection
+    .command("get")
+    .description("Show a collection's detail and member orgs")
+    .argument("<slug>", "Collection slug")
+    .option("--json", "Output as JSON")
+    .action(getAction);
+
+  collection
+    .command("releases")
+    .description("Show the cross-org release feed for a collection")
+    .argument("<slug>", "Collection slug")
+    .option("--limit <n>", "Slice size (default 20, max 100)")
+    .option("--cursor <token>", "Continuation cursor from a prior call")
+    .option("--include-prereleases", "Include alphas, betas, RCs (default: hide)")
+    .option("--json", "Output as JSON")
+    .action(releasesAction);
+}
+
 /**
  * Read-only collection commands — public, no admin gate. Registered at the
  * top-level program so anyone can browse collections without an API key.
@@ -212,30 +243,7 @@ export function registerCollectionReadCommands(program: Command): Command {
   const collection = program
     .command("collection")
     .description("Browse curated collections (cross-org playlists)");
-
-  collection
-    .command("list")
-    .description("List collections")
-    .option("--json", "Output as JSON")
-    .action(listAction);
-
-  collection
-    .command("get")
-    .description("Show a collection's detail and member orgs")
-    .argument("<slug>", "Collection slug")
-    .option("--json", "Output as JSON")
-    .action(getAction);
-
-  collection
-    .command("releases")
-    .description("Show the cross-org release feed for a collection")
-    .argument("<slug>", "Collection slug")
-    .option("--limit <n>", "Slice size (default 20, max 100)")
-    .option("--cursor <token>", "Continuation cursor from a prior call")
-    .option("--include-prereleases", "Include alphas, betas, RCs (default: hide)")
-    .option("--json", "Output as JSON")
-    .action(releasesAction);
-
+  attachReadSubcommands(collection);
   return collection;
 }
 
@@ -244,28 +252,7 @@ export function registerCollectionCommand(program: Command) {
     .command("collection")
     .description("Manage curated collections (cross-org playlists)");
 
-  collection
-    .command("list")
-    .description("List collections")
-    .option("--json", "Output as JSON")
-    .action(listAction);
-
-  collection
-    .command("get")
-    .description("Show a collection's detail and member orgs")
-    .argument("<slug>", "Collection slug")
-    .option("--json", "Output as JSON")
-    .action(getAction);
-
-  collection
-    .command("releases")
-    .description("Show the cross-org release feed for a collection")
-    .argument("<slug>", "Collection slug")
-    .option("--limit <n>", "Slice size (default 20, max 100)")
-    .option("--cursor <token>", "Continuation cursor from a prior call")
-    .option("--include-prereleases", "Include alphas, betas, RCs (default: hide)")
-    .option("--json", "Output as JSON")
-    .action(releasesAction);
+  attachReadSubcommands(collection);
 
   collection
     .command("create")

--- a/src/cli/commands/collection.ts
+++ b/src/cli/commands/collection.ts
@@ -4,6 +4,7 @@ import { renderTable } from "../render/table.js";
 import {
   listCollections,
   getCollection,
+  getCollectionReleases,
   createCollection,
   updateCollection,
   deleteCollection,
@@ -11,6 +12,7 @@ import {
   addCollectionMember,
   removeCollectionMember,
 } from "../../api/client.js";
+import { stripAnsi } from "../../lib/sanitize.js";
 import { writeJson } from "../../lib/output.js";
 
 type GlobalOpts = { json?: boolean };
@@ -66,6 +68,60 @@ async function getAction(slug: string, opts: GlobalOpts): Promise<void> {
   }
   console.log(chalk.cyan(`${detail.orgs.length} ${detail.orgs.length === 1 ? "org" : "orgs"}:`));
   for (const o of detail.orgs) console.log(`  - ${o.name} ${chalk.dim(`(${o.slug})`)}`);
+}
+
+type ReleasesOpts = GlobalOpts & {
+  limit?: string;
+  cursor?: string;
+  includePrereleases?: boolean;
+};
+async function releasesAction(slug: string, opts: ReleasesOpts): Promise<void> {
+  const limit = opts.limit ? Number(opts.limit) : undefined;
+  if (limit !== undefined && (!Number.isInteger(limit) || limit < 1)) {
+    console.error(chalk.red(`Invalid --limit "${opts.limit}" (need a positive integer)`));
+    process.exit(1);
+  }
+  const result = await getCollectionReleases(slug, {
+    limit,
+    cursor: opts.cursor ?? null,
+    includePrereleases: opts.includePrereleases,
+  });
+  if (opts.json) {
+    await writeJson(result);
+    return;
+  }
+  if (result.releases.length === 0) {
+    console.log(chalk.yellow(`No releases yet in collection "${slug}".`));
+    return;
+  }
+  console.log(
+    renderTable({
+      head: [
+        { label: "ID", noTruncate: true },
+        { label: "Org" },
+        { label: "Source" },
+        { label: "Title" },
+        { label: "Version", noTruncate: true },
+        { label: "Published", noTruncate: true },
+      ],
+      rows: result.releases.map((r) => [
+        chalk.dim(r.id),
+        `${r.org.name} ${chalk.dim(`(${r.org.slug})`)}`,
+        `${r.source.name} ${chalk.dim(`(${r.source.slug})`)}`,
+        stripAnsi(r.title),
+        r.version ? stripAnsi(r.version) : chalk.dim("—"),
+        r.publishedAt?.slice(0, 10) ?? chalk.dim("—"),
+      ]),
+    }),
+  );
+  if (result.pagination.nextCursor) {
+    console.log("");
+    console.log(
+      chalk.dim(
+        `More available. Pass --cursor "${result.pagination.nextCursor}" to continue (limit ${result.pagination.limit}).`,
+      ),
+    );
+  }
 }
 
 type CreateOpts = GlobalOpts & { slug?: string; description?: string };
@@ -148,6 +204,41 @@ async function memberRemoveAction(slug: string, org: string, opts: GlobalOpts): 
   else console.log(chalk.green(`Removed ${org} from ${slug}`));
 }
 
+/**
+ * Read-only collection commands — public, no admin gate. Registered at the
+ * top-level program so anyone can browse collections without an API key.
+ */
+export function registerCollectionReadCommands(program: Command): Command {
+  const collection = program
+    .command("collection")
+    .description("Browse curated collections (cross-org playlists)");
+
+  collection
+    .command("list")
+    .description("List collections")
+    .option("--json", "Output as JSON")
+    .action(listAction);
+
+  collection
+    .command("get")
+    .description("Show a collection's detail and member orgs")
+    .argument("<slug>", "Collection slug")
+    .option("--json", "Output as JSON")
+    .action(getAction);
+
+  collection
+    .command("releases")
+    .description("Show the cross-org release feed for a collection")
+    .argument("<slug>", "Collection slug")
+    .option("--limit <n>", "Slice size (default 20, max 100)")
+    .option("--cursor <token>", "Continuation cursor from a prior call")
+    .option("--include-prereleases", "Include alphas, betas, RCs (default: hide)")
+    .option("--json", "Output as JSON")
+    .action(releasesAction);
+
+  return collection;
+}
+
 export function registerCollectionCommand(program: Command) {
   const collection = program
     .command("collection")
@@ -165,6 +256,16 @@ export function registerCollectionCommand(program: Command) {
     .argument("<slug>", "Collection slug")
     .option("--json", "Output as JSON")
     .action(getAction);
+
+  collection
+    .command("releases")
+    .description("Show the cross-org release feed for a collection")
+    .argument("<slug>", "Collection slug")
+    .option("--limit <n>", "Slice size (default 20, max 100)")
+    .option("--cursor <token>", "Continuation cursor from a prior call")
+    .option("--include-prereleases", "Include alphas, betas, RCs (default: hide)")
+    .option("--json", "Output as JSON")
+    .action(releasesAction);
 
   collection
     .command("create")

--- a/src/cli/commands/get.ts
+++ b/src/cli/commands/get.ts
@@ -6,7 +6,9 @@ import {
   findProduct,
   getRelease,
   getLatestReleases,
+  getOrgCollections,
 } from "../../api/client.js";
+import type { CollectionListItem } from "@buildinternet/releases-api-types";
 import { stripAnsi } from "../../lib/sanitize.js";
 import { logger } from "@releases/lib/logger";
 import { renderLatestReleasesTable } from "../render/releases-table.js";
@@ -118,10 +120,24 @@ async function renderOrg(
   org: { id: string; name: string; slug: string; domain: string | null; category: string | null },
   opts: GetEntityOpts,
 ) {
-  const releases = await getLatestReleases({ org: org.slug, count: 10 });
+  // Collections degrade to empty on failure so an unrelated bug in the
+  // collections endpoint doesn't break the canonical org card; the warning
+  // surfaces real issues without aborting.
+  const fetchCollections = async (): Promise<CollectionListItem[]> => {
+    try {
+      return (await getOrgCollections(org.slug)) ?? [];
+    } catch (err) {
+      logger.warn(`Failed to fetch collections for ${org.slug}: ${err}`);
+      return [];
+    }
+  };
+  const [releases, collections] = await Promise.all([
+    getLatestReleases({ org: org.slug, count: 10 }),
+    fetchCollections(),
+  ]);
 
   if (opts.json) {
-    await writeJson({ ...org, releases });
+    await writeJson({ ...org, releases, collections });
     return;
   }
 
@@ -131,6 +147,10 @@ async function renderOrg(
   console.log(`  Slug:    ${org.slug}`);
   if (org.domain) console.log(`  Domain:  ${org.domain}`);
   if (org.category) console.log(`  Category: ${org.category}`);
+  if (collections.length > 0) {
+    const labels = collections.map((c) => `${c.name} ${chalk.dim(`(${c.slug})`)}`).join(", ");
+    console.log(`  Collections: ${labels}`);
+  }
 
   console.log("");
   if (releases.length === 0) {

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -14,7 +14,10 @@ import { registerTailCommand } from "./commands/tail.js";
 import { registerUsageCommand } from "./commands/usage.js";
 import { registerOrgCommand } from "./commands/org.js";
 import { registerProductCommand } from "./commands/product.js";
-import { registerCollectionCommand } from "./commands/collection.js";
+import {
+  registerCollectionCommand,
+  registerCollectionReadCommands,
+} from "./commands/collection.js";
 import { registerStatsCommand } from "./commands/stats.js";
 import { registerReleaseCommand } from "./commands/release.js";
 import { registerCheckCommand } from "./commands/check.js";
@@ -175,6 +178,7 @@ registerListCommand(program);
 // Canonical verb: get. Deprecated alias: show (emits a warning).
 registerGetCommand(program);
 registerShowCommand(program);
+registerCollectionReadCommands(program);
 registerTelemetryCommand(program);
 registerWhoamiCommand(program);
 registerAgentContextCommand(program);


### PR DESCRIPTION
## Summary

- Splits `collection.ts` into a public read surface (`list` / `get` / `releases`) and the existing admin tree, then registers the read commands at the top level so anyone can browse collections without an API key. The `admin collection ...` parent keeps the full tree for back-compat.
- Adds `releases collection releases <slug>` for the cross-org feed, cursor-paginated with `--limit` / `--cursor` / `--include-prereleases`.
- `releases get <orgslug>` now shows a `Collections:` line when the org belongs to any. Failures degrade silently with a logger warning so an unrelated bug in the collections endpoint never breaks the canonical org card.

`CollectionReleaseItem` isn't in the published api-types yet, so the wire shape is declared inline; the comment in `client.ts` flags it for removal once api-types ships its next minor.

## Sample output

```
$ releases collection list
frontier-ai-labs   Frontier AI Labs   2   Frontier AI research labs and model providers, side by side.

$ releases get anthropic
Organization
Anthropic
  ID:      org_HXldkKAl-bZUWW6lNnELP
  Slug:    anthropic
  Domain:  anthropic.com
  Collections: Frontier AI Labs (frontier-ai-labs)
  ...
```

## Test plan

- [x] `npx tsc --noEmit` — clean.
- [x] `bun run lint` — clean.
- [x] `bun test` — 286 pass.
- [x] Live smoke against prod: `collection list`, `collection get frontier-ai-labs`, `collection releases frontier-ai-labs --limit 3`, and `get anthropic` all return correct output.
- [x] Changeset added (`@buildinternet/releases` minor).

Companion monorepo PR (MCP tools + `get_organization` membership line): buildinternet/releases#836.

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public CLI commands to browse collections without an API key (collection list/get available publicly and under admin for compatibility).
  * New releases collection command: `releases collection releases <slug>` — cross-organization feed with cursor pagination (`--limit`, `--cursor`) and `--include-prereleases`.
  * Org details now include associated collections (JSON and table outputs), with JSON returning null when a collection isn’t found.
  * Results table shows continuation message when more pages exist; failures degrade gracefully with a logged warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->