### PR TITLE
chore: bump releases-core to ^0.21.0

### DIFF
--- a/.changeset/bump-core-021.md
+++ b/.changeset/bump-core-021.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": patch
+---
+
+Bump `@buildinternet/releases-core` to `^0.21.0` and `@buildinternet/releases-api-types` to `^0.16.0` so the bundled `CATEGORIES` constant picks up the `commerce`, `crm`, `finance`, and `productivity` slugs added in buildinternet/releases#889 and buildinternet/releases#891. Without this, `releases admin org update --category crm` (and the three other new slugs) rejects locally even though the API accepts them.

--- a/bun.lock
+++ b/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "releases-cli",
       "dependencies": {
-        "@buildinternet/releases-api-types": "^0.14.0",
-        "@buildinternet/releases-core": "^0.19.0",
+        "@buildinternet/releases-api-types": "^0.16.0",
+        "@buildinternet/releases-core": "^0.21.0",
         "@buildinternet/releases-lib": "workspace:*",
         "@buildinternet/releases-skills": "workspace:*",
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -27,7 +27,7 @@
     },
     "npm/releases": {
       "name": "@buildinternet/releases",
-      "version": "0.35.0",
+      "version": "0.35.2",
       "bin": {
         "releases": "bin/releases",
       },
@@ -41,31 +41,31 @@
     },
     "npm/releases-darwin-arm64": {
       "name": "@buildinternet/releases-darwin-arm64",
-      "version": "0.35.0",
+      "version": "0.35.2",
     },
     "npm/releases-darwin-x64": {
       "name": "@buildinternet/releases-darwin-x64",
-      "version": "0.35.0",
+      "version": "0.35.2",
     },
     "npm/releases-linux-arm64": {
       "name": "@buildinternet/releases-linux-arm64",
-      "version": "0.35.0",
+      "version": "0.35.2",
     },
     "npm/releases-linux-x64": {
       "name": "@buildinternet/releases-linux-x64",
-      "version": "0.35.0",
+      "version": "0.35.2",
     },
     "npm/releases-windows-x64": {
       "name": "@buildinternet/releases-windows-x64",
-      "version": "0.35.0",
+      "version": "0.35.2",
     },
     "packages/lib": {
       "name": "@buildinternet/releases-lib",
-      "version": "0.35.0",
+      "version": "0.35.2",
     },
     "packages/skills": {
       "name": "@buildinternet/releases-skills",
-      "version": "0.35.0",
+      "version": "0.35.2",
     },
   },
   "packages": {
@@ -73,9 +73,9 @@
 
     "@buildinternet/releases": ["@buildinternet/releases@workspace:npm/releases"],
 
-    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.14.0", "", { "dependencies": { "@buildinternet/releases-core": "^0.19.0", "zod": "^4.3.6" } }, "sha512-higQ1A6IgdeJEtwx0Hvb/FjFTvTHsfHD66yfcrIsEJMkapN0Vmz5pbKl5VoB3YeAPT1f1bAOODOObFZgtLz4GA=="],
+    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.16.0", "", { "dependencies": { "@buildinternet/releases-core": "^0.21.0", "zod": "^4.3.6" } }, "sha512-CCfkwVImIT3nLW79PEd9iuy1RD8e7dtr/BKli3okTZH9NdxlHyfsBH0eEH49MoR9CR94OULHCzd+aQLqi9TJmw=="],
 
-    "@buildinternet/releases-core": ["@buildinternet/releases-core@0.19.0", "", { "dependencies": { "drizzle-orm": "^0.45.2", "js-tiktoken": "^1.0.21", "nanoid": "^5.1.7" } }, "sha512-8E/bShlB5rsFNryN+fRTUf4z/Y20ChzMjhTR4IBJAD426w7Mn5T0pdvzlsjOZg19GbYGXmQklqPRhJa41p+LiA=="],
+    "@buildinternet/releases-core": ["@buildinternet/releases-core@0.21.0", "", { "dependencies": { "drizzle-orm": "^0.45.2", "js-tiktoken": "^1.0.21", "nanoid": "^5.1.7" } }, "sha512-tWLBc3BvBot1Rrb5j3X2RPSogcgm5+hwFlnQocMTHFgF8gtF4jZRM7Mc+HoGNOlMJHacH1uyqt2nDcqTGZaNZQ=="],
 
     "@buildinternet/releases-darwin-arm64": ["@buildinternet/releases-darwin-arm64@workspace:npm/releases-darwin-arm64"],
 

--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
   },
   "homepage": "https://releases.sh",
   "dependencies": {
-    "@buildinternet/releases-api-types": "^0.14.0",
-    "@buildinternet/releases-core": "^0.19.0",
+    "@buildinternet/releases-api-types": "^0.16.0",
+    "@buildinternet/releases-core": "^0.21.0",
     "@buildinternet/releases-lib": "workspace:*",
     "@buildinternet/releases-skills": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.29.0",


### PR DESCRIPTION
## Summary

- Bumps `@buildinternet/releases-core` to `^0.21.0` and `@buildinternet/releases-api-types` to `^0.16.0` so the CLI's bundled `CATEGORIES` validator learns the new canonical slugs: `commerce`, `crm`, `finance`, `productivity`.
- Without this, `releases admin org update --category crm` (and the three other new slugs) rejects locally even though the API accepts the write.
- Includes a `patch` changeset so the fixed-group cascade picks it up on the next version bump.

## Test plan

- [x] `releases categories` lists 14 slugs after the bump
- [x] `releases admin org update lightfield --category crm` succeeds end-to-end
- [ ] Changesets bot rolls into the next "version packages" PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to enable support for additional category options (`commerce`, `crm`, `finance`, `productivity`) in admin commands.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/buildinternet/releases-cli/pull/163)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->