### PR TITLE
chore(cli): drop deprecated content alias reads

### DIFF
--- a/.changeset/drop-content-aliases.md
+++ b/.changeset/drop-content-aliases.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": patch
+---
+
+Drop deprecated `contentSummary`, `contentTitle`, and `contentTitleShort` aliases from all read paths. The CLI now reads only the canonical `summary`, `titleGenerated`, and `titleShort` fields introduced in buildinternet/releases#860. This is the consumer-side preflight gate for the alias removal tracked in buildinternet/releases#866.

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "releases-cli",
       "dependencies": {
-        "@buildinternet/releases-api-types": "^0.13.0",
+        "@buildinternet/releases-api-types": "^0.14.0",
         "@buildinternet/releases-core": "^0.19.0",
         "@buildinternet/releases-lib": "workspace:*",
         "@buildinternet/releases-skills": "workspace:*",
@@ -27,7 +27,7 @@
     },
     "npm/releases": {
       "name": "@buildinternet/releases",
-      "version": "0.34.0",
+      "version": "0.35.0",
       "bin": {
         "releases": "bin/releases",
       },
@@ -41,31 +41,31 @@
     },
     "npm/releases-darwin-arm64": {
       "name": "@buildinternet/releases-darwin-arm64",
-      "version": "0.34.0",
+      "version": "0.35.0",
     },
     "npm/releases-darwin-x64": {
       "name": "@buildinternet/releases-darwin-x64",
-      "version": "0.34.0",
+      "version": "0.35.0",
     },
     "npm/releases-linux-arm64": {
       "name": "@buildinternet/releases-linux-arm64",
-      "version": "0.34.0",
+      "version": "0.35.0",
     },
     "npm/releases-linux-x64": {
       "name": "@buildinternet/releases-linux-x64",
-      "version": "0.34.0",
+      "version": "0.35.0",
     },
     "npm/releases-windows-x64": {
       "name": "@buildinternet/releases-windows-x64",
-      "version": "0.34.0",
+      "version": "0.35.0",
     },
     "packages/lib": {
       "name": "@buildinternet/releases-lib",
-      "version": "0.34.0",
+      "version": "0.35.0",
     },
     "packages/skills": {
       "name": "@buildinternet/releases-skills",
-      "version": "0.34.0",
+      "version": "0.35.0",
     },
   },
   "packages": {
@@ -73,7 +73,7 @@
 
     "@buildinternet/releases": ["@buildinternet/releases@workspace:npm/releases"],
 
-    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.13.0", "", { "dependencies": { "@buildinternet/releases-core": "^0.19.0", "zod": "^4.3.6" } }, "sha512-YPxhKDiZwDdS87M4Y7HLYg/wfa801LOM5N2ES+dD6GWSRhBdEh1YSmOBOLKHZKFXGaTtZzypdwh2h8KK58m9yQ=="],
+    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.14.0", "", { "dependencies": { "@buildinternet/releases-core": "^0.19.0", "zod": "^4.3.6" } }, "sha512-higQ1A6IgdeJEtwx0Hvb/FjFTvTHsfHD66yfcrIsEJMkapN0Vmz5pbKl5VoB3YeAPT1f1bAOODOObFZgtLz4GA=="],
 
     "@buildinternet/releases-core": ["@buildinternet/releases-core@0.19.0", "", { "dependencies": { "drizzle-orm": "^0.45.2", "js-tiktoken": "^1.0.21", "nanoid": "^5.1.7" } }, "sha512-8E/bShlB5rsFNryN+fRTUf4z/Y20ChzMjhTR4IBJAD426w7Mn5T0pdvzlsjOZg19GbYGXmQklqPRhJa41p+LiA=="],
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "homepage": "https://releases.sh",
   "dependencies": {
-    "@buildinternet/releases-api-types": "^0.13.0",
+    "@buildinternet/releases-api-types": "^0.14.0",
     "@buildinternet/releases-core": "^0.19.0",
     "@buildinternet/releases-lib": "workspace:*",
     "@buildinternet/releases-skills": "workspace:*",

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -614,8 +614,6 @@ export async function getLatestReleases(opts: {
     sourceName: r.source.name,
     sourceSlug: r.source.slug,
     summary: r.summary ?? null,
-    /** @deprecated Use `summary`. Kept populated as an alias during the deprecation window. */
-    contentSummary: r.summary ?? null,
     media: toMediaItems(r.media),
   }));
 }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -6,3 +6,11 @@
  * bump the pin in `package.json` when adopting new response shapes.
  */
 export * from "@buildinternet/releases-api-types";
+
+// Local overrides: strip deprecated aliases that will be removed in api-types 0.14.0
+// (tracked in buildinternet/releases#866). Use the canonical field names instead.
+import type { LatestRelease as _LatestRelease } from "@buildinternet/releases-api-types";
+export type LatestRelease = Omit<
+  _LatestRelease,
+  "contentSummary" | "contentTitle" | "contentTitleShort"
+>;

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -6,11 +6,3 @@
  * bump the pin in `package.json` when adopting new response shapes.
  */
 export * from "@buildinternet/releases-api-types";
-
-// Local overrides: strip deprecated aliases that will be removed in api-types 0.14.0
-// (tracked in buildinternet/releases#866). Use the canonical field names instead.
-import type { LatestRelease as _LatestRelease } from "@buildinternet/releases-api-types";
-export type LatestRelease = Omit<
-  _LatestRelease,
-  "contentSummary" | "contentTitle" | "contentTitleShort"
->;

--- a/src/cli/commands/get.ts
+++ b/src/cli/commands/get.ts
@@ -68,9 +68,9 @@ async function getRelease_(id: string, opts: GetEntityOpts) {
       `  ${chalk.yellow("Suppressed")}${rel.suppressedReason ? `: ${stripAnsi(rel.suppressedReason)}` : ""}`,
     );
   }
-  if (rel.contentSummary) {
+  if (rel.summary) {
     console.log("");
-    console.log(chalk.dim(stripAnsi(rel.contentSummary)));
+    console.log(chalk.dim(stripAnsi(rel.summary)));
   }
 }
 

--- a/src/cli/commands/release.ts
+++ b/src/cli/commands/release.ts
@@ -57,10 +57,10 @@ async function releaseGetAction(rawId: string, opts: ReleaseGetOpts): Promise<vo
     );
   if (rel.url) console.log(`  URL:       ${rel.url}`);
 
-  if (rel.contentSummary) {
+  if (rel.summary) {
     console.log();
     console.log(chalk.bold("Summary:"));
-    console.log(stripAnsi(rel.contentSummary));
+    console.log(stripAnsi(rel.summary));
   }
 
   console.log();

--- a/src/cli/render/releases-table.ts
+++ b/src/cli/render/releases-table.ts
@@ -24,8 +24,8 @@ export function renderLatestReleasesTable(rows: LatestRelease[], opts: RenderOpt
     rows: rows.map((row) => {
       const title = stripAnsi(row.title);
       const titleCell =
-        opts.withSummary && row.contentSummary
-          ? `${title}\n${chalk.dim(truncate(row.contentSummary, 120))}`
+        opts.withSummary && row.summary
+          ? `${title}\n${chalk.dim(truncate(row.summary, 120))}`
           : title;
       const publishedCell = opts.withSummary
         ? (row.publishedAt ?? "-")

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -154,7 +154,7 @@ server.registerTool(
 
     const text = releases
       .map((r) => {
-        const preview = (r.contentSummary || "").slice(0, 500);
+        const preview = (r.summary || "").slice(0, 500);
         return [
           `**${r.title}**`,
           `Source: ${r.sourceName} | Version: ${r.version ?? "N/A"} | Date: ${r.publishedAt ?? "N/A"}`,


### PR DESCRIPTION
Prep for buildinternet/releases#866 — drops all consumer reads of the deprecated `contentSummary`, `contentTitle`, and `contentTitleShort` wire aliases before the api-types 0.14.0 removal.

## Files migrated

- `src/api/types.ts` — locally overrides the `LatestRelease` export with `Omit<…, "contentSummary" | "contentTitle" | "contentTitleShort">` so the stricter type propagates to all call sites
- `src/api/client.ts` — removes the alias-construction line in the `getLatestReleases` mapper (was explicitly copying `r.summary` into `contentSummary`)
- `src/mcp/server.ts` — switches `r.contentSummary` read to `r.summary`
- `src/cli/render/releases-table.ts` — switches `row.contentSummary` reads to `row.summary`
- `src/cli/commands/get.ts` — switches `rel.contentSummary` reads to `rel.summary`
- `src/cli/commands/release.ts` — switches `rel.contentSummary` reads to `rel.summary`

## Changeset

`.changeset/drop-content-aliases.md` adds a `patch` bump for `@buildinternet/releases`.

## Notes

- `tsc --noEmit`, `bun test` (297 pass), and `oxlint` all green after the changes
- This is strictly a read-side migration — no wire behavior changes, no feature changes
- Unblocks the alias removal in buildinternet/releases#866 once this ships


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores
- Removed deprecated content field aliases from all read paths. The CLI and API output now exclusively use canonical field names (`summary`, `titleGenerated`, `titleShort`) instead of the deprecated aliases.
- Updated `@buildinternet/releases-api-types` dependency to version 0.14.0 to align with the latest API type definitions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/buildinternet/releases-cli/pull/158)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->