### PR TITLE
chore: changeset for org update --avatar becoming functional

### DIFF
--- a/.changeset/org-update-avatar-functional.md
+++ b/.changeset/org-update-avatar-functional.md
@@ -1,0 +1,7 @@
+---
+"@buildinternet/releases": patch
+---
+
+`releases org update --avatar <url>` now works end-to-end. The flag was already wired (it set `avatarUrl` in the PATCH body) but the API silently dropped the field via Zod's default unknown-key stripping. The matching API change landed in `buildinternet/releases#979`; once that ships in the published `releases-api-types` rev, the CLI's `--avatar` and `--no-avatar` flags affect the server state for real.
+
+Forward-compatible: existing scripts that already use `--avatar` start working without any CLI change — the wire shape didn't move, only the server-side acceptance did.


### PR DESCRIPTION
## Summary

- Adds a changeset for the `releases org update --avatar <url>` flag becoming functional end-to-end.
- The flag itself was already in the CLI (`src/cli/commands/org.ts:268-294`), but the matching API change is what made it actually persist. That landed in `buildinternet/releases#979` (private monorepo).
- No CLI code change in this PR — just the changeset so the next release of `@buildinternet/releases-*` carries a user-visible note.

## Test plan

- [x] No code change → no tests
- [x] Changeset format matches recent examples
- [x] Targets `@buildinternet/releases` (fixed-group cascades to the 8 published packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
