### PR TITLE
feat(cli): --paused / --no-paused flags on admin org update (#178)

### DIFF
--- a/.changeset/feat-178-org-update-paused.md
+++ b/.changeset/feat-178-org-update-paused.md
@@ -2,4 +2,4 @@
 "@buildinternet/releases": minor
 ---
 
-feat(cli): add `--paused` / `--no-paused` flags to `admin org update` for the org-level ingest pause flag landed in [buildinternet/releases#1064](https://github.com/buildinternet/releases/pull/1064). Mirrors the existing `--enable` / `--disable` shape on `admin source update`; lands on the deprecated `edit` alias too. (#178)
+feat(cli): add `--paused` / `--no-paused` flags to `admin org update` for the org-level ingest pause flag landed in [buildinternet/releases#1064](https://github.com/buildinternet/releases/pull/1064). Mirrors the existing `--enable` / `--disable` shape on `admin source update`; lands on the deprecated `edit` alias too. Pins `@buildinternet/releases-api-types` to `^0.20.0` so the typed `fetchPaused` field on `UpdateOrgBody` is in scope downstream. (#178)

--- a/.changeset/feat-178-org-update-paused.md
+++ b/.changeset/feat-178-org-update-paused.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": minor
+---
+
+feat(cli): add `--paused` / `--no-paused` flags to `admin org update` for the org-level ingest pause flag landed in [buildinternet/releases#1064](https://github.com/buildinternet/releases/pull/1064). Mirrors the existing `--enable` / `--disable` shape on `admin source update`; lands on the deprecated `edit` alias too. (#178)

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "releases-cli",
       "dependencies": {
-        "@buildinternet/releases-api-types": "^0.19.0",
+        "@buildinternet/releases-api-types": "^0.20.0",
         "@buildinternet/releases-core": "^0.21.0",
         "@buildinternet/releases-lib": "workspace:*",
         "@buildinternet/releases-skills": "workspace:*",
@@ -27,7 +27,7 @@
     },
     "npm/releases": {
       "name": "@buildinternet/releases",
-      "version": "0.36.0",
+      "version": "0.37.0",
       "bin": {
         "releases": "bin/releases",
       },
@@ -41,31 +41,31 @@
     },
     "npm/releases-darwin-arm64": {
       "name": "@buildinternet/releases-darwin-arm64",
-      "version": "0.36.0",
+      "version": "0.37.0",
     },
     "npm/releases-darwin-x64": {
       "name": "@buildinternet/releases-darwin-x64",
-      "version": "0.36.0",
+      "version": "0.37.0",
     },
     "npm/releases-linux-arm64": {
       "name": "@buildinternet/releases-linux-arm64",
-      "version": "0.36.0",
+      "version": "0.37.0",
     },
     "npm/releases-linux-x64": {
       "name": "@buildinternet/releases-linux-x64",
-      "version": "0.36.0",
+      "version": "0.37.0",
     },
     "npm/releases-windows-x64": {
       "name": "@buildinternet/releases-windows-x64",
-      "version": "0.36.0",
+      "version": "0.37.0",
     },
     "packages/lib": {
       "name": "@buildinternet/releases-lib",
-      "version": "0.36.0",
+      "version": "0.37.0",
     },
     "packages/skills": {
       "name": "@buildinternet/releases-skills",
-      "version": "0.36.0",
+      "version": "0.37.0",
     },
   },
   "packages": {
@@ -73,7 +73,7 @@
 
     "@buildinternet/releases": ["@buildinternet/releases@workspace:npm/releases"],
 
-    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.19.0", "", { "dependencies": { "@buildinternet/releases-core": "^0.21.0", "zod": "^4.3.6" } }, "sha512-LN1unLEru3H469Um+Z6qwGRZoaVvNvIcSsa2Ut2iYsYJHnO3ALps32fp5sn15gqbXj4gSKvHLG9QVVyVv60SOQ=="],
+    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.20.0", "", { "dependencies": { "@buildinternet/releases-core": "^0.21.0", "zod": "^4.4.3" } }, "sha512-RoU/YU5QxvJdkptiVepy0T2q34UA6IvohKGJJMJM41/H++IID/MeI+iab7DbYTpLaFOp0heXh4pIdODWenqXEg=="],
 
     "@buildinternet/releases-core": ["@buildinternet/releases-core@0.21.0", "", { "dependencies": { "drizzle-orm": "^0.45.2", "js-tiktoken": "^1.0.21", "nanoid": "^5.1.7" } }, "sha512-tWLBc3BvBot1Rrb5j3X2RPSogcgm5+hwFlnQocMTHFgF8gtF4jZRM7Mc+HoGNOlMJHacH1uyqt2nDcqTGZaNZQ=="],
 
@@ -554,6 +554,8 @@
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "@buildinternet/releases-api-types/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "@changesets/apply-release-plan/prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "homepage": "https://releases.sh",
   "dependencies": {
-    "@buildinternet/releases-api-types": "^0.19.0",
+    "@buildinternet/releases-api-types": "^0.20.0",
     "@buildinternet/releases-core": "^0.21.0",
     "@buildinternet/releases-lib": "workspace:*",
     "@buildinternet/releases-skills": "workspace:*",

--- a/src/cli/commands/org.ts
+++ b/src/cli/commands/org.ts
@@ -266,6 +266,7 @@ type OrgUpdateOpts = {
   description?: string;
   category?: string | boolean;
   avatar?: string | boolean;
+  paused?: boolean;
   json?: boolean;
   dryRun?: boolean;
 };
@@ -293,6 +294,8 @@ async function orgUpdateAction(identifier: string, opts: OrgUpdateOpts): Promise
   if (opts.avatar === false) updates.avatarUrl = null;
   else if (typeof opts.avatar === "string") updates.avatarUrl = opts.avatar;
 
+  if (opts.paused !== undefined) updates.fetchPaused = opts.paused;
+
   if (Object.keys(updates).length === 0) {
     logger.warn("No fields to update.");
     process.exit(1);
@@ -311,7 +314,13 @@ async function orgUpdateAction(identifier: string, opts: OrgUpdateOpts): Promise
   const updated = await updateOrg(found.slug, updates);
 
   if (opts.json) await writeJson(updated);
-  else logger.info(chalk.green(`Updated organization: ${updated.name} (${updated.slug})`));
+  else {
+    const pausedSuffix =
+      opts.paused === true ? "  — paused" : opts.paused === false ? "  — unpaused" : "";
+    logger.info(
+      chalk.green(`Updated organization: ${updated.name} (${updated.slug})${pausedSuffix}`),
+    );
+  }
 }
 
 type OrgDeleteOpts = { json?: boolean; dryRun?: boolean; hard?: boolean; yes?: boolean };
@@ -613,6 +622,8 @@ Examples:
     .option("--no-category", "Clear category")
     .option("--avatar <url>", "Set avatar image URL")
     .option("--no-avatar", "Clear avatar URL")
+    .option("--paused", "Pause ingest for all of this org's sources (catalog stays visible)")
+    .option("--no-paused", "Resume ingest for this org's sources")
     .option("--json", "Output as JSON")
     .option("--dry-run", "Show what would change without writing")
     .action(orgUpdateAction);
@@ -629,6 +640,8 @@ Examples:
     .option("--no-category", "Clear category")
     .option("--avatar <url>", "Set avatar image URL")
     .option("--no-avatar", "Clear avatar URL")
+    .option("--paused", "Pause ingest for all of this org's sources (catalog stays visible)")
+    .option("--no-paused", "Resume ingest for this org's sources")
     .option("--json", "Output as JSON")
     .option("--dry-run", "Show what would change without writing")
     .action(warnDeprecatedAlias<[string, OrgUpdateOpts]>("edit", "update", orgUpdateAction));

--- a/tests/cli/org-update-paused.test.ts
+++ b/tests/cli/org-update-paused.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "bun:test";
+import { runCli } from "../utils.js";
+
+/**
+ * Surface coverage for `releases admin org update --paused` (issue #178).
+ *
+ * The body assembly (`updates.fetchPaused = opts.paused`) is exercised end-to-end
+ * by the API tests in the monorepo PR that landed `fetchPaused`. Here we only
+ * assert that the flags are registered on both the canonical `update` and the
+ * deprecated `edit` alias, so muscle-memory callers don't fail silently.
+ */
+describe("admin org update --paused (CLI surface)", () => {
+  it("exposes --paused / --no-paused on `org update`", () => {
+    const { stdout, exitCode } = runCli(["admin", "org", "update", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--paused");
+    expect(stdout).toContain("--no-paused");
+  });
+
+  it("exposes --paused / --no-paused on the deprecated `org edit` alias", () => {
+    const { stdout, exitCode } = runCli(["admin", "org", "edit", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--paused");
+    expect(stdout).toContain("--no-paused");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #178.

- `admin org update` (and the deprecated `edit` alias) now accept `--paused` / `--no-paused`, mirroring the `--enable` / `--disable` shape on `admin source update`.
- The flag lands as `{ fetchPaused: true | false }` in the existing `updateOrg(slug, updates)` call — no new client function. The field was added to `UpdateOrgBodySchema` server-side in [buildinternet/releases#1064](https://github.com/buildinternet/releases/pull/1064).
- The success line gets a `— paused` / `— unpaused` suffix when the flag is set so the operator confirmation matches the issue's mock.

Diff: 14 lines in `src/cli/commands/org.ts`, surface-level test, changeset for the minor bump.

## Test plan

- [x] `bun test` — 307 pass, 2 new
- [x] `npx tsc --noEmit` — clean
- [x] `bun run lint` / `bun run format:check` — clean
- [x] `releases admin org update --help` exposes `--paused` / `--no-paused`
- [x] `releases admin org update notion --paused --dry-run` prints `fetchPaused → true`
- [x] `releases admin org update notion --no-paused --dry-run` prints `fetchPaused → false`
- [ ] End-to-end against an org once `@buildinternet/releases-api-types` republishes with `fetchPaused` on `UpdateOrgBodySchema` (out of scope for this PR; the server already accepts the field — the api-types bump is needed for downstream type-checking, not for runtime).

## Notes for review

- The published `@buildinternet/releases-api-types@0.19.0` doesn't yet carry `fetchPaused` on `UpdateOrgBodySchema`. #1064 added it to the source but didn't bump the package version, so the `publish-api-types.yml` workflow (which gates on `packages/api-types/package.json`) didn't fire. The CLI's `updateOrg(slug, Record<string, unknown>)` signature means this PR is type-safe regardless; we'll want a monorepo follow-up to bump the api-types version so downstream consumers get the typed field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--paused` and `--no-paused` flags to the `admin org update` command and its `admin org edit` alias to control organization-level ingest pause state.
  * Success output now appends “— paused” or “— unpaused” when the pause flag is used.

* **Tests**
  * Added test coverage validating the new pause flags appear in CLI help output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/buildinternet/releases-cli/pull/179?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->