### PR TITLE
fix(release): install shell completions in the auto-generated tap formula

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,10 +158,13 @@ jobs:
               # (e.g. releases-darwin-arm64). Rename to "releases" on install.
               binary = Dir["releases-*"].find { |f| File.file?(f) }
               bin.install binary => "releases"
+
+              generate_completions_from_executable(bin/"releases", "completion", shells: [:bash, :zsh, :fish])
             end
 
             test do
               assert_match "releases", shell_output("#{bin}/releases --version")
+              assert_match "complete -F _releases releases", shell_output("#{bin}/releases completion bash")
             end
           end
           FORMULA


### PR DESCRIPTION
## Summary

- The release workflow at `.github/workflows/release.yml:129-167` generates `Formula/releases.rb` from a heredoc template on every published release and force-pushes it to `buildinternet/homebrew-tap@main`. Anything edited directly in the tap repo gets clobbered.
- Adds `generate_completions_from_executable(bin/"releases", "completion", shells: [:bash, :zsh, :fish])` to the template's `def install` block so the next release produces a formula that auto-installs bash/zsh/fish completions for `brew` users.
- Adds a `test do` line asserting `releases completion bash` emits the expected `complete -F` directive, so a broken `completion` subcommand would fail `brew test` and surface before users hit it.

Pairs with #180 (added the `releases completion` subcommand). **Merge this before cutting the next CLI release** — without it, the new release ships the same no-completions formula as today.

## Test plan

- [x] Diff is minimal — 3 lines, all inside the existing heredoc template.
- [ ] After release, verify `brew install buildinternet/tap/releases` writes completion files to `$(brew --prefix)/share/{bash-completion/completions,zsh/site-functions,fish/vendor_completions.d}/`.
- [ ] After release, verify `brew test releases` passes.
