### PR TITLE
chore(cli): bump api-types to 0.21.0 + cursor SourceDetail formatter

### DIFF
--- a/.changeset/api-types-021-cursor-pagination.md
+++ b/.changeset/api-types-021-cursor-pagination.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": patch
+---
+
+chore(cli): bump `@buildinternet/releases-api-types` to `^0.21.0` and align `sourceToMarkdown` with the cursor-paginated `SourceDetail` shape. The helper had no callers in production code; this is a types-alignment fix with zero runtime impact.

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "releases-cli",
       "dependencies": {
-        "@buildinternet/releases-api-types": "^0.20.0",
+        "@buildinternet/releases-api-types": "^0.21.0",
         "@buildinternet/releases-core": "^0.21.0",
         "@buildinternet/releases-lib": "workspace:*",
         "@buildinternet/releases-skills": "workspace:*",
@@ -73,7 +73,7 @@
 
     "@buildinternet/releases": ["@buildinternet/releases@workspace:npm/releases"],
 
-    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.20.0", "", { "dependencies": { "@buildinternet/releases-core": "^0.21.0", "zod": "^4.4.3" } }, "sha512-RoU/YU5QxvJdkptiVepy0T2q34UA6IvohKGJJMJM41/H++IID/MeI+iab7DbYTpLaFOp0heXh4pIdODWenqXEg=="],
+    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.21.0", "", { "dependencies": { "@buildinternet/releases-core": "^0.21.0", "zod": "^4.4.3" } }, "sha512-2ZTTTxO2GrMXJZFufQ9ADs2YR1BjHLQGP4H/5fUEqrQFzXJJVqfjavELm4NK1koFhR2jsTWEDzIAzPoD6rq+GQ=="],
 
     "@buildinternet/releases-core": ["@buildinternet/releases-core@0.21.0", "", { "dependencies": { "drizzle-orm": "^0.45.2", "js-tiktoken": "^1.0.21", "nanoid": "^5.1.7" } }, "sha512-tWLBc3BvBot1Rrb5j3X2RPSogcgm5+hwFlnQocMTHFgF8gtF4jZRM7Mc+HoGNOlMJHacH1uyqt2nDcqTGZaNZQ=="],
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "homepage": "https://releases.sh",
   "dependencies": {
-    "@buildinternet/releases-api-types": "^0.20.0",
+    "@buildinternet/releases-api-types": "^0.21.0",
     "@buildinternet/releases-core": "^0.21.0",
     "@buildinternet/releases-lib": "workspace:*",
     "@buildinternet/releases-skills": "workspace:*",

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -154,18 +154,14 @@ export function sourceToMarkdown(source: SourceDetail, opts: FormatOptions = {})
   }
 
   // ── Pagination ──
-  if ((source.pagination.totalPages ?? 0) > 1) {
-    const paginationAttrs = [
-      `page="${source.pagination.page}"`,
-      `total-pages="${source.pagination.totalPages}"`,
-      `total-items="${source.pagination.totalItems}"`,
-    ];
+  if (source.pagination.nextCursor) {
+    const cursorAttrs = [`cursor="${source.pagination.nextCursor}"`];
     if (opts.baseUrl) {
-      paginationAttrs.push(
-        `next="${opts.baseUrl}${sourcePath}.md?page=${source.pagination.page + 1}"`,
+      cursorAttrs.push(
+        `next="${opts.baseUrl}${sourcePath}.md?cursor=${encodeURIComponent(source.pagination.nextCursor)}&limit=${source.pagination.limit}"`,
       );
     }
-    lines.push(`<Pagination ${paginationAttrs.join(" ")} />`);
+    lines.push(`<Pagination ${cursorAttrs.join(" ")} />`);
     lines.push("");
   }
 

--- a/tests/unit/formatters.test.ts
+++ b/tests/unit/formatters.test.ts
@@ -39,7 +39,7 @@ const fullSource: FormatSourceDetail = {
       url: null,
     },
   ],
-  pagination: { page: 1, pageSize: 20, totalPages: 1, totalItems: 2 },
+  pagination: { nextCursor: null, limit: 20 },
   summaries: {
     rolling: {
       windowDays: 90,
@@ -195,18 +195,18 @@ describe("sourceToMarkdown", () => {
     expect(md).toContain("## Next.js 15");
   });
 
-  it("does NOT show Pagination when totalPages is 1", () => {
+  it("does NOT show Pagination when nextCursor is null", () => {
     const md = sourceToMarkdown(fullSource);
     expect(md).not.toContain("<Pagination");
   });
 
-  it("shows Pagination tag when totalPages > 1", () => {
+  it("shows Pagination tag when nextCursor is present", () => {
     const source: FormatSourceDetail = {
       ...fullSource,
-      pagination: { page: 1, pageSize: 20, totalPages: 3, totalItems: 55 },
+      pagination: { nextCursor: "tok_abc123", limit: 20 },
     };
     const md = sourceToMarkdown(source);
-    expect(md).toContain('<Pagination page="1" total-pages="3" total-items="55"');
+    expect(md).toContain('<Pagination cursor="tok_abc123"');
   });
 
   it("includes canonical URL when baseUrl is provided", () => {
@@ -215,13 +215,13 @@ describe("sourceToMarkdown", () => {
     expect(md).toContain("organization_url: https://releases.sh/vercel");
   });
 
-  it("includes next page URL in Pagination when baseUrl is provided", () => {
+  it("includes next cursor URL in Pagination when baseUrl is provided", () => {
     const source: FormatSourceDetail = {
       ...fullSource,
-      pagination: { page: 1, pageSize: 20, totalPages: 3, totalItems: 55 },
+      pagination: { nextCursor: "tok_abc123", limit: 20 },
     };
     const md = sourceToMarkdown(source, { baseUrl: "https://releases.sh" });
-    expect(md).toContain('next="https://releases.sh/vercel/next-js.md?page=2"');
+    expect(md).toContain('next="https://releases.sh/vercel/next-js.md?cursor=tok_abc123&limit=20"');
   });
 
   it("omits canonical URL when baseUrl is not provided", () => {

--- a/tests/unit/formatters.test.ts
+++ b/tests/unit/formatters.test.ts
@@ -16,7 +16,7 @@ const fullSource: FormatSourceDetail = {
   type: "github",
   url: "https://github.com/vercel/next.js",
   changelogUrl: "https://nextjs.org/changelog",
-  org: { slug: "vercel", name: "Vercel" },
+  org: { id: "org_vercel", slug: "vercel", name: "Vercel" },
   releaseCount: 150,
   latestVersion: "15.0.0",
   latestDate: "2024-06-15T00:00:00Z",
@@ -73,6 +73,7 @@ const fullOrg: FormatOrgDetail = {
   releasesLast30Days: 12,
   avgReleasesPerWeek: 3.5,
   lastFetchedAt: "2024-06-16T00:00:00Z",
+  lastPolledAt: "2024-06-16T06:00:00Z",
   trackingSince: "2024-01-01T00:00:00Z",
   accounts: [
     { platform: "github", handle: "vercel" },


### PR DESCRIPTION
## Summary

- Bumps `@buildinternet/releases-api-types` to `^0.21.0` in `package.json`
- Updates `sourceToMarkdown` in `src/lib/formatters.ts` to use the cursor-paginated `SourceDetail.pagination` shape (`{ nextCursor, limit }` instead of `{ page, pageSize, totalPages, totalItems }`)
- Updates the corresponding tests in `tests/unit/formatters.test.ts` to match the new cursor shape
- **Lockfile refreshed to 0.21.0** — `@buildinternet/releases-api-types@0.21.0` was published to npm on 2026-05-19; `bun.lock` now resolves to `0.21.0`
- **Test fixtures updated** — `SourceOrgRefSchema` now requires `id`; `OrgDetailSchema` now requires `lastPolledAt`; both fields added to the test fixtures

This is a types-alignment fix with **zero runtime impact** — `sourceToMarkdown` has no callers in production code today.

Closes #182

## Test plan

- [x] `bun run typecheck` — passes
- [x] `bun test` — 339 tests pass
- [x] `bun run lint` — 0 warnings, 0 errors
- [x] `bun run format:check` — all files formatted correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
