### PR TITLE
fix(cli): reject partial integers in parsePositiveIntFlag

### DIFF
--- a/.changeset/fix-177-parse-positive-int-flag.md
+++ b/.changeset/fix-177-parse-positive-int-flag.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": patch
+---
+
+fix(cli): reject partial integers in parsePositiveIntFlag — "1.5" and "10abc" no longer silently truncate to 1 and 10 (#177)

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -7,7 +7,11 @@ import chalk from "chalk";
  */
 export function parsePositiveIntFlag(label: string, raw: string | undefined): number | undefined {
   if (raw === undefined) return undefined;
-  const n = Number.parseInt(raw, 10);
+  // Strict integer match first — Number.parseInt would silently accept "1.5" → 1
+  // and "10abc" → 10. Allow an optional leading minus so the range check below
+  // produces the same error message for "-1" as it does for "1.5".
+  const isInt = /^-?\d+$/.test(raw);
+  const n = isInt ? Number.parseInt(raw, 10) : NaN;
   if (!Number.isFinite(n) || n <= 0) {
     console.error(chalk.red(`Invalid --${label}: must be a positive integer (got ${raw})`));
     process.exit(2);

--- a/tests/unit/flags.test.ts
+++ b/tests/unit/flags.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, spyOn } from "bun:test";
+import { parsePositiveIntFlag, parseNonNegIntFlag } from "../../src/lib/flags.js";
+
+// Intercept process.exit so invalid-input tests don't kill the runner.
+function withExitTrap(fn: () => void): void {
+  const spy = spyOn(process, "exit").mockImplementation(() => {
+    throw new Error("process.exit called");
+  });
+  try {
+    fn();
+  } finally {
+    spy.mockRestore();
+  }
+}
+
+describe("parsePositiveIntFlag", () => {
+  it("returns undefined when the flag is not supplied", () => {
+    expect(parsePositiveIntFlag("limit", undefined)).toBeUndefined();
+  });
+
+  it("accepts a plain positive integer string", () => {
+    expect(parsePositiveIntFlag("limit", "1")).toBe(1);
+    expect(parsePositiveIntFlag("limit", "100")).toBe(100);
+  });
+
+  it("rejects a decimal string (1.5 must not silently become 1)", () => {
+    withExitTrap(() => {
+      expect(() => parsePositiveIntFlag("limit", "1.5")).toThrow("process.exit called");
+    });
+  });
+
+  it("rejects a string with trailing non-digit chars (10abc must not become 10)", () => {
+    withExitTrap(() => {
+      expect(() => parsePositiveIntFlag("limit", "10abc")).toThrow("process.exit called");
+    });
+  });
+
+  it("rejects zero", () => {
+    withExitTrap(() => {
+      expect(() => parsePositiveIntFlag("limit", "0")).toThrow("process.exit called");
+    });
+  });
+
+  it("rejects a negative integer", () => {
+    withExitTrap(() => {
+      expect(() => parsePositiveIntFlag("limit", "-1")).toThrow("process.exit called");
+    });
+  });
+
+  it("rejects a non-numeric string", () => {
+    withExitTrap(() => {
+      expect(() => parsePositiveIntFlag("limit", "abc")).toThrow("process.exit called");
+    });
+  });
+});
+
+describe("parseNonNegIntFlag", () => {
+  it("returns undefined when the flag is not supplied", () => {
+    expect(parseNonNegIntFlag("offset", undefined)).toBeUndefined();
+  });
+
+  it("accepts zero", () => {
+    expect(parseNonNegIntFlag("offset", "0")).toBe(0);
+  });
+
+  it("accepts a plain positive integer string", () => {
+    expect(parseNonNegIntFlag("offset", "42")).toBe(42);
+  });
+
+  it("rejects a decimal string (1.5 must not silently become 1)", () => {
+    withExitTrap(() => {
+      expect(() => parseNonNegIntFlag("offset", "1.5")).toThrow("process.exit called");
+    });
+  });
+
+  it("rejects a string with trailing non-digit chars (10abc must not become 10)", () => {
+    withExitTrap(() => {
+      expect(() => parseNonNegIntFlag("offset", "10abc")).toThrow("process.exit called");
+    });
+  });
+
+  it("rejects a negative integer", () => {
+    withExitTrap(() => {
+      expect(() => parseNonNegIntFlag("offset", "-1")).toThrow("process.exit called");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- `parsePositiveIntFlag` in `src/lib/flags.ts` had the same partial-integer parsing bug as `parseNonNegIntFlag` before PR #175: `Number.parseInt("1.5", 10)` returns `1` and `Number.parseInt("10abc", 10)` returns `10`, both slipping past the existing `Number.isFinite` guard.
- Fix mirrors the regex guard already used by `parseNonNegIntFlag`: test `/^-?\d+$/` before parsing, so non-integer strings produce `NaN` and hit the error path.
- Adds `tests/unit/flags.test.ts` covering both helpers with acceptance cases (`"1"`, `"100"`, `"0"` for non-neg) and rejection cases (`"1.5"`, `"10abc"`, `"0"`, `"-1"`, non-numeric strings).

Closes #177

## Test plan

- [ ] `bun test tests/unit/flags.test.ts` — all 13 cases green
- [ ] `bun test` — full suite passes (352 tests)
- [ ] `bun run typecheck` — no errors
- [ ] `bun run lint` — 0 warnings, 0 errors
- [ ] `bun run format:check` — all files formatted
