### PR TITLE
feat(cli): richer, self-explanatory `releases get` output for all entity kinds

### DIFF
--- a/.changeset/get-response-utility.md
+++ b/.changeset/get-response-utility.md
@@ -1,0 +1,14 @@
+---
+"@buildinternet/releases": minor
+---
+
+Improve the default `releases get` output for all entity kinds so the response is useful on its own without flag discovery, while staying token-efficient via progressive disclosure to the dedicated drill-in commands.
+
+- **Release**: the summary is now labeled `Summary · AI-generated, abbreviated` (it was unlabeled before, so callers couldn't tell it wasn't the full body). Every response ends with a `Next steps` footer that points at `releases release get <id>` for the full content — phrasing flips when no summary is on file yet.
+- **Organization**: now surfaces description, tags, a source breakdown (active / erroring / hidden), and the product list with names + slugs. Latest-releases preview trimmed from 10 to 5. Footer hints at `org get` (overview / accounts / aliases), `org overview`, and the org-scoped release feed.
+- **Product**: previously showed only static metadata. Now adds description, tags, and the product's source list, with footer hints to the org-scoped release feed and to drilling into a specific source.
+- **Source**: previously showed only static metadata. Now adds org/product binding, fetch status (active / erroring / hidden), `lastFetchedAt`, and the latest 5 releases for the source. Footer hints at `list --source`, `fetch-log`, and `release get`.
+
+Also fixes a latent bug in `getProductsByOrg`: `/v1/products` returns a paginated envelope but the client typed the response as a bare array, so every downstream `for/find/filter/map` was silently no-op'ing. That's why the previous `releases org get` Products section never rendered for orgs that had products (e.g. Supabase's Auth / CLI / Client SDK). The client now unwraps the envelope and tolerates the legacy bare-array shape.
+
+JSON output gains a few additive fields (`sources`, `products`, `sourceCount`, `tags`) on the org/product responses; existing fields are unchanged.

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -877,7 +877,15 @@ export async function findProduct(identifier: string): Promise<Product | null> {
 export async function getProductsByOrg(
   orgId: string,
 ): Promise<Array<Product & { sourceCount: number }>> {
-  return apiFetch<Array<Product & { sourceCount: number }>>(`/v1/products?orgId=${orgId}`);
+  // /v1/products returns a paginated envelope; tolerate the legacy bare-array
+  // shape too in case an old worker is ever in the path. Without the unwrap,
+  // every downstream `for/find/filter/map` over the result was silently
+  // iterating an object and yielding nothing — which is what made
+  // `releases org get` skip the Products section even when the org had them.
+  type Row = Product & { sourceCount: number };
+  const raw = await apiFetch<Row[] | ListResponse<Row>>(`/v1/products?orgId=${orgId}`);
+  if (!raw) return [];
+  return Array.isArray(raw) ? raw : raw.items;
 }
 
 export async function updateProduct(

--- a/src/cli/commands/get.ts
+++ b/src/cli/commands/get.ts
@@ -76,6 +76,7 @@ async function getRelease_(id: string, opts: GetEntityOpts) {
   }
   console.log(chalk.dim("Release"));
   console.log(chalk.bold(stripAnsi(rel.title)));
+  console.log(`  ID:        ${rel.id}`);
   if (rel.version) console.log(`  Version:   ${stripAnsi(rel.version)}`);
   console.log(
     `  Source:    ${rel.sourceName ? stripAnsi(rel.sourceName) : chalk.dim("—")} (${rel.sourceSlug ?? chalk.dim("—")})`,
@@ -87,20 +88,39 @@ async function getRelease_(id: string, opts: GetEntityOpts) {
       `  ${chalk.yellow("Suppressed")}${rel.suppressedReason ? `: ${stripAnsi(rel.suppressedReason)}` : ""}`,
     );
   }
+  // Preview tier — never leave the response with only metadata between the
+  // header and the footer. Order of preference:
+  //   1. AI summary (richest)
+  //   2. AI-generated headline (`titleGenerated` / `titleShort`) — cheap
+  //      single-line context for releases the summarizer hasn't reached yet
+  //   3. Slice of the raw content body — last-resort fallback so very old or
+  //      unsummarized releases still show *something* useful before the user
+  //      pivots to `release get`.
   if (rel.summary) {
     console.log("");
     console.log(chalk.dim("Summary  · AI-generated, abbreviated"));
     console.log(stripAnsi(rel.summary));
+  } else if (rel.titleGenerated || rel.titleShort) {
+    console.log("");
+    console.log(chalk.dim("Headline  · AI-generated (no full summary on file yet)"));
+    console.log(stripAnsi(rel.titleGenerated ?? rel.titleShort!));
+  } else if (rel.content && rel.content.trim().length > 0) {
+    const PREVIEW_CHARS = 280;
+    const raw = stripAnsi(rel.content).trim();
+    const truncated = raw.length > PREVIEW_CHARS;
+    console.log("");
+    console.log(
+      chalk.dim(
+        `Preview  · raw content${truncated ? ` (first ${PREVIEW_CHARS} of ${raw.length} chars)` : ""}`,
+      ),
+    );
+    console.log(truncated ? raw.slice(0, PREVIEW_CHARS) + "…" : raw);
   }
 
   // Progressive disclosure: the dispatcher response never includes the full
-  // release body (content can run 10K+ tokens). Point callers at the verbose
-  // command — phrasing differs depending on whether a summary was shown.
-  printFooterHint([
-    rel.summary
-      ? `releases release get ${rel.id}      — full release body (content + metadata)`
-      : `releases release get ${rel.id}      — full release body (no AI summary on file yet)`,
-  ]);
+  // release body (content can run 10K+ tokens). Always point callers at the
+  // verbose command for the complete payload.
+  printFooterHint([`releases release get ${rel.id}      — full release body (content + metadata)`]);
 }
 
 async function getSource(identifier: string, opts: GetEntityOpts) {
@@ -155,6 +175,7 @@ async function renderSource(rawSource: unknown, opts: GetEntityOpts) {
 
   console.log(chalk.dim("Source"));
   console.log(chalk.bold(source.name));
+  console.log(`  ID:         ${source.id}`);
   console.log(`  Slug:       ${source.slug}`);
   console.log(`  Type:       ${source.type}`);
   console.log(`  URL:        ${source.url}`);
@@ -226,6 +247,7 @@ async function renderOrg(
 
   console.log(chalk.dim("Organization"));
   console.log(chalk.bold(org.name));
+  console.log(`  ID:          ${org.id}`);
   console.log(`  Slug:        ${org.slug}`);
   if (org.domain) console.log(`  Domain:      ${org.domain}`);
   if (org.category) console.log(`  Category:    ${org.category}`);
@@ -313,6 +335,7 @@ async function renderProduct(
 
   console.log(chalk.dim("Product"));
   console.log(chalk.bold(product.name));
+  console.log(`  ID:        ${product.id}`);
   console.log(`  Slug:      ${product.slug}`);
   console.log(`  Org:       ${org ? `${org.name} (${org.slug})` : product.orgId}`);
   console.log(`  URL:       ${product.url ?? chalk.dim("—")}`);
@@ -339,8 +362,12 @@ async function renderProduct(
       org
         ? `releases list --org ${org.slug}              — release feed (org-scoped; mixes other products)`
         : "",
+      // Use the typed source ID rather than the bare slug — bare slugs are
+      // per-org-unique since #698, so the same slug under a different org
+      // could misroute this example. Typed `src_…` IDs stay globally unique
+      // and resolve via the bare path regardless of org.
       productSources.length > 0
-        ? `releases get ${productSources[0]!.slug}                    — drill into a source for its release feed`
+        ? `releases get ${productSources[0]!.id}        — drill into a source for its release feed`
         : "",
     ].filter(Boolean),
   );

--- a/src/cli/commands/get.ts
+++ b/src/cli/commands/get.ts
@@ -7,8 +7,13 @@ import {
   getRelease,
   getLatestReleases,
   getOrgCollections,
+  getSourcesByOrg,
+  getProductsByOrg,
+  getTagsForOrg,
+  getTagsForProduct,
 } from "../../api/client.js";
 import type { CollectionListItem } from "@buildinternet/releases-api-types";
+import type { Source } from "@buildinternet/releases-core/schema";
 import { stripAnsi } from "../../lib/sanitize.js";
 import { logger } from "@releases/lib/logger";
 import { renderLatestReleasesTable } from "../render/releases-table.js";
@@ -16,6 +21,21 @@ import { getEntityType, normalizeReleaseId, isLikelyBareId } from "@buildinterne
 import { writeJson } from "../../lib/output.js";
 
 export type GetEntityOpts = { json?: boolean };
+
+/**
+ * Default count for the "Latest releases" preview embedded in get responses.
+ * Kept small so the text output stays scannable / token-efficient — callers
+ * who want more should pivot to `releases list` or the per-entity feed.
+ */
+const PREVIEW_RELEASE_COUNT = 5;
+
+/** Footer hint pointing at the canonical drill-in for fuller detail. */
+function printFooterHint(lines: string[]): void {
+  if (lines.length === 0) return;
+  console.log("");
+  console.log(chalk.dim("Next steps:"));
+  for (const line of lines) console.log(chalk.dim(`  ${line}`));
+}
 
 async function notFound(identifier: string, kind: string, opts: GetEntityOpts): Promise<never> {
   if (opts.json) await writeJson(null);
@@ -56,7 +76,6 @@ async function getRelease_(id: string, opts: GetEntityOpts) {
   }
   console.log(chalk.dim("Release"));
   console.log(chalk.bold(stripAnsi(rel.title)));
-  console.log(`  ID:        ${rel.id}`);
   if (rel.version) console.log(`  Version:   ${stripAnsi(rel.version)}`);
   console.log(
     `  Source:    ${rel.sourceName ? stripAnsi(rel.sourceName) : chalk.dim("—")} (${rel.sourceSlug ?? chalk.dim("—")})`,
@@ -70,8 +89,18 @@ async function getRelease_(id: string, opts: GetEntityOpts) {
   }
   if (rel.summary) {
     console.log("");
-    console.log(chalk.dim(stripAnsi(rel.summary)));
+    console.log(chalk.dim("Summary  · AI-generated, abbreviated"));
+    console.log(stripAnsi(rel.summary));
   }
+
+  // Progressive disclosure: the dispatcher response never includes the full
+  // release body (content can run 10K+ tokens). Point callers at the verbose
+  // command — phrasing differs depending on whether a summary was shown.
+  printFooterHint([
+    rel.summary
+      ? `releases release get ${rel.id}      — full release body (content + metadata)`
+      : `releases release get ${rel.id}      — full release body (no AI summary on file yet)`,
+  ]);
 }
 
 async function getSource(identifier: string, opts: GetEntityOpts) {
@@ -92,32 +121,77 @@ async function getProduct(identifier: string, opts: GetEntityOpts) {
   await renderProduct(product, opts);
 }
 
-async function renderSource(
-  source: {
-    id: string;
-    name: string;
-    slug: string;
-    type: string;
-    url: string;
-    orgId: string | null;
-    productId: string | null;
-  },
-  opts: GetEntityOpts,
-) {
+/** Loose Source shape — `findSource` returns the full row but callers historically
+ * narrowed it. Accept the full schema row so we can surface fetch state. */
+type SourceRow = Source & {
+  // Drizzle-derived fields that aren't in the published narrow Source export
+  // but ARE on the wire (see `packages/core/src/schema.ts`).
+  lastFetchedAt?: string | null;
+  consecutiveErrors?: number | null;
+  isHidden?: boolean | null;
+  description?: string | null;
+};
+
+async function renderSource(rawSource: unknown, opts: GetEntityOpts) {
+  const source = rawSource as SourceRow;
   if (opts.json) {
     await writeJson(source);
     return;
   }
+
+  // Resolve org/product context + a small recent-releases preview in parallel.
+  // Failures degrade silently so a broken sub-call doesn't blank the card.
+  const [org, product, latest] = await Promise.all([
+    source.orgId ? findOrg(source.orgId).catch(() => null) : Promise.resolve(null),
+    source.productId ? findProduct(source.productId).catch(() => null) : Promise.resolve(null),
+    getLatestReleases({ source: source.slug, count: PREVIEW_RELEASE_COUNT }).catch(() => []),
+  ]);
+
+  const statusLabel = source.isHidden
+    ? chalk.red("hidden")
+    : source.consecutiveErrors && source.consecutiveErrors > 0
+      ? chalk.yellow(`erroring (${source.consecutiveErrors} consecutive)`)
+      : chalk.green("active");
+
   console.log(chalk.dim("Source"));
   console.log(chalk.bold(source.name));
-  console.log(`  ID:        ${source.id}`);
-  console.log(`  Slug:      ${source.slug}`);
-  console.log(`  Type:      ${source.type}`);
-  console.log(`  URL:       ${source.url}`);
+  console.log(`  Slug:       ${source.slug}`);
+  console.log(`  Type:       ${source.type}`);
+  console.log(`  URL:        ${source.url}`);
+  if (org) console.log(`  Org:        ${org.name} (${org.slug})`);
+  if (product) console.log(`  Product:    ${product.name} (${product.slug})`);
+  console.log(`  Status:     ${statusLabel}`);
+  if (source.lastFetchedAt) console.log(`  Last fetch: ${source.lastFetchedAt}`);
+
+  console.log("");
+  if (latest.length === 0) {
+    console.log(chalk.dim("No releases yet."));
+  } else {
+    console.log(
+      chalk.dim(
+        `Latest ${latest.length} release${latest.length === 1 ? "" : "s"} (most recent first):`,
+      ),
+    );
+    console.log(renderLatestReleasesTable(latest));
+  }
+
+  printFooterHint([
+    `releases list --source ${source.slug}             — full release feed`,
+    `releases fetch-log ${source.slug}                  — recent fetch attempts and errors`,
+    `releases release get <rel_id>                      — open one release with full content`,
+  ]);
 }
 
 async function renderOrg(
-  org: { id: string; name: string; slug: string; domain: string | null; category: string | null },
+  org: {
+    id: string;
+    name: string;
+    slug: string;
+    domain: string | null;
+    category: string | null;
+  } & {
+    description?: string | null;
+  },
   opts: GetEntityOpts,
 ) {
   // Collections degrade to empty on failure so an unrelated bug in the
@@ -131,22 +205,48 @@ async function renderOrg(
       return [];
     }
   };
-  const [releases, collections] = await Promise.all([
-    getLatestReleases({ org: org.slug, count: 10 }),
+  const [releases, collections, sources, products, tags] = await Promise.all([
+    getLatestReleases({ org: org.slug, count: PREVIEW_RELEASE_COUNT }),
     fetchCollections(),
+    getSourcesByOrg(org.id).catch(() => []),
+    getProductsByOrg(org.id).catch(() => []),
+    getTagsForOrg(org.id).catch(() => []),
   ]);
 
   if (opts.json) {
-    await writeJson({ ...org, releases, collections });
+    await writeJson({ ...org, releases, collections, sources, products, tags });
     return;
   }
 
+  const activeSources = sources.filter((s) => !s.isHidden && !s.consecutiveErrors).length;
+  const erroringSources = sources.filter(
+    (s) => !s.isHidden && s.consecutiveErrors && s.consecutiveErrors > 0,
+  ).length;
+  const hiddenSources = sources.filter((s) => s.isHidden).length;
+
   console.log(chalk.dim("Organization"));
   console.log(chalk.bold(org.name));
-  console.log(`  ID:      ${org.id}`);
-  console.log(`  Slug:    ${org.slug}`);
-  if (org.domain) console.log(`  Domain:  ${org.domain}`);
-  if (org.category) console.log(`  Category: ${org.category}`);
+  console.log(`  Slug:        ${org.slug}`);
+  if (org.domain) console.log(`  Domain:      ${org.domain}`);
+  if (org.category) console.log(`  Category:    ${org.category}`);
+  if (org.description) console.log(`  About:       ${stripAnsi(org.description)}`);
+  if (tags.length > 0) console.log(`  Tags:        ${tags.join(", ")}`);
+  if (sources.length > 0) {
+    const breakdown: string[] = [];
+    if (activeSources) breakdown.push(`${activeSources} active`);
+    if (erroringSources) breakdown.push(chalk.yellow(`${erroringSources} erroring`));
+    if (hiddenSources) breakdown.push(chalk.dim(`${hiddenSources} hidden`));
+    const suffix = breakdown.length > 0 ? ` — ${breakdown.join(", ")}` : "";
+    console.log(`  Sources:     ${sources.length}${suffix}`);
+  }
+  if (products.length > 0) {
+    const names = products
+      .slice(0, 5)
+      .map((p) => `${p.name} ${chalk.dim(`(${p.slug})`)}`)
+      .join(", ");
+    const more = products.length > 5 ? chalk.dim(` +${products.length - 5} more`) : "";
+    console.log(`  Products:    ${products.length} — ${names}${more}`);
+  }
   if (collections.length > 0) {
     const labels = collections.map((c) => `${c.name} ${chalk.dim(`(${c.slug})`)}`).join(", ");
     console.log(`  Collections: ${labels}`);
@@ -154,11 +254,21 @@ async function renderOrg(
 
   console.log("");
   if (releases.length === 0) {
-    console.log(chalk.dim("  No releases yet."));
+    console.log(chalk.dim("No releases yet."));
   } else {
-    console.log(chalk.dim(`Latest ${releases.length} release${releases.length === 1 ? "" : "s"}:`));
+    console.log(
+      chalk.dim(
+        `Latest ${releases.length} release${releases.length === 1 ? "" : "s"} (most recent first):`,
+      ),
+    );
     console.log(renderLatestReleasesTable(releases));
   }
+
+  printFooterHint([
+    `releases org get ${org.slug}                  — accounts, aliases, overview, full source list`,
+    `releases org overview ${org.slug}             — AI-generated rollup`,
+    `releases list --org ${org.slug}               — full release feed`,
+  ]);
 }
 
 async function renderProduct(
@@ -169,21 +279,71 @@ async function renderProduct(
     orgId: string;
     url: string | null;
     category: string | null;
-  },
+  } & { description?: string | null },
   opts: GetEntityOpts,
 ) {
-  const org = await findOrg(product.orgId);
+  // Pull related context concurrently. Each individually-degradable so a
+  // single endpoint failure can't blank the product card.
+  const [org, orgProducts, orgSources, tags] = await Promise.all([
+    findOrg(product.orgId).catch(() => null),
+    getProductsByOrg(product.orgId).catch(() => []),
+    getSourcesByOrg(product.orgId).catch<Source[]>(() => []),
+    getTagsForProduct(product.id).catch(() => []),
+  ]);
+
+  // /v1/sources?orgId=… returns the SourceWithOrg projection, which carries
+  // productSlug/productName but not productId — match on slug to keep this
+  // working without an extra round-trip per source.
+  const productSources = orgSources.filter(
+    (s) => (s as unknown as { productSlug?: string | null }).productSlug === product.slug,
+  );
+  const sourceCountRow = orgProducts.find((p) => p.id === product.id);
+  const sourceCount = sourceCountRow?.sourceCount ?? productSources.length;
+
   if (opts.json) {
-    await writeJson({ ...product, orgSlug: org?.slug ?? null });
+    await writeJson({
+      ...product,
+      orgSlug: org?.slug ?? null,
+      sources: productSources,
+      sourceCount,
+      tags,
+    });
     return;
   }
+
   console.log(chalk.dim("Product"));
   console.log(chalk.bold(product.name));
-  console.log(`  ID:        ${product.id}`);
   console.log(`  Slug:      ${product.slug}`);
   console.log(`  Org:       ${org ? `${org.name} (${org.slug})` : product.orgId}`);
   console.log(`  URL:       ${product.url ?? chalk.dim("—")}`);
   console.log(`  Category:  ${product.category ?? chalk.dim("—")}`);
+  if (product.description) console.log(`  About:     ${stripAnsi(product.description)}`);
+  if (tags.length > 0) console.log(`  Tags:      ${tags.join(", ")}`);
+  if (sourceCount > 0) {
+    const preview = productSources
+      .slice(0, 5)
+      .map((s) => chalk.dim(`(${s.slug})`))
+      .join(" ");
+    const more = productSources.length > 5 ? chalk.dim(` +${productSources.length - 5}`) : "";
+    console.log(`  Sources:   ${sourceCount} ${preview}${more}`);
+  } else {
+    console.log(`  Sources:   ${chalk.dim("none")}`);
+  }
+
+  // No product-scoped "latest releases" endpoint today (releases/latest takes
+  // org or source, not product). Surface the workaround commands directly so
+  // the user doesn't have to discover them — releases-per-org gives the
+  // closest mixed feed, releases-per-source the per-source feed.
+  printFooterHint(
+    [
+      org
+        ? `releases list --org ${org.slug}              — release feed (org-scoped; mixes other products)`
+        : "",
+      productSources.length > 0
+        ? `releases get ${productSources[0]!.slug}                    — drill into a source for its release feed`
+        : "",
+    ].filter(Boolean),
+  );
 }
 
 export function registerGetCommand(program: Command) {

--- a/src/cli/commands/get.ts
+++ b/src/cli/commands/get.ts
@@ -18,7 +18,20 @@ import { stripAnsi } from "../../lib/sanitize.js";
 import { logger } from "@releases/lib/logger";
 import { renderLatestReleasesTable } from "../render/releases-table.js";
 import { getEntityType, normalizeReleaseId, isLikelyBareId } from "@buildinternet/releases-core/id";
+import { countTokensSafe } from "@buildinternet/releases-core/tokens";
 import { writeJson } from "../../lib/output.js";
+
+/** Format a payload-size annotation like `3.2K chars (~800 tokens)` so agents
+ * can decide whether to pull the full content body before they spend the
+ * round-trip. Token count uses `cl100k_base` via tiktoken (within ~5% of
+ * Claude's tokenizer on English prose); see `packages/core/src/tokens.ts`. */
+function formatSize(text: string): string {
+  const chars = text.length;
+  const tokens = countTokensSafe(text);
+  const charsFmt =
+    chars >= 1000 ? `${(chars / 1000).toFixed(chars >= 10_000 ? 0 : 1)}K` : String(chars);
+  return `${charsFmt} chars (~${tokens.toLocaleString()} tokens)`;
+}
 
 export type GetEntityOpts = { json?: boolean };
 
@@ -70,8 +83,13 @@ async function getRelease_(id: string, opts: GetEntityOpts) {
   const result = await getRelease(id);
   if (!result) return notFound(id, "release", opts);
   const rel = result;
+  const contentChars = rel.content?.length ?? 0;
+  const contentTokens = rel.content ? countTokensSafe(rel.content) : 0;
+
   if (opts.json) {
-    await writeJson(rel);
+    // Computed-size annotations land on the JSON shape too so agents don't
+    // have to re-encode the body just to decide whether to pull it.
+    await writeJson({ ...rel, contentChars, contentTokens });
     return;
   }
   console.log(chalk.dim("Release"));
@@ -83,6 +101,7 @@ async function getRelease_(id: string, opts: GetEntityOpts) {
   );
   if (rel.publishedAt) console.log(`  Published: ${rel.publishedAt}`);
   if (rel.url) console.log(`  URL:       ${rel.url}`);
+  if (rel.content) console.log(`  Content:   ${formatSize(rel.content)}`);
   if (rel.suppressed) {
     console.log(
       `  ${chalk.yellow("Suppressed")}${rel.suppressedReason ? `: ${stripAnsi(rel.suppressedReason)}` : ""}`,
@@ -154,24 +173,41 @@ type SourceRow = Source & {
 
 async function renderSource(rawSource: unknown, opts: GetEntityOpts) {
   const source = rawSource as SourceRow;
-  if (opts.json) {
-    await writeJson(source);
-    return;
-  }
 
   // Resolve org/product context + a small recent-releases preview in parallel.
-  // Failures degrade silently so a broken sub-call doesn't blank the card.
+  // Run for both text and JSON paths so the JSON contract is at least as
+  // informative as the text card — agents shouldn't have to fall back to the
+  // human output to discover what the dispatcher resolved. Failures degrade
+  // silently so a broken sub-call doesn't blank the card.
   const [org, product, latest] = await Promise.all([
     source.orgId ? findOrg(source.orgId).catch(() => null) : Promise.resolve(null),
     source.productId ? findProduct(source.productId).catch(() => null) : Promise.resolve(null),
     getLatestReleases({ source: source.slug, count: PREVIEW_RELEASE_COUNT }).catch(() => []),
   ]);
 
-  const statusLabel = source.isHidden
-    ? chalk.red("hidden")
+  const status: "hidden" | "erroring" | "active" = source.isHidden
+    ? "hidden"
     : source.consecutiveErrors && source.consecutiveErrors > 0
-      ? chalk.yellow(`erroring (${source.consecutiveErrors} consecutive)`)
-      : chalk.green("active");
+      ? "erroring"
+      : "active";
+
+  if (opts.json) {
+    await writeJson({
+      ...source,
+      status,
+      org: org ? { id: org.id, slug: org.slug, name: org.name } : null,
+      product: product ? { id: product.id, slug: product.slug, name: product.name } : null,
+      latestReleases: latest,
+    });
+    return;
+  }
+
+  const statusLabel =
+    status === "hidden"
+      ? chalk.red("hidden")
+      : status === "erroring"
+        ? chalk.yellow(`erroring (${source.consecutiveErrors} consecutive)`)
+        : chalk.green("active");
 
   console.log(chalk.dim("Source"));
   console.log(chalk.bold(source.name));


### PR DESCRIPTION
## Summary

Audits the default `releases get <identifier>` output for all four entity kinds (release / org / product / source) so the response is useful on its own without flag discovery, while staying token-efficient via progressive disclosure (footer hints to the dedicated drill-in commands).

- **Release**: label the AI summary as `Summary · AI-generated, abbreviated` (was unlabeled — readers couldn't tell it wasn't the full body). When no summary is on file, fall back through a three-tier ladder: AI-generated headline (`titleGenerated` / `titleShort`) → 280-char slice of raw content body labeled `Preview · raw content`. The card is never empty between metadata and the footer.
- **Org**: add description, tags, source breakdown (active / erroring / hidden), and the product list (with names + slugs). Trim the latest-releases preview from 10 → 5. Footer hints at `org get` (overview / accounts / aliases), `org overview`, and the org-scoped feed.
- **Product**: previously had nothing release- or source-related. Now adds description, tags, source list. Footer hints at the org-scoped feed and per-source drill-in.
- **Source**: previously had nothing release-related. Now adds org/product binding, fetch status (active / erroring / hidden), `lastFetchedAt`, and the latest 5 releases. Footer hints at `list --source`, `fetch-log`, and `release get`.

All four renderers carry the stable typed ID (`rel_…` / `org_…` / `prod_…` / `src_…`) on the first metadata line — useful as a pivot for follow-up commands and scripts even when the caller already used the ID to look up the entity.

Footer hints that reference a source use the typed `src_…` ID rather than the bare slug — source slugs are per-org-unique since #698, so a bare-slug example could misroute across orgs.

**Release size hint.** `releases get <rel_…>` text adds a `Content: N chars (~M tokens)` metadata line; JSON gains `contentChars` and `contentTokens`. Lets agents decide whether to round-trip for the full body before spending the call. Token count uses `cl100k_base` tiktoken (within ~5% of Claude's tokenizer on English prose). Surfacing the same signal on embedded latest-release lists requires a backend change — filed as buildinternet/releases#958.

**Text/JSON parity.** All four renderers now keep `--json` at least as informative as the text card:
- Release JSON gains `contentChars` / `contentTokens` (computed locally, since `content` is already on the wire).
- Org JSON: `sources`, `products`, `tags`, `collections`, `releases` (latest 5).
- Product JSON: `sources` (filtered to the product), `sourceCount`, `tags`, `orgSlug`.
- Source JSON: `status` (derived), resolved `org` / `product` summaries, `latestReleases`. Previously the text path resolved org/product names and pulled the latest 5 releases while JSON returned only the raw source row — corrected here.

Also fixes a **latent bug** in `getProductsByOrg`: `/v1/products` returns a paginated envelope but the client typed it as a bare array, so every downstream `for / find / filter / map` silently iterated nothing. That's why `releases org get` never rendered a Products section even for orgs with products (e.g. Supabase's Auth / CLI / Client SDK; Vercel's Next.js / Turborepo). The client now unwraps the envelope and tolerates the legacy bare-array shape too.

JSON output: additive only (`sources`, `products`, `sourceCount`, `tags` on org/product); existing fields unchanged.

## Sample output (final state)

### Organization

```
Organization
Vercel
  ID:          org_qsyZSlC_PRGFDYIGsMfzp
  Slug:        vercel
  Domain:      vercel.com
  Category:    cloud
  Sources:     6 — 6 active
  Products:    2 — Next.js (nextjs), Turborepo (turborepo)
  Collections: Application Platforms (application-platforms)

Latest 5 releases (most recent first):
rel_hbfYtfgFQ2tbpDCozKGjI  AI SDK (vercel-ai-sdk)     @ai-sdk/open-responses@1.0.16  …  2026-05-13
rel_ItYzsybPLezAuCEMOZwwZ  AI SDK (vercel-ai-sdk)     ai@6.0.182                     …  2026-05-13
rel_IPLluj5DgqcmUl8TPxXPa  Vercel CLI (vercel-cli)    @vercel/python@6.41.0          …  2026-05-13
rel_aw2ASUk5TTpZkW8BPXSK1  Vercel CLI (vercel-cli)    vercel@54.0.0                  …  2026-05-13
rel_27YPhIvM70nKZVTYOSpBc  Vercel CLI (vercel-cli)    @vercel/backends@0.6.0         …  2026-05-13

Next steps:
  releases org get vercel       — accounts, aliases, overview, full source list
  releases org overview vercel  — AI-generated rollup
  releases list --org vercel    — full release feed
```

> Note: the `Products: 2 — Next.js, Turborepo` line was empty before this PR — that's the latent `getProductsByOrg` envelope bug surfacing.

### Release (with AI summary)

```
Release
v2.1.141
  ID:        rel_MzbAaWLcgqFaUq0NdcU6h
  Version:   v2.1.141
  Source:    Claude Code (claude-code)
  Published: 2026-05-13T23:19:16.000Z
  URL:       https://code.claude.com/docs/en/changelog#2-1-141
  Content:   7.5K chars (~1,549 tokens)

Summary  · AI-generated, abbreviated
Fixed switching permission mode while a tool-permission prompt is open not auto-dismissing the prompt when the new setting permits the tool, and background jobs no longer stay under Working when they finish—they now move to Completed. Plus dozens of fixes across MCP servers, plugin installation, voice mode, and terminal rendering.

Next steps:
  releases release get rel_MzbAaWLcgqFaUq0NdcU6h      — full release body (content + metadata)
```

### Release (no summary — preview fallback)

```
Release
@ai-sdk/open-responses@1.0.16
  ID:        rel_hbfYtfgFQ2tbpDCozKGjI
  Version:   @ai-sdk/open-responses@1.0.16
  Source:    AI SDK (vercel-ai-sdk)
  Published: 2026-05-13T18:10:47.000Z
  URL:       https://github.com/vercel/ai/releases/tag/%40ai-sdk/open-responses%401.0.16
  Content:   135 chars (~33 tokens)

Preview  · raw content
### Patch Changes

-   16a5de5: fix(open-responses): map non-image file parts to input_file

Next steps:
  releases release get rel_hbfYtfgFQ2tbpDCozKGjI      — full release body (content + metadata)
```

### Product

```
Product
CLI
  ID:        prod_BKFY5jbWb9UMcB4sz4Szm
  Slug:      supabase-cli
  Org:       Supabase (supabase)
  URL:       —
  Category:  developer-tools
  About:     Command-line interface for local development and deployment
  Tags:      cli
  Sources:   1 (supabase-cli)

Next steps:
  releases list --org supabase                       — release feed (org-scoped; mixes other products)
  releases get src_i60jAGP4pdC7Ln9DBQm93             — drill into a source for its release feed
```

### Source

```
Source
Supabase CLI
  ID:         src_i60jAGP4pdC7Ln9DBQm93
  Slug:       supabase-cli
  Type:       github
  URL:        https://github.com/supabase/cli
  Org:        Supabase (supabase)
  Product:    CLI (supabase-cli)
  Status:     active
  Last fetch: 2026-05-14T13:00:30.074Z

Latest 5 releases (most recent first):
rel_BmShoH5XZQgnWeH8T6w_P  Supabase CLI (supabase-cli)  v2.98.2  v2.98.2  2026-05-05
rel_gGhVnlkdsEkUfpNH2eaNd  Supabase CLI (supabase-cli)  v2.98.1  v2.98.1  2026-05-04
rel_hbUqmmZX-Jo9fAk9Zg3HE  Supabase CLI (supabase-cli)  v2.98.0  v2.98.0  2026-04-30
rel_EBNh1xxtI43UPx0izMH28  Supabase CLI (supabase-cli)  v2.97.0  v2.97.0  2026-04-30
rel_qg6qd20DkFbP304Zx8AAz  Supabase CLI (supabase-cli)  v2.96.0  v2.96.0  2026-04-30

Next steps:
  releases list --source supabase-cli             — full release feed
  releases fetch-log supabase-cli                  — recent fetch attempts and errors
  releases release get <rel_id>                    — open one release with full content
```

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `bun run lint` — 0 warnings, 0 errors
- [x] `bun test` — 297 / 297 pass
- [x] Smoke-tested live API: release with summary (Claude Code v2.1.141 — `Content: 7.5K chars (~1,549 tokens)`), release without summary (AI SDK — preview fallback renders the raw content slice + size line), org with products (Vercel — Products line now shows Next.js/Turborepo, was hidden by envelope bug; Supabase — shows Auth/CLI/Client SDK), product (supabase-cli — typed `src_…` ID in footer hint), source (src_… — text card and `--json` both carry resolved org/product + latest releases + status).

## Follow-ups

- **#169** — depth-control convention for the dispatcher (`--summary` flag vs. status quo vs. `--full`). Comparative audit (kubectl / gh / stripe / vercel / doctl / cf) lives in the issue. Today's footer hints are the discoverability bridge.
- **buildinternet/releases#958** — surface `contentChars` / `contentTokens` on the `LatestRelease` wire shape so the size hint applies to every embedded feed (org card, source card, MCP `get_latest_releases`), not just the single-release `releases get`. Requires a backend column + schema bump; out of scope for the CLI-only change here.
