### PR TITLE
feat(cli): show content size hint on latest-releases table

### DIFF
--- a/.changeset/958-surface-content-size.md
+++ b/.changeset/958-surface-content-size.md
@@ -1,0 +1,7 @@
+---
+"@buildinternet/releases": patch
+---
+
+Surface release body size on the latest-releases table (`releases get <org>`, `releases get <src_…>`, `releases tail`). Each row picks up a dim "~1.5K tokens" hint next to the title when the cached `contentTokens` field is available, so agents browsing a feed can decide whether to pull the full body before spending the round-trip. Compact mode only shows the hint for releases ≥1K tokens; `--with-summary` shows it on every row.
+
+Forward-compatible: the field is read as optional. API deployments mid-rollout return `undefined` and the hint is silently dropped. Lights up once `@buildinternet/releases-api-types` ships the matching wire-shape change (`buildinternet/releases#958`).

--- a/src/cli/render/releases-table.ts
+++ b/src/cli/render/releases-table.ts
@@ -7,6 +7,18 @@ function truncate(s: string, max: number): string {
   return s.length > max ? s.slice(0, max - 1) + "…" : s;
 }
 
+/**
+ * Compact token-count formatter — "1.5K", "12K", "87". `null` / `0` / missing
+ * → empty string so the renderer can `${size ? ` ${size}` : ""}` without a
+ * branch. Mirrors how Sentry and OpenAI's chat surfaces show "tokens".
+ */
+function formatTokenCount(n: number | null | undefined): string {
+  if (!n || n < 0) return "";
+  if (n < 1000) return `~${n} tokens`;
+  if (n < 100_000) return `~${(n / 1000).toFixed(1).replace(/\.0$/, "")}K tokens`;
+  return `~${Math.round(n / 1000)}K tokens`;
+}
+
 export interface RenderOptions {
   /** Append a dimmed summary preview under each title (for tail/latest listings). */
   withSummary?: boolean;
@@ -23,10 +35,23 @@ export function renderLatestReleasesTable(rows: LatestRelease[], opts: RenderOpt
     ],
     rows: rows.map((row) => {
       const title = stripAnsi(row.title);
+      // Append size hint to the title cell when present so the field doesn't
+      // need its own column. Skip in compact mode unless body is large enough
+      // to matter (~1K tokens) — small releases would just add noise. #958.
+      //
+      // `contentTokens` is declared on `LatestRelease` from api-types ≥0.19;
+      // the CLI's pin (^0.16) accepts older shapes too, so the cast keeps
+      // the renderer running before the registry publishes the field. Older
+      // payloads land `undefined` and the hint is dropped.
+      const contentTokens = (row as LatestRelease & { contentTokens?: number | null })
+        .contentTokens;
+      const sizeHint = formatTokenCount(contentTokens);
+      const showSize = sizeHint && (opts.withSummary || (contentTokens ?? 0) >= 1000);
+      const titleWithSize = showSize ? `${title} ${chalk.dim(sizeHint)}` : title;
       const titleCell =
         opts.withSummary && row.summary
-          ? `${title}\n${chalk.dim(truncate(row.summary, 120))}`
-          : title;
+          ? `${titleWithSize}\n${chalk.dim(truncate(row.summary, 120))}`
+          : titleWithSize;
       const publishedCell = opts.withSummary
         ? (row.publishedAt ?? "-")
         : (row.publishedAt?.slice(0, 10) ?? chalk.dim("—"));


### PR DESCRIPTION
## Summary

Surfaces the cached release body size on `renderLatestReleasesTable` (used by `releases get <org>`, `releases get <src_…>`, `releases tail`). Each row picks up a dim `~1.5K tokens` hint next to the title when the wire shape carries `contentTokens`. Compact mode only shows the hint for releases ≥1K tokens; `--with-summary` shows it on every row.

Forward-compatible: the field is read as optional. API deployments mid-rollout return `undefined` and the hint is silently dropped. Lights up once `@buildinternet/releases-api-types` publishes the matching wire-shape change ([buildinternet/releases#958](https://github.com/buildinternet/releases/issues/958)).

## Test plan

- [ ] `bun test` (297 passing locally)
- [ ] `npx tsc --noEmit` clean
- [ ] Against staging once the matching API change ships, run `releases get vercel` and confirm the latest-5 list shows `~Nx tokens` after the title
- [ ] Run `releases tail --with-summary` and confirm every row shows the hint
- [ ] Confirm rows without `contentTokens` (older inserts) silently drop the hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)
