### PR TITLE
feat(mcp,cli): filter empty orgs by default; add include_empty / --include-empty opt-in

### DIFF
--- a/.changeset/feat-filter-empty-orgs-746.md
+++ b/.changeset/feat-filter-empty-orgs-746.md
@@ -1,0 +1,8 @@
+---
+"@buildinternet/releases": minor
+---
+
+MCP `list_organizations` now mirrors the remote MCP default of hiding orgs
+with zero indexed releases. Pass `include_empty: true` to see them.
+CLI `releases org list` gains `--include-empty` for the same opt-in.
+See buildinternet/releases#746.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,10 +158,13 @@ jobs:
               # (e.g. releases-darwin-arm64). Rename to "releases" on install.
               binary = Dir["releases-*"].find { |f| File.file?(f) }
               bin.install binary => "releases"
+
+              generate_completions_from_executable(bin/"releases", "completion", shells: [:bash, :zsh, :fish])
             end
 
             test do
               assert_match "releases", shell_output("#{bin}/releases --version")
+              assert_match "complete -F _releases releases", shell_output("#{bin}/releases completion bash")
             end
           end
           FORMULA

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -222,12 +222,14 @@ export async function listOrgs(opts?: {
   platform?: string;
   limit?: number;
   page?: number;
+  includeEmpty?: boolean;
 }): Promise<ListResponse<Organization>> {
   const params = new URLSearchParams();
   if (opts?.query) params.set("q", opts.query);
   if (opts?.platform) params.set("platform", opts.platform);
   if (opts?.limit != null) params.set("limit", String(opts.limit));
   if (opts?.page != null) params.set("page", String(opts.page));
+  if (opts?.includeEmpty) params.set("includeEmpty", "true");
   const qs = params.toString();
   return apiFetch<ListResponse<Organization>>(`/v1/orgs${qs ? `?${qs}` : ""}`);
 }

--- a/src/cli/commands/org.ts
+++ b/src/cli/commands/org.ts
@@ -439,6 +439,7 @@ export function registerOrgCommand(program: Command) {
     .description("List all organizations")
     .option("--query <text>", "Filter by name, slug, domain, handle, or org_ id")
     .option("--platform <platform>", "Filter to orgs with an account on this platform")
+    .option("--include-empty", "Include orgs with zero indexed releases (curator stubs)")
     .option("--json", "Output as JSON")
     .option("--limit <n>", `Limit the number of results (default ${DEFAULT_PAGE_SIZE})`)
     .option("--page <n>", "Page number for paginated results")
@@ -446,6 +447,7 @@ export function registerOrgCommand(program: Command) {
       async (opts: {
         query?: string;
         platform?: string;
+        includeEmpty?: boolean;
         json?: boolean;
         limit?: string;
         page?: string;
@@ -468,6 +470,7 @@ export function registerOrgCommand(program: Command) {
         const { items: pageItems, pagination } = await listOrgs({
           query: opts.query,
           platform: opts.platform,
+          includeEmpty: opts.includeEmpty,
           limit: pageSize,
           page,
         });

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -311,16 +311,23 @@ server.registerTool(
 server.registerTool(
   "list_organizations",
   {
-    description: "List all indexed organizations, optionally filtered",
+    description:
+      "List all indexed organizations, optionally filtered. Orgs with zero indexed releases are hidden by default (curator-stub noise); set `include_empty: true` to see them.",
     inputSchema: {
       query: z
         .string()
         .optional()
         .describe("Search across org name, slug, domain, and account handles"),
       platform: z.string().optional().describe("Filter to orgs with an account on this platform"),
+      include_empty: z
+        .boolean()
+        .optional()
+        .describe(
+          "Include orgs with zero indexed releases (curator stubs). Omit or set false to hide them.",
+        ),
     },
   },
-  async ({ query, platform }) => {
+  async ({ query, platform, include_empty }) => {
     // /v1/orgs is paginated server-side post-#723; page through every result so
     // the tool truly lists all indexed organizations, not just the first page.
     const allOrgs: Awaited<ReturnType<typeof listOrgs>>["items"] = [];
@@ -328,7 +335,13 @@ server.registerTool(
     let hasMore = true;
     while (hasMore) {
       // eslint-disable-next-line no-await-in-loop
-      const result = await listOrgs({ query, platform, page, limit: 200 });
+      const result = await listOrgs({
+        query,
+        platform,
+        page,
+        limit: 200,
+        includeEmpty: include_empty,
+      });
       allOrgs.push(...result.items);
       hasMore = result.pagination.hasMore;
       page += 1;


### PR DESCRIPTION
## Summary

- **`src/api/client.ts`** — `listOrgs()` gains `includeEmpty?: boolean`; emits `includeEmpty=true` on the query string when set (mirrors the wire-param name from buildinternet/releases#1071).
- **`src/mcp/server.ts`** — `list_organizations` tool gains `include_empty: boolean` input with description matching the remote MCP wording; threads through to `listOrgs`; tool description updated to document the new default.
- **`src/cli/commands/org.ts`** — `releases org list` gains `--include-empty` flag and threads it through to `listOrgs`.
- **`.changeset/feat-filter-empty-orgs-746.md`** — minor bump on `@buildinternet/releases`.

This is the second half of buildinternet/releases#746 (monorepo PR buildinternet/releases#1071). The wire change (`includeEmpty` query param, API default of hiding empty orgs) is additive and ships in the monorepo. This PR brings the OSS CLI into alignment so power users and curators have the opt-in surface.

## Test plan

- [x] \`bun test\` — 339 tests pass, 0 failures
- [x] \`bun run lint\` — 0 warnings, 0 errors
- [x] \`npx tsc --noEmit\` — clean
- [x] \`bun run format\` — no unexpected diffs
- [ ] After monorepo deploy: smoke-test \`releases org list\` (default hides stubs) and \`releases org list --include-empty\` (stubs visible)

Closes buildinternet/releases#746 (CLI side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)