### PR TITLE
feat(cli): --citations-file on overview update

### DIFF
--- a/.changeset/citations-file-flag.md
+++ b/.changeset/citations-file-flag.md
@@ -1,0 +1,10 @@
+---
+"@buildinternet/releases": minor
+---
+
+`admin overview update` accepts an optional `--citations-file <path>` pointing
+at a JSON array of inline citations (`{startIndex, endIndex, sourceUrl, title?,
+citedText}[]`). The CLI validates the shape locally and forwards the array to
+`POST /v1/orgs/:slug/overview`, which persists them to `knowledge_page_citations`
+with replace-all semantics. Pairs with the regenerating-overviews skill, which
+now passes the file produced by the agent's response walk.

--- a/bun.lock
+++ b/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "releases-cli",
       "dependencies": {
-        "@buildinternet/releases-api-types": "^0.9.0",
-        "@buildinternet/releases-core": "^0.17.0",
+        "@buildinternet/releases-api-types": "^0.11.0",
+        "@buildinternet/releases-core": "^0.19.0",
         "@buildinternet/releases-lib": "workspace:*",
         "@buildinternet/releases-skills": "workspace:*",
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -27,7 +27,7 @@
     },
     "npm/releases": {
       "name": "@buildinternet/releases",
-      "version": "0.32.0",
+      "version": "0.33.0",
       "bin": {
         "releases": "bin/releases",
       },
@@ -41,31 +41,31 @@
     },
     "npm/releases-darwin-arm64": {
       "name": "@buildinternet/releases-darwin-arm64",
-      "version": "0.32.0",
+      "version": "0.33.0",
     },
     "npm/releases-darwin-x64": {
       "name": "@buildinternet/releases-darwin-x64",
-      "version": "0.32.0",
+      "version": "0.33.0",
     },
     "npm/releases-linux-arm64": {
       "name": "@buildinternet/releases-linux-arm64",
-      "version": "0.32.0",
+      "version": "0.33.0",
     },
     "npm/releases-linux-x64": {
       "name": "@buildinternet/releases-linux-x64",
-      "version": "0.32.0",
+      "version": "0.33.0",
     },
     "npm/releases-windows-x64": {
       "name": "@buildinternet/releases-windows-x64",
-      "version": "0.32.0",
+      "version": "0.33.0",
     },
     "packages/lib": {
       "name": "@buildinternet/releases-lib",
-      "version": "0.32.0",
+      "version": "0.33.0",
     },
     "packages/skills": {
       "name": "@buildinternet/releases-skills",
-      "version": "0.32.0",
+      "version": "0.33.0",
     },
   },
   "packages": {
@@ -73,9 +73,9 @@
 
     "@buildinternet/releases": ["@buildinternet/releases@workspace:npm/releases"],
 
-    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.9.0", "", { "dependencies": { "@buildinternet/releases-core": "^0.18.0", "zod": "^4.3.6" } }, "sha512-bGubh5jlDs9Hl4oyRmGbKTlVmKpg5auvDN3vUg+ay5Jz/p6Vy5yOjOu0d4P492lVuzJTDIYYbLJhJ1do3o8mhQ=="],
+    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.11.0", "", { "dependencies": { "@buildinternet/releases-core": "^0.19.0", "zod": "^4.3.6" } }, "sha512-lVoD1/0+7JTcEGaeoYZuiechJ8D2ibX33k/PPy1UxR73AaX6ZnWS4fJU45o8yQ++mmi5oBVEAOVBQlSvfUWWhQ=="],
 
-    "@buildinternet/releases-core": ["@buildinternet/releases-core@0.17.0", "", { "dependencies": { "drizzle-orm": "^0.45.2", "js-tiktoken": "^1.0.21", "nanoid": "^5.1.7" } }, "sha512-ijIcgPHqAG7Jb2dFD83l6FRXN0XPLi02bqWomQneM+tkes9vfENg7WXx++rNPyMaHoe5Y1Gb0eZn6evNUr/rnA=="],
+    "@buildinternet/releases-core": ["@buildinternet/releases-core@0.19.0", "", { "dependencies": { "drizzle-orm": "^0.45.2", "js-tiktoken": "^1.0.21", "nanoid": "^5.1.7" } }, "sha512-8E/bShlB5rsFNryN+fRTUf4z/Y20ChzMjhTR4IBJAD426w7Mn5T0pdvzlsjOZg19GbYGXmQklqPRhJa41p+LiA=="],
 
     "@buildinternet/releases-darwin-arm64": ["@buildinternet/releases-darwin-arm64@workspace:npm/releases-darwin-arm64"],
 
@@ -554,8 +554,6 @@
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
-
-    "@buildinternet/releases-api-types/@buildinternet/releases-core": ["@buildinternet/releases-core@0.18.0", "", { "dependencies": { "drizzle-orm": "^0.45.2", "js-tiktoken": "^1.0.21", "nanoid": "^5.1.7" } }, "sha512-L4CdqRwg+73OAYKJdByvfDqqF2i86q3aTuRdjgBaa3KHwd123pYi65pwd8Qyq3rS9nw3I0fmkqmQKrQHle2xUw=="],
 
     "@changesets/apply-release-plan/prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
 

--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
   },
   "homepage": "https://releases.sh",
   "dependencies": {
-    "@buildinternet/releases-api-types": "^0.9.0",
-    "@buildinternet/releases-core": "^0.17.0",
+    "@buildinternet/releases-api-types": "^0.11.0",
+    "@buildinternet/releases-core": "^0.19.0",
     "@buildinternet/releases-lib": "workspace:*",
     "@buildinternet/releases-skills": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1116,12 +1116,25 @@ export async function getPlaybook(identifier: string): Promise<KnowledgePage | n
   return apiFetch<KnowledgePage | null>(`/v1/orgs/${encodeURIComponent(identifier)}/playbook`);
 }
 
+// Defined locally until @buildinternet/releases-api-types ships an OverviewCitation
+// export. Mirror the wire shape from workers/api/src/routes/overview.ts —
+// startIndex/endIndex are character offsets into the overview body, sourceUrl
+// is the originating release URL, citedText is the verbatim quote.
+export interface OverviewCitation {
+  startIndex: number;
+  endIndex: number;
+  sourceUrl: string;
+  title?: string | null;
+  citedText: string;
+}
+
 export async function upsertOverview(
   orgSlug: string,
   data: {
     content: string;
     releaseCount: number;
     lastContributingReleaseAt?: string | null;
+    citations?: OverviewCitation[];
   },
 ): Promise<void> {
   await apiFetch(`/v1/orgs/${encodeURIComponent(orgSlug)}/overview`, {

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -36,6 +36,7 @@ import type {
 import type { ListResponse } from "@buildinternet/releases-core/cli-contracts";
 import type {
   DomainLookupResponse,
+  OverviewCitation,
   OverviewInputsCheck,
   OverviewManifestResponse,
   OverviewManifestRow,
@@ -52,6 +53,7 @@ import type {
 } from "@buildinternet/releases-api-types";
 export type {
   DomainLookupResponse,
+  OverviewCitation,
   OverviewInputsCheck,
   OverviewManifestResponse,
   OverviewManifestRow,
@@ -1114,18 +1116,6 @@ export async function getOverview(
 
 export async function getPlaybook(identifier: string): Promise<KnowledgePage | null> {
   return apiFetch<KnowledgePage | null>(`/v1/orgs/${encodeURIComponent(identifier)}/playbook`);
-}
-
-// Defined locally until @buildinternet/releases-api-types ships an OverviewCitation
-// export. Mirror the wire shape from workers/api/src/routes/overview.ts —
-// startIndex/endIndex are character offsets into the overview body, sourceUrl
-// is the originating release URL, citedText is the verbatim quote.
-export interface OverviewCitation {
-  startIndex: number;
-  endIndex: number;
-  sourceUrl: string;
-  title?: string | null;
-  citedText: string;
 }
 
 export async function upsertOverview(

--- a/src/cli/commands/admin/overview.ts
+++ b/src/cli/commands/admin/overview.ts
@@ -16,6 +16,7 @@ import {
   getOverviewInputsCheck,
   getOverviewManifest,
   upsertOverview,
+  type OverviewCitation,
   type OverviewManifestRow,
 } from "../../../api/client.js";
 import { orgNotFound } from "../../suggest.js";
@@ -32,6 +33,7 @@ import {
 import type { OrgListItem } from "@buildinternet/releases-api-types";
 import { computePagination } from "@buildinternet/releases-core/cli-contracts";
 import { unescapeHtmlEntities } from "./overview/unescape-html.js";
+import { parseCitationsJson, ParseCitationsError } from "./overview/parse-citations.js";
 import { readContentArg } from "../../../lib/input.js";
 import { warnDeprecatedAlias } from "../../../lib/deprecated-alias.js";
 
@@ -56,6 +58,7 @@ interface OverviewGetOpts {
 
 interface OverviewUpdateOpts {
   contentFile: string;
+  citationsFile?: string;
   releaseCount?: string;
   lastContributingAt?: string;
   unescapeHtml?: boolean;
@@ -127,6 +130,20 @@ async function overviewUpdateAction(
     process.exit(2);
   }
 
+  let citations: OverviewCitation[] | undefined;
+  if (opts.citationsFile !== undefined) {
+    const raw = await readContentArg(opts.citationsFile);
+    try {
+      citations = parseCitationsJson(raw, opts.citationsFile);
+    } catch (err) {
+      if (err instanceof ParseCitationsError) {
+        logger.error(err.message);
+        process.exit(1);
+      }
+      throw err;
+    }
+  }
+
   let releaseCount = parsePositiveIntFlag("release-count", opts.releaseCount);
   let lastContributingAt = opts.lastContributingAt;
 
@@ -140,6 +157,7 @@ async function overviewUpdateAction(
     content,
     releaseCount,
     lastContributingReleaseAt: lastContributingAt ?? null,
+    citations,
   });
 
   if (opts.json) {
@@ -148,10 +166,12 @@ async function overviewUpdateAction(
       chars: content.length,
       releaseCount,
       lastContributingReleaseAt: lastContributingAt ?? null,
+      citations: citations?.length ?? 0,
     });
   } else {
+    const citationsLabel = citations ? `, ${citations.length} citations` : "";
     logger.info(
-      `Overview written for ${org.name}: ${content.length} chars, ${releaseCount} releases.`,
+      `Overview written for ${org.name}: ${content.length} chars, ${releaseCount} releases${citationsLabel}.`,
     );
   }
 }
@@ -601,6 +621,10 @@ result with \`releases admin overview update\`.`,
     .argument("<org>", "Organization slug or ID")
     .requiredOption("--content-file <path>", "Path to a markdown file containing the overview")
     .option(
+      "--citations-file <path>",
+      "Path to a JSON array of inline source citations ({startIndex,endIndex,sourceUrl,title?,citedText})",
+    )
+    .option(
       "--release-count <n>",
       "Number of releases the overview reflects (defaults to totalAvailable from inputs)",
     )
@@ -616,10 +640,15 @@ result with \`releases admin overview update\`.`,
 Examples:
   releases admin overview update vercel --content-file /tmp/vercel-overview.md
   releases admin overview update vercel --content-file - --json   (reads stdin)
+  releases admin overview update vercel --content-file /tmp/o.md --citations-file /tmp/c.json
 
 Writes via POST /v1/orgs/:slug/overview. Last-write-wins on conflict.
 When --release-count or --last-contributing-at are omitted, the CLI re-fetches
-overview-inputs to derive them.`,
+overview-inputs to derive them.
+
+Citations are replace-all on every write — omitting --citations-file CLEARS
+any existing citations on the page. Pass an empty-array file to be explicit,
+or include a non-empty array to swap them out.`,
     )
     .action(overviewUpdateAction);
 
@@ -664,6 +693,7 @@ overview-inputs to derive them.`,
     .description("(deprecated — use overview update) Upload a generated overview body")
     .argument("<org>", "Organization slug or ID")
     .requiredOption("--content-file <path>", "Path to a markdown file containing the overview")
+    .option("--citations-file <path>", "Path to a JSON array of inline source citations")
     .option("--release-count <n>", "Number of releases the overview reflects")
     .option("--last-contributing-at <iso>", "ISO timestamp of the most recent release reflected")
     .option("--unescape-html", "Decode HTML entities before uploading")

--- a/src/cli/commands/admin/overview/parse-citations.ts
+++ b/src/cli/commands/admin/overview/parse-citations.ts
@@ -1,0 +1,52 @@
+import type { OverviewCitation } from "../../../../api/client.js";
+
+export class ParseCitationsError extends Error {}
+
+/**
+ * Parse a citations JSON file. Shape mirrors the wire contract:
+ * `[{ startIndex, endIndex, sourceUrl, title?, citedText }, ...]`. The API
+ * worker validates and rejects bad spans with `400 bad_citations`, but failing
+ * client-side keeps the error message close to the offending file.
+ *
+ * Throws `ParseCitationsError` with a single-line message — the CLI command
+ * surface logs and exits 1; tests assert the message.
+ */
+export function parseCitationsJson(raw: string, source: string): OverviewCitation[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new ParseCitationsError(
+      `citations-file ${source}: invalid JSON (${err instanceof Error ? err.message : String(err)})`,
+    );
+  }
+  if (!Array.isArray(parsed)) {
+    throw new ParseCitationsError(`citations-file ${source}: expected a JSON array`);
+  }
+  const out: OverviewCitation[] = [];
+  for (let i = 0; i < parsed.length; i++) {
+    const c = parsed[i] as Partial<OverviewCitation> | null;
+    if (!c || typeof c !== "object") {
+      throw new ParseCitationsError(`citations-file ${source}: citations[${i}] must be an object`);
+    }
+    if (typeof c.startIndex !== "number" || typeof c.endIndex !== "number") {
+      throw new ParseCitationsError(
+        `citations-file ${source}: citations[${i}] missing numeric startIndex/endIndex`,
+      );
+    }
+    if (typeof c.sourceUrl !== "string" || !c.sourceUrl) {
+      throw new ParseCitationsError(`citations-file ${source}: citations[${i}] missing sourceUrl`);
+    }
+    if (typeof c.citedText !== "string" || !c.citedText) {
+      throw new ParseCitationsError(`citations-file ${source}: citations[${i}] missing citedText`);
+    }
+    out.push({
+      startIndex: c.startIndex,
+      endIndex: c.endIndex,
+      sourceUrl: c.sourceUrl,
+      title: typeof c.title === "string" ? c.title : null,
+      citedText: c.citedText,
+    });
+  }
+  return out;
+}

--- a/tests/cli/overview-subcommands.test.ts
+++ b/tests/cli/overview-subcommands.test.ts
@@ -57,6 +57,13 @@ describe("admin overview subcommand group", () => {
     expect(exitCode).toBe(0);
     expect(stdout).toContain("--content-file");
   });
+
+  it("`overview update --help` exposes --citations-file", () => {
+    const { stdout, exitCode } = runCli(["admin", "overview", "update", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--citations-file");
+    expect(stdout).toContain("startIndex");
+  });
 });
 
 describe("deprecated overview kebab aliases", () => {

--- a/tests/cli/parse-citations.test.ts
+++ b/tests/cli/parse-citations.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "bun:test";
+import {
+  parseCitationsJson,
+  ParseCitationsError,
+} from "../../src/cli/commands/admin/overview/parse-citations.js";
+
+const SRC = "/tmp/cite.json";
+
+describe("parseCitationsJson", () => {
+  it("accepts a well-formed citation array", () => {
+    const raw = JSON.stringify([
+      {
+        startIndex: 0,
+        endIndex: 10,
+        sourceUrl: "https://acme.com/post",
+        title: "v2 launch",
+        citedText: "Acme shipped v2",
+      },
+    ]);
+    const out = parseCitationsJson(raw, SRC);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toEqual({
+      startIndex: 0,
+      endIndex: 10,
+      sourceUrl: "https://acme.com/post",
+      title: "v2 launch",
+      citedText: "Acme shipped v2",
+    });
+  });
+
+  it("accepts an empty array", () => {
+    expect(parseCitationsJson("[]", SRC)).toEqual([]);
+  });
+
+  it("normalizes missing title to null (server treats undefined === null)", () => {
+    const raw = JSON.stringify([
+      { startIndex: 0, endIndex: 5, sourceUrl: "https://x.com", citedText: "hello" },
+    ]);
+    const out = parseCitationsJson(raw, SRC);
+    expect(out[0]?.title).toBeNull();
+  });
+
+  it("rejects malformed JSON with the source path in the error", () => {
+    expect(() => parseCitationsJson("not json", SRC)).toThrow(ParseCitationsError);
+    try {
+      parseCitationsJson("not json", SRC);
+    } catch (err) {
+      expect((err as Error).message).toContain(SRC);
+      expect((err as Error).message).toContain("invalid JSON");
+    }
+  });
+
+  it("rejects a non-array root", () => {
+    expect(() => parseCitationsJson("{}", SRC)).toThrow(/expected a JSON array/);
+  });
+
+  it("rejects a citation missing sourceUrl", () => {
+    const raw = JSON.stringify([{ startIndex: 0, endIndex: 5, citedText: "hi" }]);
+    expect(() => parseCitationsJson(raw, SRC)).toThrow(/sourceUrl/);
+  });
+
+  it("rejects a citation missing citedText", () => {
+    const raw = JSON.stringify([{ startIndex: 0, endIndex: 5, sourceUrl: "https://x.com" }]);
+    expect(() => parseCitationsJson(raw, SRC)).toThrow(/citedText/);
+  });
+
+  it("rejects a citation with non-numeric span", () => {
+    const raw = JSON.stringify([
+      { startIndex: "0", endIndex: 5, sourceUrl: "https://x.com", citedText: "hi" },
+    ]);
+    expect(() => parseCitationsJson(raw, SRC)).toThrow(/startIndex\/endIndex/);
+  });
+
+  it("rejects a null entry inside the array", () => {
+    expect(() => parseCitationsJson("[null]", SRC)).toThrow(/must be an object/);
+  });
+
+  it("reports the index of the first bad row", () => {
+    const raw = JSON.stringify([
+      { startIndex: 0, endIndex: 5, sourceUrl: "https://x.com", citedText: "hi" },
+      { startIndex: 0, endIndex: 5, sourceUrl: "https://y.com" }, // missing citedText
+    ]);
+    expect(() => parseCitationsJson(raw, SRC)).toThrow(/citations\[1\]/);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 of [buildinternet/releases#846](https://github.com/buildinternet/releases/issues/846). Adds `--citations-file <path>` to `releases admin overview update` so the regenerating-overviews skill can persist inline source citations alongside the overview body.

- **New flag**: `--citations-file <path>` (and on the deprecated `overview-write` alias). Reads a JSON array of `{ startIndex, endIndex, sourceUrl, title?, citedText }` and forwards it on the `POST /v1/orgs/:slug/overview` body.
- **Local validation**: malformed payloads exit 1 with the file path in the message — the API would 400 with `bad_citations` anyway, but failing client-side keeps the error close to the offending file. Wire spec validation (negative spans, past content end) is server-side; client only checks shape.
- **Replace-all semantics** mirror the API: omitting the flag clears existing citations on the page, an empty-array file is the explicit "remove all" form, a non-empty array swaps them out. Help text calls this out.
- **Type**: `OverviewCitation` is defined locally in `src/api/client.ts` because the published `@buildinternet/releases-api-types@0.10.0` doesn't include the export — monorepo PR #847 forgot the version bump. Once api-types ships with `OverviewCitation`, the local interface gets swapped for the import.

## Notes

- Backwards compatible: existing CLI users without `--citations-file` keep working — the field is omitted from the wire body and the API drops citations only if the page has any (replace-all of an empty set is a no-op).
- `parseCitationsJson` is extracted to `src/cli/commands/admin/overview/parse-citations.ts` so it can be unit-tested without the spawn harness; the command file just wraps the call to surface `ParseCitationsError` as exit 1.
- Changeset: minor bump on `@buildinternet/releases` (cascades to the 8 fixed-group packages).

## Test plan

- [x] `bun test tests/cli/parse-citations.test.ts` — 10 unit tests (happy path, empty array, missing title→null, malformed JSON, non-array root, missing fields, non-numeric span, null entry, error indexes the bad row)
- [x] `bun test tests/cli/overview-subcommands.test.ts` — surface test confirms `--citations-file` shows in `overview update --help`
- [x] Full suite: 297 pass / 0 fail across 28 files
- [x] `npx tsc --noEmit` clean
- [x] `bun run lint` clean
- [x] `bun run format:check` clean
- [ ] Manual: regen one staging overview end-to-end with `--citations-file`, then `GET` and verify citations land

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --citations-file to admin overview update to supply inline source citations; supplying the file validates and replaces stored citations, omitting it clears citations. Command output (JSON and human) now includes citations count.
* **Documentation**
  * Help text updated to document citations format and replace-all/clearing behavior.
* **Tests**
  * Added tests covering citations-file parsing and validation.
* **Chores**
  * Added Changeset entry for the release.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/buildinternet/releases-cli/pull/153)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->