### PR TITLE
feat(cli): remove deprecated --notes / --parse-instructions inline forms (Phase 2 of #103)

### DIFF
--- a/.changeset/remove-inline-notes-parse-instructions.md
+++ b/.changeset/remove-inline-notes-parse-instructions.md
@@ -1,0 +1,7 @@
+---
+"@buildinternet/releases": minor
+---
+
+Remove deprecated `--notes` and `--parse-instructions` inline flags (Phase 2 of #103).
+
+Both flags were deprecated in Phase 1 (#118) with file-based replacements. They are now removed; passing either flag exits non-zero with `unknown option`. Use `--notes-file` and `--parse-instructions-file` (or `-` for stdin) instead.

--- a/src/cli/commands/admin/playbook.ts
+++ b/src/cli/commands/admin/playbook.ts
@@ -3,12 +3,11 @@ import chalk from "chalk";
 import { findOrg, getPlaybook, updatePlaybookNotes } from "../../../api/client.js";
 import { orgNotFound } from "../../suggest.js";
 import { writeJson } from "../../../lib/output.js";
-import { resolveInlineOrFile } from "../../../lib/input.js";
+import { readContentArg } from "../../../lib/input.js";
 import { timeAgo } from "@buildinternet/releases-core/dates";
 
 interface PlaybookOpts {
   json?: boolean;
-  notes?: string;
   notesFile?: string;
 }
 
@@ -18,10 +17,6 @@ export function registerPlaybookCommand(program: Command) {
     .description("Read or update an organization's playbook")
     .argument("<org>", "Organization slug or ID")
     .option("--json", "Output as JSON")
-    .option(
-      "--notes <text>",
-      "(deprecated — use --notes-file) Replace agent notes inline; quote-hostile, prefer --notes-file",
-    )
     .option(
       "--notes-file <path>",
       "Path to file with agent notes (use - for stdin; empty file clears)",
@@ -37,18 +32,11 @@ Examples:
 
 The playbook's header (source list, products) regenerates automatically after
 any source add/edit/remove — no manual regenerate step is needed. The PATCH
-run by --notes-file also seeds a fresh header on first write.
-
---notes (inline) is deprecated and will be removed in a future minor release.
-Quoting markdown across newlines is fragile; prefer --notes-file.`,
+run by --notes-file also seeds a fresh header on first write.`,
     )
     .action(async (orgIdentifier: string, opts: PlaybookOpts) => {
-      const notesPayload = await resolveInlineOrFile({
-        inline: opts.notes,
-        file: opts.notesFile,
-        inlineName: "--notes",
-        fileName: "--notes-file",
-      });
+      const notesPayload =
+        opts.notesFile !== undefined ? await readContentArg(opts.notesFile) : undefined;
 
       const org = await findOrg(orgIdentifier);
       if (!org) return orgNotFound(orgIdentifier);

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -12,7 +12,7 @@ import { sourceNotFound } from "../suggest.js";
 import { toSlug } from "@buildinternet/releases-core/slug";
 import { logger } from "@releases/lib/logger";
 import { writeJson } from "../../lib/output.js";
-import { resolveInlineOrFile } from "../../lib/input.js";
+import { readContentArg } from "../../lib/input.js";
 
 const VALID_TYPES = ["github", "scrape", "feed", "agent"] as const;
 
@@ -36,7 +36,7 @@ export type UpdateSourceOpts = {
   markdownUrl?: string;
   provider?: string;
   fetchMethod?: string;
-  parseInstructions?: string | boolean;
+  parseInstructions?: boolean;
   parseInstructionsFile?: string;
   categoryAllow?: string | boolean;
   render?: boolean;
@@ -82,23 +82,14 @@ export async function updateSourceAction(
   identifier: string,
   opts: UpdateSourceOpts,
 ): Promise<void> {
-  // `--no-parse-instructions` produces `false` and is mutually exclusive with
-  // any other parse-instructions flag (mirrors the inline-vs-file mutex below).
-  // The string and file forms collapse via the shared resolver: file contents
-  // become the value, and an empty file clears (matches `--parse-instructions ""`).
-  if (opts.parseInstructions !== undefined && opts.parseInstructionsFile !== undefined) {
-    logger.error("--parse-instructions and --parse-instructions-file are mutually exclusive");
-    process.exit(1);
-  }
+  // `--no-parse-instructions` produces `false` (boolean); `--parse-instructions-file`
+  // provides the content string. An empty file clears (matches the empty-string case).
   const parseInstructions: string | false | undefined =
     opts.parseInstructions === false
       ? false
-      : await resolveInlineOrFile({
-          inline: typeof opts.parseInstructions === "string" ? opts.parseInstructions : undefined,
-          file: opts.parseInstructionsFile,
-          inlineName: "--parse-instructions",
-          fileName: "--parse-instructions-file",
-        });
+      : opts.parseInstructionsFile !== undefined
+        ? await readContentArg(opts.parseInstructionsFile)
+        : undefined;
 
   const source = await findSource(identifier);
   if (!source) return sourceNotFound(identifier);
@@ -362,10 +353,6 @@ export function attachUpdateOptions(cmd: Command): Command {
     .option("--no-feed-url", "Remove stored feed URL")
     .option("--markdown-url <markdownUrl>", "Set the raw markdown URL for this source")
     .option(
-      "--parse-instructions <text>",
-      "(deprecated — use --parse-instructions-file) Set AI parsing instructions inline; quote-hostile, prefer the file form",
-    )
-    .option(
       "--parse-instructions-file <path>",
       "Path to file with AI parsing instructions (use - for stdin; empty file clears)",
     )
@@ -401,11 +388,7 @@ export function registerUpdateCommand(program: Command) {
 Examples:
   releases update src_abc123 --primary
   releases update src_abc123 --parse-instructions-file parse.md
-  cat parse.md | releases update src_abc123 --parse-instructions-file -
-
---parse-instructions (inline) is deprecated and will be removed in a future
-minor release. Quoting markdown across newlines is fragile; prefer
---parse-instructions-file.`,
+  cat parse.md | releases update src_abc123 --parse-instructions-file -`,
     )
     .action(updateSourceAction);
 }

--- a/src/lib/input.ts
+++ b/src/lib/input.ts
@@ -17,39 +17,3 @@ export async function readContentArg(pathOrDash: string): Promise<string> {
     process.exit(1);
   }
 }
-
-/**
- * Resolve a deprecated inline-string flag and its `--*-file` replacement to a
- * single payload string.
- *
- * - Errors and exits 1 if both forms are provided (mutually exclusive).
- * - Reads the file (or stdin when `"-"`) when `file` is set.
- * - Warns once that the inline form is deprecated when only `inline` is set.
- * - Returns `undefined` if neither form was provided.
- *
- * Used by `--notes` / `--notes-file` (admin playbook) and
- * `--parse-instructions` / `--parse-instructions-file` (source update).
- */
-export async function resolveInlineOrFile(args: {
-  inline: string | undefined;
-  file: string | undefined;
-  inlineName: string;
-  fileName: string;
-}): Promise<string | undefined> {
-  const { inline, file, inlineName, fileName } = args;
-
-  if (inline !== undefined && file !== undefined) {
-    logger.error(`${inlineName} and ${fileName} are mutually exclusive`);
-    process.exit(1);
-  }
-  if (file !== undefined) {
-    return readContentArg(file);
-  }
-  if (inline !== undefined) {
-    logger.warn(
-      `"${inlineName}" is deprecated, use "${fileName} <path>" (use - for stdin); the inline form will be removed in a future release.`,
-    );
-    return inline;
-  }
-  return undefined;
-}

--- a/tests/cli/notes-and-parse-instructions-file.test.ts
+++ b/tests/cli/notes-and-parse-instructions-file.test.ts
@@ -2,11 +2,12 @@ import { describe, it, expect } from "bun:test";
 import { runCli } from "../utils.js";
 
 /**
- * Coverage for #103 workstream 3: --notes-file / --parse-instructions-file
- * replace the inline string forms (which are quote-hostile and silently
- * truncate at unescaped newlines for AI-generated bodies).
+ * Coverage for #103 workstream 3 and Phase 2 (#119):
+ * --notes-file / --parse-instructions-file are the only supported forms.
+ * The deprecated inline --notes / --parse-instructions flags were removed in
+ * Phase 2 and now exit non-zero as unknown options.
  *
- * Behavioral coverage uses --help and the mutex error path because
+ * Behavioral coverage uses --help and commander's unknown-option path because
  * exercising the full flow requires HTTP mocks (per the convention
  * documented in idempotent-create.test.ts).
  */
@@ -20,20 +21,18 @@ describe("admin playbook --notes-file (#103 ws3)", () => {
     expect(stdout).toContain("--notes-file");
   });
 
-  it("keeps --notes documented but marks it deprecated", () => {
+  it("does not document removed --notes flag in --help", () => {
     const { stdout, exitCode } = runCli(["admin", "playbook", "--help"], { env: adminEnv });
     expect(exitCode).toBe(0);
-    expect(stdout).toContain("--notes <text>");
-    expect(stdout).toContain("(deprecated — use --notes-file)");
+    expect(stdout).not.toContain("--notes <text>");
   });
 
-  it("errors when --notes and --notes-file are passed together", () => {
-    const { stderr, exitCode } = runCli(
-      ["admin", "playbook", "acme", "--notes", "x", "--notes-file", "-"],
-      { env: adminEnv },
-    );
-    expect(exitCode).toBe(1);
-    expect(stderr).toContain("--notes and --notes-file are mutually exclusive");
+  it("exits non-zero with unknown option error for removed --notes flag", () => {
+    const { stderr, exitCode } = runCli(["admin", "playbook", "acme", "--notes", "x"], {
+      env: adminEnv,
+    });
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("unknown option '--notes'");
   });
 });
 
@@ -52,30 +51,18 @@ describe("source update --parse-instructions-file (#103 ws3)", () => {
     expect(stdout).toContain("--parse-instructions-file");
   });
 
-  it("keeps --parse-instructions documented but marks it deprecated", () => {
+  it("does not document removed --parse-instructions flag in update --help", () => {
     const { stdout, exitCode } = runCli(["admin", "source", "update", "--help"], { env: adminEnv });
     expect(exitCode).toBe(0);
-    expect(stdout).toContain("--parse-instructions <text>");
-    expect(stdout).toContain("(deprecated — use --parse-instructions-file)");
+    expect(stdout).not.toContain("--parse-instructions <text>");
   });
 
-  it("errors when --parse-instructions and --parse-instructions-file are passed together", () => {
+  it("exits non-zero with unknown option error for removed --parse-instructions flag", () => {
     const { stderr, exitCode } = runCli(
-      [
-        "admin",
-        "source",
-        "update",
-        "src_dummy",
-        "--parse-instructions",
-        "x",
-        "--parse-instructions-file",
-        "-",
-      ],
+      ["admin", "source", "update", "src_dummy", "--parse-instructions", "x"],
       { env: adminEnv },
     );
-    expect(exitCode).toBe(1);
-    expect(stderr).toContain(
-      "--parse-instructions and --parse-instructions-file are mutually exclusive",
-    );
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("unknown option '--parse-instructions'");
   });
 });


### PR DESCRIPTION
## Summary

Phase 2 of the `--notes` / `--parse-instructions` deprecation (#103, first deprecated in #118). The inline forms are now removed:

- `releases admin playbook <org> --notes <text>` — flag dropped; exits non-zero with `error: unknown option '--notes'`
- `releases admin source update <id> --parse-instructions <text>` — flag dropped; exits non-zero with `error: unknown option '--parse-instructions'`
- `resolveInlineOrFile()` helper removed from `src/lib/input.ts` (was only used by the two removed flags; `readContentArg` is the only remaining reader)
- `UpdateSourceOpts.parseInstructions` narrowed from `string | boolean` to `boolean` — the inline-string branch is gone

The file-based forms remain and are unchanged:
- `--notes-file <path>` (use `-` for stdin)
- `--parse-instructions-file <path>` (use `-` for stdin)
- `--no-parse-instructions` (boolean clear flag)

Changeset: minor bump (`@buildinternet/releases`).

## Acceptance criteria

- [x] `releases admin playbook acme --notes "x"` exits non-zero with `unknown option '--notes'`
- [x] `releases admin source update src_x --parse-instructions "x"` exits non-zero with `unknown option '--parse-instructions'`
- [x] `releases admin playbook acme --notes-file -` continues to work (existing behavior preserved)
- [x] `--parse-instructions-file -` continues to work (existing behavior preserved)
- [x] No inline `--notes "..."` / `--parse-instructions "..."` examples remain in CLI skills or docs

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — 0 warnings, 0 errors
- [x] `bun run format:check` — clean
- [x] `bun test` — 339 pass, 0 fail (updated `tests/cli/notes-and-parse-instructions-file.test.ts`: replaced "deprecated but documented" + mutex-error assertions with "not in --help" + "unknown option" assertions)
- [x] Monorepo sweep (`src/agent/skills/`, `plugins/claude/releases/`, `web/src/content/docs/`, `.claude/commands/`) — no stale inline-form examples found; no monorepo PR needed

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)
