### PR TITLE
chore: changeset for categories overlay reader note

### DIFF
--- a/.changeset/categories-overlay-note.md
+++ b/.changeset/categories-overlay-note.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": patch
+---
+
+Update the reader skill reference to mention the editable categories overlay (`PATCH /v1/categories/:slug`) and alias resolution behavior introduced in buildinternet/releases#889.


### PR DESCRIPTION
## Summary

- Adds a `patch` changeset targeting `@buildinternet/releases` so the docs-only skill-reference update from [#160](https://github.com/buildinternet/releases-cli/pull/160) actually ships to consumers.
- Cascades via the existing fixed group to the 7 sibling packages on the next "version packages" PR.

## Test plan

- [ ] Changesets bot picks this up and rolls it into the next version-packages PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to include details about the categories overlay endpoint and alias resolution behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/buildinternet/releases-cli/pull/161)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->