### PR TITLE
fix(cli): allow 0 for --min-new-releases and --min-overview-age-days in admin overview batch

### DIFF
--- a/.changeset/fix-174-allow-zero-thresholds.md
+++ b/.changeset/fix-174-allow-zero-thresholds.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": patch
+---
+
+fix(cli): allow 0 for --min-new-releases and --min-overview-age-days in `admin overview batch` to match API contract (#174)

--- a/src/cli/commands/admin/overview.ts
+++ b/src/cli/commands/admin/overview.ts
@@ -25,7 +25,7 @@ import {
 } from "../../../api/client.js";
 import { orgNotFound } from "../../suggest.js";
 import { writeJson } from "../../../lib/output.js";
-import { parsePositiveIntFlag, parseTagList } from "../../../lib/flags.js";
+import { parseNonNegIntFlag, parsePositiveIntFlag, parseTagList } from "../../../lib/flags.js";
 import { logger } from "@releases/lib/logger";
 import { timeAgo } from "@buildinternet/releases-core/dates";
 import {
@@ -532,8 +532,8 @@ function parsePositiveFloatFlag(label: string, raw: string | undefined): number 
 }
 
 async function overviewBatchAction(opts: OverviewBatchOpts): Promise<void> {
-  const minNewReleases = parsePositiveIntFlag("min-new-releases", opts.minNewReleases);
-  const minOverviewAgeDays = parsePositiveIntFlag("min-overview-age-days", opts.minOverviewAgeDays);
+  const minNewReleases = parseNonNegIntFlag("min-new-releases", opts.minNewReleases);
+  const minOverviewAgeDays = parseNonNegIntFlag("min-overview-age-days", opts.minOverviewAgeDays);
   const maxCandidates = parsePositiveIntFlag("max-candidates", opts.maxCandidates);
   const maxCostUsd = parsePositiveFloatFlag("max-cost-usd", opts.maxCostUsd);
   const orgs = opts.orgs ? parseTagList(opts.orgs) : undefined;

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -15,6 +15,21 @@ export function parsePositiveIntFlag(label: string, raw: string | undefined): nu
   return n;
 }
 
+/**
+ * Parse a non-negative-integer CLI flag value (0 is allowed). Returns
+ * `undefined` if the option was not provided. Exits with code 2 on invalid
+ * input.
+ */
+export function parseNonNegIntFlag(label: string, raw: string | undefined): number | undefined {
+  if (raw === undefined) return undefined;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 0) {
+    console.error(chalk.red(`Invalid --${label}: must be a non-negative integer (got ${raw})`));
+    process.exit(2);
+  }
+  return n;
+}
+
 /** Parse a comma-separated `--tags foo,bar` flag into a trimmed, non-empty list. */
 export function parseTagList(raw: string | undefined): string[] {
   if (!raw) return [];

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -22,7 +22,11 @@ export function parsePositiveIntFlag(label: string, raw: string | undefined): nu
  */
 export function parseNonNegIntFlag(label: string, raw: string | undefined): number | undefined {
   if (raw === undefined) return undefined;
-  const n = Number.parseInt(raw, 10);
+  // Strict integer match first — Number.parseInt would silently accept "1.5" → 1
+  // and "10abc" → 10. Allow an optional leading minus so the range check below
+  // produces the same error message for "-1" as it does for "1.5".
+  const isInt = /^-?\d+$/.test(raw);
+  const n = isInt ? Number.parseInt(raw, 10) : NaN;
   if (!Number.isFinite(n) || n < 0) {
     console.error(chalk.red(`Invalid --${label}: must be a non-negative integer (got ${raw})`));
     process.exit(2);

--- a/tests/cli/overview-subcommands.test.ts
+++ b/tests/cli/overview-subcommands.test.ts
@@ -85,6 +85,48 @@ describe("admin overview subcommand group", () => {
   });
 });
 
+describe("`overview batch` flag validation", () => {
+  it("accepts 0 for --min-new-releases (no validation error)", () => {
+    // With 0 the flag parses fine; the action itself would need a live API so
+    // we only check that the CLI doesn't exit(2) on argument validation.
+    // Passing an unknown flag that triggers usage error would give exit 1,
+    // but a bad value gives exit 2 — so exit != 2 proves the validator passed.
+    const { exitCode, stderr } = runCli([
+      "admin",
+      "overview",
+      "batch",
+      "--min-new-releases",
+      "0",
+    ]);
+    expect(exitCode).not.toBe(2);
+    expect(stderr).not.toContain("must be a non-negative integer");
+  });
+
+  it("accepts 0 for --min-overview-age-days (no validation error)", () => {
+    const { exitCode, stderr } = runCli([
+      "admin",
+      "overview",
+      "batch",
+      "--min-overview-age-days",
+      "0",
+    ]);
+    expect(exitCode).not.toBe(2);
+    expect(stderr).not.toContain("must be a non-negative integer");
+  });
+
+  it("rejects -1 for --min-new-releases with a clear message", () => {
+    const { exitCode, stderr } = runCli([
+      "admin",
+      "overview",
+      "batch",
+      "--min-new-releases",
+      "-1",
+    ]);
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("must be a non-negative integer");
+  });
+});
+
 describe("deprecated overview kebab aliases", () => {
   it("`overview-list --help` is marked deprecated", () => {
     const { stdout, exitCode } = runCli(["admin", "overview-list", "--help"]);

--- a/tests/cli/overview-subcommands.test.ts
+++ b/tests/cli/overview-subcommands.test.ts
@@ -91,13 +91,7 @@ describe("`overview batch` flag validation", () => {
     // we only check that the CLI doesn't exit(2) on argument validation.
     // Passing an unknown flag that triggers usage error would give exit 1,
     // but a bad value gives exit 2 — so exit != 2 proves the validator passed.
-    const { exitCode, stderr } = runCli([
-      "admin",
-      "overview",
-      "batch",
-      "--min-new-releases",
-      "0",
-    ]);
+    const { exitCode, stderr } = runCli(["admin", "overview", "batch", "--min-new-releases", "0"]);
     expect(exitCode).not.toBe(2);
     expect(stderr).not.toContain("must be a non-negative integer");
   });
@@ -115,12 +109,42 @@ describe("`overview batch` flag validation", () => {
   });
 
   it("rejects -1 for --min-new-releases with a clear message", () => {
+    const { exitCode, stderr } = runCli(["admin", "overview", "batch", "--min-new-releases", "-1"]);
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("must be a non-negative integer");
+  });
+
+  it("rejects -1 for --min-overview-age-days with a clear message", () => {
+    const { exitCode, stderr } = runCli([
+      "admin",
+      "overview",
+      "batch",
+      "--min-overview-age-days",
+      "-1",
+    ]);
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("must be a non-negative integer");
+  });
+
+  it("rejects non-integer strings like '1.5' for --min-new-releases", () => {
     const { exitCode, stderr } = runCli([
       "admin",
       "overview",
       "batch",
       "--min-new-releases",
-      "-1",
+      "1.5",
+    ]);
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("must be a non-negative integer");
+  });
+
+  it("rejects trailing-garbage strings like '10abc' for --min-new-releases", () => {
+    const { exitCode, stderr } = runCli([
+      "admin",
+      "overview",
+      "batch",
+      "--min-new-releases",
+      "10abc",
     ]);
     expect(exitCode).toBe(2);
     expect(stderr).toContain("must be a non-negative integer");


### PR DESCRIPTION
## Summary

- Fixes #174: `releases admin overview batch` was rejecting `0` for `--min-new-releases` and `--min-overview-age-days` with "must be a positive integer", even though the API accepts `>= 0`.
- Adds `parseNonNegIntFlag` alongside the existing `parsePositiveIntFlag` in `src/lib/flags.ts` — keeps all other callers (pagination, release-count, stale-days, etc.) at strict-positive semantics.
- Switches the two batch threshold flags in `overviewBatchAction` to use the new non-negative helper.
- Companion monorepo issue: buildinternet/releases#1017 (the `>= 0` bypass bug that surfaced this divergence).

## Test plan

- [ ] `bun test` — 302 pass, 0 fail (3 new cases for `--min-new-releases 0`, `--min-overview-age-days 0`, and `-1` rejection)
- [ ] `bun run typecheck` — clean
- [ ] `bun run lint` — 0 warnings, 0 errors
- [ ] Manually: `releases admin overview batch --min-new-releases 0 --dry-run` (or with `--help`) no longer exits 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The admin overview batch CLI now accepts 0 for the --min-new-releases and --min-overview-age-days flags, matching the API contract (previously required positive integers).

* **Tests**
  * Added CLI tests verifying 0 is accepted and negative/non-integer values are rejected with the expected error and exit code.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/buildinternet/releases-cli/pull/175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->