### PR TITLE
feat(search): show collections in search results

### DIFF
--- a/.changeset/search-collections.md
+++ b/.changeset/search-collections.md
@@ -1,0 +1,7 @@
+---
+"@buildinternet/releases": minor
+---
+
+Surface collections in `releases search` output. Direct LIKE matches on the collection's name/slug/description appear in a new "Collections" section, alongside member rollups for collections containing one of the matched orgs (with an `↳ includes …` hint). Use `--type collections` to narrow to that section. JSON output includes a new `collections` array on the response shell.
+
+Forward-compatible: the field is read as optional, so older API deployments mid-rollout still work — they just return `undefined` and the section stays empty until the API ships the matching change (`buildinternet/releases#955`).

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -15,12 +15,16 @@ function parseMode(raw: string | undefined): SearchMode | undefined {
   throw new Error(`Invalid --mode value: "${raw}". Expected one of: ${SEARCH_MODES.join(", ")}.`);
 }
 
-type SearchSection = "orgs" | "catalog" | "releases";
+type SearchSection = "orgs" | "catalog" | "releases" | "collections";
 
 function normalizeType(raw: string): SearchSection {
   if (raw === "products") return "catalog";
-  if (raw === "orgs" || raw === "catalog" || raw === "releases") return raw;
-  throw new Error(`Invalid --type value: "${raw}". Expected one of: orgs, catalog, releases.`);
+  if (raw === "orgs" || raw === "catalog" || raw === "releases" || raw === "collections") {
+    return raw;
+  }
+  throw new Error(
+    `Invalid --type value: "${raw}". Expected one of: orgs, catalog, releases, collections.`,
+  );
 }
 
 const PREVIEW_LIMIT = 5;
@@ -116,7 +120,7 @@ export function registerSearchCommand(program: Command) {
     .description("Search across organizations, the catalog, and releases")
     .argument("<query>", "Search query")
     .option("-l, --limit <n>", "Max results per type", "10")
-    .option("--type <type>", "Limit to a result type: orgs, catalog, releases")
+    .option("--type <type>", "Limit to a result type: orgs, catalog, releases, collections")
     .option("--mode <mode>", `Search mode: ${SEARCH_MODES.join(" | ")}`)
     .option(
       "--domain <domain>",
@@ -148,7 +152,7 @@ export function registerSearchCommand(program: Command) {
         try {
           types = opts.type
             ? [normalizeType(opts.type)]
-            : (["orgs", "catalog", "releases"] as const);
+            : (["orgs", "catalog", "releases", "collections"] as const);
         } catch (err) {
           logger.error(err instanceof Error ? err.message : String(err));
           process.exit(1);
@@ -181,11 +185,29 @@ export function registerSearchCommand(program: Command) {
           | UnifiedSearchResponse["catalog"]
           | undefined;
         const catalog: UnifiedSearchResponse["catalog"] = response.catalog ?? legacy ?? [];
+        // `collections` is optional on the wire — older API deployments emit it
+        // as `undefined`. Treat missing and `[]` identically so the CLI doesn't
+        // blow up before the feature lands in production. Inline the shape so
+        // the CLI can read it before the api-types pin bumps to a version that
+        // exports the field on UnifiedSearchResponse.
+        type SearchCollectionHit = {
+          slug: string;
+          name: string;
+          description: string | null;
+          memberCount: number;
+          via: "direct" | "member";
+          score?: number;
+          matchedOrgSlugs?: string[];
+        };
+        const collections: SearchCollectionHit[] =
+          (response as unknown as { collections?: SearchCollectionHit[] }).collections ?? [];
 
         if (opts.json) {
           const filtered: Record<string, unknown> = { query: response.query };
           for (const t of types) {
-            filtered[t] = t === "catalog" ? catalog : response[t];
+            if (t === "catalog") filtered[t] = catalog;
+            else if (t === "collections") filtered[t] = collections;
+            else filtered[t] = response[t];
           }
           if (response.mode !== undefined) filtered.mode = response.mode;
           if (response.degraded !== undefined) filtered.degraded = response.degraded;
@@ -233,6 +255,25 @@ export function registerSearchCommand(program: Command) {
           }
           console.log();
           totalResults += catalog.length;
+        }
+
+        if (types.includes("collections") && collections.length > 0) {
+          console.log(chalk.bold.underline("Collections"));
+          for (const c of collections) {
+            const count = c.memberCount === 1 ? "1 member" : `${c.memberCount} members`;
+            console.log(
+              `  ${chalk.cyan.bold(stripAnsi(c.name))} ${chalk.dim(`(${c.slug})`)} ${chalk.dim(`— ${count}`)}`,
+            );
+            if (c.via === "member" && c.matchedOrgSlugs && c.matchedOrgSlugs.length > 0) {
+              console.log(chalk.dim(`  ↳ includes ${c.matchedOrgSlugs.join(", ")}`));
+            }
+            if (c.description) {
+              const desc = stripAnsi(c.description);
+              console.log(chalk.dim(`  ${desc}`));
+            }
+          }
+          console.log();
+          totalResults += collections.length;
         }
 
         if (types.includes("releases") && response.releases.length > 0) {

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -117,7 +117,7 @@ function renderLookup(lookup: LookupResultPayload, query: string): void {
 export function registerSearchCommand(program: Command) {
   program
     .command("search")
-    .description("Search across organizations, the catalog, and releases")
+    .description("Search across organizations, collections, the catalog, and releases")
     .argument("<query>", "Search query")
     .option("-l, --limit <n>", "Max results per type", "10")
     .option("--type <type>", "Limit to a result type: orgs, catalog, releases, collections")


### PR DESCRIPTION
## Summary

- Add a "Collections" section to `releases search`: direct LIKE hits on a collection's name/description, plus member rollups for collections containing a matched org (rendered with a `↳ includes vercel, anthropic` hint).
- New `--type collections` value to narrow to that section.
- JSON output gains a `collections` array on the response shell.

Forward-compatible: the wire field is read as optional via an inline type, so the CLI keeps working against the currently published `@buildinternet/releases-api-types@^0.16.0`. Once the api-types pin bumps to a release that exports `SearchCollectionHit` on `UnifiedSearchResponse`, the inline type can be dropped.

Pairs with `buildinternet/releases#955` (monorepo PR that ships the `/v1/search` and MCP changes).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `bun run lint` clean
- [x] `bun run format:check` clean
- [x] All 297 CLI tests pass
- [ ] After monorepo #955 deploys: run `releases search "anthropic"` and confirm Frontier AI Labs appears under "Collections" with `↳ includes anthropic` (member rollup)
- [ ] Run `releases search "frontier"` and confirm Frontier AI Labs appears as a direct hit (no rollup hint)
- [ ] Run `releases search "anthropic" --type collections --json` and confirm only the collections array is populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Search command now includes a dedicated "Collections" section in results.
  * Collections section displays name/slug/description matches and indicates which matched organizations are included.
  * New `--type collections` flag to filter search results to collections only.
  * JSON responses now include a top-level `collections` array with collection results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/buildinternet/releases-cli/pull/166)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->