### PR TITLE
feat(cli): release update --title-generated / --title-short / --summary flags

### DIFF
--- a/.changeset/release-update-title-flags.md
+++ b/.changeset/release-update-title-flags.md
@@ -1,0 +1,9 @@
+---
+"@buildinternet/releases": minor
+---
+
+Add `--title-generated`, `--title-short`, and `--summary` flags to `releases release update`. They write through to the API's PATCH /v1/sources/:slug/releases/:id endpoint, which exposes the renamed AI-generated release fields introduced in buildinternet/releases#860.
+
+Pass an empty string to clear a field (e.g. `releases release update rel_xxx --summary=""` writes NULL).
+
+The new fields are accepted by registries running api-types 0.13.0 or later; older registries silently ignore the unknown body keys.

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "releases-cli",
       "dependencies": {
-        "@buildinternet/releases-api-types": "^0.11.0",
+        "@buildinternet/releases-api-types": "^0.13.0",
         "@buildinternet/releases-core": "^0.19.0",
         "@buildinternet/releases-lib": "workspace:*",
         "@buildinternet/releases-skills": "workspace:*",
@@ -27,7 +27,7 @@
     },
     "npm/releases": {
       "name": "@buildinternet/releases",
-      "version": "0.33.0",
+      "version": "0.34.0",
       "bin": {
         "releases": "bin/releases",
       },
@@ -41,31 +41,31 @@
     },
     "npm/releases-darwin-arm64": {
       "name": "@buildinternet/releases-darwin-arm64",
-      "version": "0.33.0",
+      "version": "0.34.0",
     },
     "npm/releases-darwin-x64": {
       "name": "@buildinternet/releases-darwin-x64",
-      "version": "0.33.0",
+      "version": "0.34.0",
     },
     "npm/releases-linux-arm64": {
       "name": "@buildinternet/releases-linux-arm64",
-      "version": "0.33.0",
+      "version": "0.34.0",
     },
     "npm/releases-linux-x64": {
       "name": "@buildinternet/releases-linux-x64",
-      "version": "0.33.0",
+      "version": "0.34.0",
     },
     "npm/releases-windows-x64": {
       "name": "@buildinternet/releases-windows-x64",
-      "version": "0.33.0",
+      "version": "0.34.0",
     },
     "packages/lib": {
       "name": "@buildinternet/releases-lib",
-      "version": "0.33.0",
+      "version": "0.34.0",
     },
     "packages/skills": {
       "name": "@buildinternet/releases-skills",
-      "version": "0.33.0",
+      "version": "0.34.0",
     },
   },
   "packages": {
@@ -73,7 +73,7 @@
 
     "@buildinternet/releases": ["@buildinternet/releases@workspace:npm/releases"],
 
-    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.11.0", "", { "dependencies": { "@buildinternet/releases-core": "^0.19.0", "zod": "^4.3.6" } }, "sha512-lVoD1/0+7JTcEGaeoYZuiechJ8D2ibX33k/PPy1UxR73AaX6ZnWS4fJU45o8yQ++mmi5oBVEAOVBQlSvfUWWhQ=="],
+    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.13.0", "", { "dependencies": { "@buildinternet/releases-core": "^0.19.0", "zod": "^4.3.6" } }, "sha512-YPxhKDiZwDdS87M4Y7HLYg/wfa801LOM5N2ES+dD6GWSRhBdEh1YSmOBOLKHZKFXGaTtZzypdwh2h8KK58m9yQ=="],
 
     "@buildinternet/releases-core": ["@buildinternet/releases-core@0.19.0", "", { "dependencies": { "drizzle-orm": "^0.45.2", "js-tiktoken": "^1.0.21", "nanoid": "^5.1.7" } }, "sha512-8E/bShlB5rsFNryN+fRTUf4z/Y20ChzMjhTR4IBJAD426w7Mn5T0pdvzlsjOZg19GbYGXmQklqPRhJa41p+LiA=="],
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "homepage": "https://releases.sh",
   "dependencies": {
-    "@buildinternet/releases-api-types": "^0.11.0",
+    "@buildinternet/releases-api-types": "^0.13.0",
     "@buildinternet/releases-core": "^0.19.0",
     "@buildinternet/releases-lib": "workspace:*",
     "@buildinternet/releases-skills": "workspace:*",

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -613,6 +613,8 @@ export async function getLatestReleases(opts: {
     publishedAt: r.publishedAt,
     sourceName: r.source.name,
     sourceSlug: r.source.slug,
+    summary: r.summary ?? null,
+    /** @deprecated Use `summary`. Kept populated as an alias during the deprecation window. */
     contentSummary: r.summary ?? null,
     media: toMediaItems(r.media),
   }));

--- a/src/cli/commands/release.ts
+++ b/src/cli/commands/release.ts
@@ -78,6 +78,12 @@ type ReleaseUpdateOpts = {
   title?: string;
   version?: string;
   content?: string;
+  /** AI-generated self-contained headline (#860). */
+  titleGenerated?: string;
+  /** AI-generated smart-brevity headline (#860). */
+  titleShort?: string;
+  /** AI-generated summary (#860). */
+  summary?: string;
   json?: boolean;
   dryRun?: boolean;
 };
@@ -105,6 +111,26 @@ async function releaseUpdateAction(rawId: string, opts: ReleaseUpdateOpts): Prom
     updates.contentHash = hash;
     changes.push(`content → (${opts.content.length} chars)`);
     changes.push(`contentHash → ${hash.slice(0, 12)}…`);
+  }
+
+  // Treat empty strings as "clear" — pass through as null so the API stores
+  // a NULL rather than a literal empty value. The API accepts undefined to
+  // skip the column entirely; a present-but-empty CLI flag is an explicit
+  // request to wipe the field.
+  if (opts.titleGenerated !== undefined) {
+    const v = opts.titleGenerated.length === 0 ? null : opts.titleGenerated;
+    updates.titleGenerated = v;
+    changes.push(v === null ? "titleGenerated → (cleared)" : `titleGenerated → ${v}`);
+  }
+  if (opts.titleShort !== undefined) {
+    const v = opts.titleShort.length === 0 ? null : opts.titleShort;
+    updates.titleShort = v;
+    changes.push(v === null ? "titleShort → (cleared)" : `titleShort → ${v}`);
+  }
+  if (opts.summary !== undefined) {
+    const v = opts.summary.length === 0 ? null : opts.summary;
+    updates.summary = v;
+    changes.push(v === null ? "summary → (cleared)" : `summary → (${opts.summary.length} chars)`);
   }
 
   if (changes.length === 0) {
@@ -240,6 +266,15 @@ export function registerReleaseCommand(program: Command) {
     .option("--title <title>", "Update title")
     .option("--version <version>", "Update version")
     .option("--content <content>", "Update content (recomputes contentHash)")
+    .option(
+      "--title-generated <title>",
+      "Update AI-generated self-contained headline (pass empty string to clear)",
+    )
+    .option(
+      "--title-short <title>",
+      "Update AI-generated smart-brevity headline (pass empty string to clear)",
+    )
+    .option("--summary <summary>", "Update AI-generated summary (pass empty string to clear)")
     .option("--json", "Output as JSON")
     .option("--dry-run", "Show what would change without writing")
     .action(releaseUpdateAction);
@@ -251,6 +286,15 @@ export function registerReleaseCommand(program: Command) {
     .option("--title <title>", "Update title")
     .option("--version <version>", "Update version")
     .option("--content <content>", "Update content (recomputes contentHash)")
+    .option(
+      "--title-generated <title>",
+      "Update AI-generated self-contained headline (pass empty string to clear)",
+    )
+    .option(
+      "--title-short <title>",
+      "Update AI-generated smart-brevity headline (pass empty string to clear)",
+    )
+    .option("--summary <summary>", "Update AI-generated summary (pass empty string to clear)")
     .option("--json", "Output as JSON")
     .option("--dry-run", "Show what would change without writing")
     .action(


### PR DESCRIPTION
## Summary

Adds three flags on `releases release update` that map to the renamed AI-generated release columns exposed by the registry's PATCH endpoint (buildinternet/releases#860 / #861):

```
--title-generated   AI-generated self-contained headline
--title-short       AI-generated smart-brevity headline
--summary           AI-generated summary
```

Pass an empty string to clear a field, e.g. `releases release update rel_xxx --summary=""` writes NULL.

## Compatibility

The flags ride the existing generic-payload PATCH wrapper (`updateRelease(id, data: Record<string, unknown>)`), so this PR doesn't strictly require the api-types bump to compile or test. Registries running `@buildinternet/releases-api-types@^0.13.0` (after buildinternet/releases#861 merges and publishes) store the values; older registries silently ignore the unknown body keys.

A follow-up PR can bump the `@buildinternet/releases-api-types` pin in `package.json` to `^0.13.0` once that version is on npm.

## Validation

- [x] `bun test` — 297/297 passing
- [x] `npx tsc --noEmit` clean
- [x] `bun run lint` clean
- [x] `bun run format:check` clean
- [x] Changeset added (`@buildinternet/releases` minor; fixed-group cascades to the eight published packages)

## Test plan

- [ ] After buildinternet/releases#861 merges + deploys, run `releases release update rel_xxx --title-short="Worktree no longer drops commits"` against staging and confirm the value lands in the registry
- [ ] Pass `--summary=""` and confirm the column nulls out


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--title-generated`, `--title-short`, and `--summary` CLI flags to the `release update` command. Pass an empty string to clear any field.

* **Updates**
  * Release objects now include a `summary` field. The `contentSummary` field is deprecated.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/buildinternet/releases-cli/pull/156)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->