### PR TITLE
docs(skills): note categories overlay + alias resolution

### DIFF
--- a/plugins/claude/releases/skills/releases-cli/references/reader.md
+++ b/plugins/claude/releases/skills/releases-cli/references/reader.md
@@ -91,7 +91,7 @@ releases categories          # list the canonical category values
 releases categories --json
 ```
 
-The category list is fixed — adding a new category requires a code change in `@buildinternet/releases-core`.
+The category list is fixed — adding a new category requires a code change in `@buildinternet/releases-core`. Each canonical slug supports an optional editable overlay (display-name override, description byline, aliases) managed via `PATCH /v1/categories/:slug` on the API. Alias inputs (e.g. `e-commerce`) are resolved to their canonical slug on write paths and 301-redirect on read paths.
 
 ## Changelog slicing (admin CLI, reader endpoint)
 


### PR DESCRIPTION
## Summary

- Update the `releases-cli` reader skill reference to mention the editable categories overlay (`PATCH /v1/categories/:slug`) and the alias-resolution behavior on read/write paths.
- Keeps the skill in sync with the API change shipped in [buildinternet/releases#889](https://github.com/buildinternet/releases/pull/889).

## Test plan

- [ ] Docs-only change — no code paths affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated reader commands documentation to clarify category behavior: fixed category slugs with optional editable overlays, alias resolution to canonical slugs on write, and 301 redirect handling on read requests.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/buildinternet/releases-cli/pull/160)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->