### PR TITLE
feat(admin): `overview batch` CLI wrapper for BatchOverviewWorkflow (#1005)

### DIFF
--- a/.changeset/admin-overview-batch.md
+++ b/.changeset/admin-overview-batch.md
@@ -1,0 +1,7 @@
+---
+"@buildinternet/releases": minor
+---
+
+`releases admin overview batch` wraps the new `BatchOverviewWorkflow` (`POST /v1/workflows/batch-overview`). Flags map 1:1 to the workflow body: `--orgs <slug,slug>`, `--min-new-releases`, `--min-overview-age-days`, `--max-candidates`, `--max-cost-usd`. Pass `--wait` to poll the status endpoint every 30s until the workflow reaches a terminal state; without it the command prints `instanceId` + `statusUrl` and returns immediately.
+
+Sits next to the agent-driven `admin overview inputs` / `admin overview update` so the batch path is discoverable alongside the single-org regen flow. Closes #1005.

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "releases-cli",
       "dependencies": {
-        "@buildinternet/releases-api-types": "^0.16.0",
+        "@buildinternet/releases-api-types": "^0.19.0",
         "@buildinternet/releases-core": "^0.21.0",
         "@buildinternet/releases-lib": "workspace:*",
         "@buildinternet/releases-skills": "workspace:*",
@@ -27,7 +27,7 @@
     },
     "npm/releases": {
       "name": "@buildinternet/releases",
-      "version": "0.35.2",
+      "version": "0.36.0",
       "bin": {
         "releases": "bin/releases",
       },
@@ -41,31 +41,31 @@
     },
     "npm/releases-darwin-arm64": {
       "name": "@buildinternet/releases-darwin-arm64",
-      "version": "0.35.2",
+      "version": "0.36.0",
     },
     "npm/releases-darwin-x64": {
       "name": "@buildinternet/releases-darwin-x64",
-      "version": "0.35.2",
+      "version": "0.36.0",
     },
     "npm/releases-linux-arm64": {
       "name": "@buildinternet/releases-linux-arm64",
-      "version": "0.35.2",
+      "version": "0.36.0",
     },
     "npm/releases-linux-x64": {
       "name": "@buildinternet/releases-linux-x64",
-      "version": "0.35.2",
+      "version": "0.36.0",
     },
     "npm/releases-windows-x64": {
       "name": "@buildinternet/releases-windows-x64",
-      "version": "0.35.2",
+      "version": "0.36.0",
     },
     "packages/lib": {
       "name": "@buildinternet/releases-lib",
-      "version": "0.35.2",
+      "version": "0.36.0",
     },
     "packages/skills": {
       "name": "@buildinternet/releases-skills",
-      "version": "0.35.2",
+      "version": "0.36.0",
     },
   },
   "packages": {
@@ -73,7 +73,7 @@
 
     "@buildinternet/releases": ["@buildinternet/releases@workspace:npm/releases"],
 
-    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.16.0", "", { "dependencies": { "@buildinternet/releases-core": "^0.21.0", "zod": "^4.3.6" } }, "sha512-CCfkwVImIT3nLW79PEd9iuy1RD8e7dtr/BKli3okTZH9NdxlHyfsBH0eEH49MoR9CR94OULHCzd+aQLqi9TJmw=="],
+    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.19.0", "", { "dependencies": { "@buildinternet/releases-core": "^0.21.0", "zod": "^4.3.6" } }, "sha512-LN1unLEru3H469Um+Z6qwGRZoaVvNvIcSsa2Ut2iYsYJHnO3ALps32fp5sn15gqbXj4gSKvHLG9QVVyVv60SOQ=="],
 
     "@buildinternet/releases-core": ["@buildinternet/releases-core@0.21.0", "", { "dependencies": { "drizzle-orm": "^0.45.2", "js-tiktoken": "^1.0.21", "nanoid": "^5.1.7" } }, "sha512-tWLBc3BvBot1Rrb5j3X2RPSogcgm5+hwFlnQocMTHFgF8gtF4jZRM7Mc+HoGNOlMJHacH1uyqt2nDcqTGZaNZQ=="],
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "homepage": "https://releases.sh",
   "dependencies": {
-    "@buildinternet/releases-api-types": "^0.16.0",
+    "@buildinternet/releases-api-types": "^0.19.0",
     "@buildinternet/releases-core": "^0.21.0",
     "@buildinternet/releases-lib": "workspace:*",
     "@buildinternet/releases-skills": "workspace:*",

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1379,9 +1379,17 @@ export async function triggerBatchOverview(
 export async function getBatchOverviewStatus(
   instanceId: string,
 ): Promise<BatchOverviewStatusResponse> {
-  return apiFetch<BatchOverviewStatusResponse>(
+  // apiFetch returns null on 404 for GETs. The status route 404s with
+  // `instance_not_found` when the workflow ID is wrong (or briefly during
+  // the create→status race window). Throw so callers reading `.status`
+  // can't crash silently.
+  const res = await apiFetch<BatchOverviewStatusResponse | null>(
     `/v1/workflows/batch-overview/status/${encodeURIComponent(instanceId)}`,
   );
+  if (res === null) {
+    throw new Error(`Workflow instance not found: ${instanceId}`);
+  }
+  return res;
 }
 
 // ── Domain Aliases ──

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1337,6 +1337,53 @@ export async function getEmbedStatus(): Promise<EmbedStatusResponse> {
   return apiFetch<EmbedStatusResponse>("/v1/admin/embed/status");
 }
 
+// ── Batch overview workflow (admin-only) ──
+
+/** Trigger body for POST /v1/workflows/batch-overview — mirrors `BatchOverviewBody` on the API worker. */
+export interface BatchOverviewTriggerBody {
+  minNewReleases?: number;
+  minOverviewAgeDays?: number;
+  maxCandidates?: number;
+  orgs?: string[];
+  maxCostUsd?: number;
+}
+
+export interface BatchOverviewTriggerResponse {
+  instanceId: string;
+  statusUrl: string;
+}
+
+/**
+ * Cloudflare Workflows surfaces a small enum on `WorkflowInstance.status()`.
+ * Terminal states are `complete | errored | terminated`; pre-terminal states
+ * are `queued | running | paused`. We type the field as string to stay
+ * forward-compatible with any new values CF introduces.
+ */
+export interface BatchOverviewStatusResponse {
+  instanceId: string;
+  status: string;
+  output?: unknown;
+  error?: unknown;
+  [k: string]: unknown;
+}
+
+export async function triggerBatchOverview(
+  body: BatchOverviewTriggerBody,
+): Promise<BatchOverviewTriggerResponse> {
+  return apiFetch<BatchOverviewTriggerResponse>("/v1/workflows/batch-overview", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+export async function getBatchOverviewStatus(
+  instanceId: string,
+): Promise<BatchOverviewStatusResponse> {
+  return apiFetch<BatchOverviewStatusResponse>(
+    `/v1/workflows/batch-overview/status/${encodeURIComponent(instanceId)}`,
+  );
+}
+
 // ── Domain Aliases ──
 
 export async function getAliases(

--- a/src/cli/commands/admin/overview.ts
+++ b/src/cli/commands/admin/overview.ts
@@ -16,12 +16,16 @@ import {
   getOverviewInputsCheck,
   getOverviewManifest,
   upsertOverview,
+  triggerBatchOverview,
+  getBatchOverviewStatus,
   type OverviewCitation,
   type OverviewManifestRow,
+  type BatchOverviewTriggerBody,
+  type BatchOverviewStatusResponse,
 } from "../../../api/client.js";
 import { orgNotFound } from "../../suggest.js";
 import { writeJson } from "../../../lib/output.js";
-import { parsePositiveIntFlag } from "../../../lib/flags.js";
+import { parsePositiveIntFlag, parseTagList } from "../../../lib/flags.js";
 import { logger } from "@releases/lib/logger";
 import { timeAgo } from "@buildinternet/releases-core/dates";
 import {
@@ -77,6 +81,16 @@ interface OverviewPlanOpts {
   staleDays?: string;
   missing?: boolean;
   hasActivity?: boolean;
+}
+
+interface OverviewBatchOpts {
+  orgs?: string;
+  minNewReleases?: string;
+  minOverviewAgeDays?: string;
+  maxCandidates?: string;
+  maxCostUsd?: string;
+  wait?: boolean;
+  json?: boolean;
 }
 
 // ── Action handlers ───────────────────────────────────────────────────────────
@@ -499,6 +513,82 @@ async function overviewPlanAction(opts: OverviewPlanOpts): Promise<void> {
   console.log(chalk.dim(`\n${rows.length} org(s) — ${parts}`));
 }
 
+// ── Batch workflow trigger ────────────────────────────────────────────────────
+
+/** Terminal Workflows states per Cloudflare's WorkflowInstance.status() enum. */
+const TERMINAL_STATUSES = new Set(["complete", "errored", "terminated"]);
+
+/** Poll cadence for --wait. 30s matches the issue's spec and the workflow's typical 3-minute end-to-end. */
+const POLL_INTERVAL_MS = 30_000;
+
+function parsePositiveFloatFlag(label: string, raw: string | undefined): number | undefined {
+  if (raw === undefined) return undefined;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) {
+    logger.error(`Invalid --${label}: must be a positive number (got ${raw})`);
+    process.exit(2);
+  }
+  return n;
+}
+
+async function overviewBatchAction(opts: OverviewBatchOpts): Promise<void> {
+  const minNewReleases = parsePositiveIntFlag("min-new-releases", opts.minNewReleases);
+  const minOverviewAgeDays = parsePositiveIntFlag("min-overview-age-days", opts.minOverviewAgeDays);
+  const maxCandidates = parsePositiveIntFlag("max-candidates", opts.maxCandidates);
+  const maxCostUsd = parsePositiveFloatFlag("max-cost-usd", opts.maxCostUsd);
+  const orgs = opts.orgs ? parseTagList(opts.orgs) : undefined;
+
+  const body: BatchOverviewTriggerBody = {
+    ...(minNewReleases !== undefined && { minNewReleases }),
+    ...(minOverviewAgeDays !== undefined && { minOverviewAgeDays }),
+    ...(maxCandidates !== undefined && { maxCandidates }),
+    ...(maxCostUsd !== undefined && { maxCostUsd }),
+    ...(orgs && orgs.length > 0 && { orgs }),
+  };
+
+  const triggered = await triggerBatchOverview(body);
+
+  if (!opts.wait) {
+    if (opts.json) {
+      await writeJson(triggered);
+      return;
+    }
+    console.log(chalk.green(`Triggered batch-overview workflow: ${triggered.instanceId}`));
+    console.log(chalk.dim(`  status: ${triggered.statusUrl}`));
+    console.log(
+      chalk.dim(`  Re-run with --wait or 'releases admin overview batch --wait' to poll inline.`),
+    );
+    return;
+  }
+
+  if (!opts.json) {
+    console.log(chalk.bold(`Triggered batch-overview workflow: ${triggered.instanceId}`));
+    console.log(chalk.dim(`  Polling every ${POLL_INTERVAL_MS / 1000}s until terminal...`));
+  }
+
+  let last: BatchOverviewStatusResponse | undefined;
+  while (true) {
+    // eslint-disable-next-line no-await-in-loop -- polling cadence
+    last = await getBatchOverviewStatus(triggered.instanceId);
+    if (!opts.json) {
+      console.log(chalk.dim(`  status: ${last.status}`));
+    }
+    if (TERMINAL_STATUSES.has(last.status)) break;
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+  }
+
+  if (opts.json) {
+    await writeJson(last);
+  } else if (last.status === "complete") {
+    console.log(chalk.green(`Done. Final status: ${last.status}`));
+  } else {
+    console.log(chalk.red(`Workflow ended in non-success state: ${last.status}`));
+  }
+
+  if (last.status !== "complete") process.exit(1);
+}
+
 // ── Command registration ──────────────────────────────────────────────────────
 
 export function registerOverviewCommands(admin: Command): void {
@@ -614,6 +704,37 @@ generator described in the \`regenerating-overviews\` skill, then upload the
 result with \`releases admin overview update\`.`,
     )
     .action(overviewInputsAction);
+
+  overview
+    .command("batch")
+    .description("Trigger BatchOverviewWorkflow for the eligibility-filtered org set")
+    .option("--orgs <slugs>", "Comma-separated org slug allowlist (skips eligibility filtering)")
+    .option("--min-new-releases <n>", "Min releases shipped since the last overview (default 20)")
+    .option(
+      "--min-overview-age-days <n>",
+      "Min age in days of an existing overview to consider it stale (default 14)",
+    )
+    .option("--max-candidates <n>", "Cap on candidate count picked by the workflow (default 100)")
+    .option("--max-cost-usd <n>", "Per-run cost ceiling in USD; workflow aborts above this")
+    .option("--wait", "Poll the workflow status every 30s until it reaches a terminal state")
+    .option("--json", "Output as JSON")
+    .addHelpText(
+      "after",
+      `
+Examples:
+  releases admin overview batch --orgs vercel,anthropic --wait
+  releases admin overview batch --max-candidates 4 --max-cost-usd 0.05 --json
+  releases admin overview batch --min-new-releases 30 --min-overview-age-days 7
+
+Triggers POST /v1/workflows/batch-overview. When --wait is omitted the command
+returns immediately with the instanceId and statusUrl; with --wait it polls
+GET /v1/workflows/batch-overview/status/:instanceId every 30s and exits
+non-zero on any terminal state other than 'complete'.
+
+--orgs explicitly bypasses the workflow's eligibility predicate (recency +
+overview-age) so handpicked smoke tests run even on already-fresh orgs.`,
+    )
+    .action(overviewBatchAction);
 
   overview
     .command("update")

--- a/tests/cli/overview-subcommands.test.ts
+++ b/tests/cli/overview-subcommands.test.ts
@@ -64,6 +64,25 @@ describe("admin overview subcommand group", () => {
     expect(stdout).toContain("--citations-file");
     expect(stdout).toContain("startIndex");
   });
+
+  it("`overview batch --help` exposes the workflow trigger flag set", () => {
+    const { stdout, exitCode } = runCli(["admin", "overview", "batch", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--orgs");
+    expect(stdout).toContain("--min-new-releases");
+    expect(stdout).toContain("--min-overview-age-days");
+    expect(stdout).toContain("--max-candidates");
+    expect(stdout).toContain("--max-cost-usd");
+    expect(stdout).toContain("--wait");
+    expect(stdout).toContain("--json");
+    expect(stdout).toContain("BatchOverviewWorkflow");
+  });
+
+  it("`overview --help` lists batch as a subcommand", () => {
+    const { stdout, exitCode } = runCli(["admin", "overview", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("batch");
+  });
 });
 
 describe("deprecated overview kebab aliases", () => {


### PR DESCRIPTION
## Summary

Closes [#1005](https://github.com/buildinternet/releases/issues/1005). Adds `releases admin overview batch` so the new `BatchOverviewWorkflow` (buildinternet/releases#1001) is reachable from the same CLI surface as `admin overview inputs` / `admin overview update`. Removes the curl + jq dance for the rollout in buildinternet/releases#1004.

## What's new

```
releases admin overview batch [--orgs <slug,slug>] [--min-new-releases <n>]
                              [--min-overview-age-days <n>] [--max-candidates <n>]
                              [--max-cost-usd <n>] [--wait] [--json]
```

- POSTs to `/v1/workflows/batch-overview` with the body shape from `BatchOverviewBody` on the API worker.
- Without `--wait`: prints `instanceId` + `statusUrl` and exits.
- With `--wait`: polls `/v1/workflows/batch-overview/status/:instanceId` every 30s until terminal (`complete | errored | terminated`), exits non-zero on any non-`complete` terminal state.
- `--orgs` skips the workflow's eligibility predicate so hand-picked smoke runs work even on already-fresh orgs.

## Test plan

- [x] `bun test tests/cli/overview-subcommands.test.ts` — 13 pass (+3 new)
- [x] `bun test` — 299 pass / 0 fail
- [x] `bun run lint` — 0/0
- [x] `bun run format:check` — clean
- [x] `bunx tsc --noEmit` — clean
- [x] `releases admin overview batch --help` renders correctly

## Wire-shape notes

The trigger + status request/response types are defined inline in `src/api/client.ts` rather than imported from `@buildinternet/releases-api-types`. The route's body interface is currently inline in the API worker too; if it gets pulled into `api-types` later the CLI types can be swapped over without breaking callers.

Changeset: minor on `@buildinternet/releases`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `admin overview batch` command to run and monitor batch overviews with filters for orgs, new-release minimums, overview age, candidate limits, cost caps; supports `--wait` to poll progress or immediate instance/status output, `--json` output, and input validation with proper exit codes.

* **Tests**
  * Added CLI test coverage for the `batch` subcommand and help output.

* **Documentation**
  * Added release notes documenting the new batch overview command and its behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/buildinternet/releases-cli/pull/173?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->