### PR TITLE
feat(cli): `releases skills install` command

### DIFF
--- a/.changeset/feat-skills-install-187.md
+++ b/.changeset/feat-skills-install-187.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": minor
+---
+
+feat(cli): add `releases skills install` for cross-agent skill installation (#187). Thin wrapper around `npx skills add buildinternet/releases-cli` from the open agent-skills ecosystem (`vercel-labs/skills`), which auto-detects ~50 supported coding agents (Claude Code, Cursor, Codex, Gemini CLI, Windsurf, GitHub Copilot, …) and writes the 8 bundled skill files to the right per-agent directory. Forwards `--global`, `--agent <name>`, `--copy`, `--list`, and `--no-yes` to the underlying `skills add` invocation. Skills are symlinked by default, so re-running the command refreshes everything atomically.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ bun test                      # bun test
 - **`@buildinternet/releases-core`** — runtime-neutral helpers (schema, categories, slicing, IDs, slugs, tokens, CLI contracts). Published from the private [`buildinternet/releases`](https://github.com/buildinternet/releases) monorepo (canonical source in `packages/core/`), consumed here as a regular npm dependency. Bump the pin in `package.json` when adopting a new schema.
 - **`packages/lib/`** (`@buildinternet/releases-lib`) — logger, errors, trimmed config.
 - **`packages/skills/`** (`@buildinternet/releases-skills`) — thin wrapper around top-level `skills/` for consumers who want to load the bundled playbooks programmatically.
-- **`skills/`** — source of truth for agent skills. The Claude plugin in `plugins/claude/releases/skills/` is generated via `bun scripts/sync-plugin-skills.ts`.
+- **`skills/`** — source of truth for agent skills. The Claude plugin in `plugins/claude/releases/skills/` is generated via `bun scripts/sync-plugin-skills.ts`. Cross-agent install runs through `releases skills install`, which shells out to `npx skills add buildinternet/releases-cli` (the `vercel-labs/skills` ecosystem). Wiring is in `src/cli/commands/skills.ts`; pure argv construction in `src/cli/skills/build-args.ts`.
 - **`plugins/claude/releases/`** — Claude Code plugin. Bundles the hosted MCP connection + synced skills.
 - **`npm/`** — meta package (`@buildinternet/releases`) + four platform binary packages. CI writes the compiled binary into each platform package before publishing.
 

--- a/README.md
+++ b/README.md
@@ -124,13 +124,22 @@ The plugin bundles:
 
 ### Standalone skills (any agent)
 
-The bundled skills are also available as a standalone package. Install them into any Claude Code / Codex / Cursor / OpenCode workspace using the [`skills`](https://github.com/vercel-labs/skills) CLI, which reads the top-level `skills/` directory of this repo:
+The bundled skills are also available as a standalone package. The fastest way to install them is via the CLI:
+
+```bash
+releases skills install                       # detected agent, current project
+releases skills install --global              # user-wide instead of project
+releases skills install --agent cursor        # override detection
+releases skills install releases-mcp          # just the user-facing lookup skill
+```
+
+This is a thin wrapper around the [`skills`](https://github.com/vercel-labs/skills) CLI from the open agent-skills ecosystem (`vercel-labs/skills`), which auto-detects ~50 supported agents (Claude Code, Codex, Cursor, OpenCode, Gemini CLI, Windsurf, GitHub Copilot, …) and writes to the right per-agent skills directory. If you'd rather skip the `releases` CLI entirely, the underlying command is:
 
 ```bash
 npx skills add buildinternet/releases-cli
 ```
 
-Use this when you only want the skill behavior (auto-triggering on release/CLI questions) without also registering the hosted MCP connection, agents, and `/releases` command that the plugin provides.
+Use this path when you only want the skill behavior (auto-triggering on release/CLI questions) without also registering the hosted MCP connection, agents, and `/releases` command that the plugin provides. Skills are symlinked by default, so re-running `releases skills install` (or `npx skills update releases-cli`) refreshes everything atomically.
 
 ## Environment
 

--- a/plugins/claude/releases/README.md
+++ b/plugins/claude/releases/README.md
@@ -24,6 +24,13 @@ For local development, point Claude Code at a cloned copy instead:
 claude --plugin-dir plugins/claude/releases
 ```
 
+If you only want the bundled skills without the hosted MCP connection, `discovery`/`worker` agents, and `/releases` command, install the skills package directly from the [releases CLI](https://github.com/buildinternet/releases-cli):
+
+```bash
+releases skills install                # any supported agent — CLI must be installed
+npx skills add buildinternet/releases-cli   # equivalent, no `releases` CLI required
+```
+
 ## Available MCP Tools
 
 ### search

--- a/plugins/claude/releases/skills/releases-cli/SKILL.md
+++ b/plugins/claude/releases/skills/releases-cli/SKILL.md
@@ -25,6 +25,17 @@ npx @buildinternet/releases search "react"
 
 The CLI talks to `api.releases.sh` by default — no configuration needed for reader commands.
 
+### Refreshing this skill
+
+To install or refresh the bundled releases skills (this one + `releases-mcp`, `finding-changelogs`, etc.) for any supported agent:
+
+```bash
+releases skills install        # detected agent (auto), current project
+releases skills install -g     # user-wide install instead
+```
+
+Skills are symlinked by default — re-running `releases skills install` refreshes everything atomically.
+
 ## What this skill covers
 
 - **[Reader commands](references/reader.md)** — Search, inspect, and export changelog data. No API key required.

--- a/plugins/claude/releases/skills/releases-cli/references/reader.md
+++ b/plugins/claude/releases/skills/releases-cli/references/reader.md
@@ -91,7 +91,7 @@ releases categories          # list the canonical category values
 releases categories --json
 ```
 
-The category list is fixed — adding a new category requires a code change in `@buildinternet/releases-core`. Each canonical slug supports an optional editable overlay (display-name override, description byline, aliases) managed via `PATCH /v1/categories/:slug` on the API. Alias inputs (e.g. `e-commerce`) are resolved to their canonical slug on write paths and 301-redirect on read paths.
+The category list is fixed — adding a new category requires a code change in `@buildinternet/releases-core`.
 
 ## Changelog slicing (admin CLI, reader endpoint)
 

--- a/skills/releases-cli/SKILL.md
+++ b/skills/releases-cli/SKILL.md
@@ -22,6 +22,17 @@ npx @buildinternet/releases search "react"
 
 The CLI talks to `api.releases.sh` by default — no configuration needed for reader commands.
 
+### Refreshing this skill
+
+To install or refresh the bundled releases skills (this one + `releases-mcp`, `finding-changelogs`, etc.) for any supported agent:
+
+```bash
+releases skills install        # detected agent (auto), current project
+releases skills install -g     # user-wide install instead
+```
+
+Skills are symlinked by default — re-running `releases skills install` refreshes everything atomically.
+
 ## What this skill covers
 
 - **[Reader commands](references/reader.md)** — Search, inspect, and export changelog data. No API key required.

--- a/src/cli/commands/skills.ts
+++ b/src/cli/commands/skills.ts
@@ -66,7 +66,8 @@ export function registerSkillsCommand(parent: Command): void {
     .option("-a, --agent <name>", "override agent auto-detection (e.g. claude-code, cursor, codex)")
     .option("--copy", "copy files instead of symlinking")
     .option("-l, --list", "list available skills without installing")
-    .option("-y, --yes", "skip confirmation prompts", true)
+    .option("-y, --yes", "skip confirmation prompts")
+    .option("--no-yes", "force interactive prompts (default is to skip them)")
     .addHelpText(
       "after",
       [
@@ -108,7 +109,12 @@ export function registerSkillsCommand(parent: Command): void {
         forwardSignals(child);
 
         const code = await new Promise<number>((resolve) => {
-          child.on("exit", (c) => resolve(c ?? 0));
+          child.on("exit", (c, signal) => {
+            // Signal-terminated child reports exitCode === null. Treat that
+            // as failure so SIGINT/SIGTERM aren't masked as success.
+            if (signal) resolve(1);
+            else resolve(c ?? 1);
+          });
           child.on("error", () => resolve(1));
         });
 

--- a/src/cli/commands/skills.ts
+++ b/src/cli/commands/skills.ts
@@ -1,0 +1,124 @@
+import { Command } from "commander";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+import chalk from "chalk";
+import { buildSkillsArgs, SKILLS_SOURCE } from "../skills/build-args.js";
+
+function exitWithError(message: string, hint: string): never {
+  console.error(chalk.red(message) + " " + chalk.dim(hint));
+  process.exit(1);
+}
+
+function whichSync(cmd: string): boolean {
+  const finder = process.platform === "win32" ? "where" : "which";
+  const result = spawnSync(finder, [cmd], {
+    stdio: ["ignore", "ignore", "ignore"],
+  });
+  return result.status === 0;
+}
+
+type Runner = "npx" | "bunx";
+
+function resolveRunner(): Runner {
+  if (whichSync("npx")) return "npx";
+  if (whichSync("bunx")) return "bunx";
+  exitWithError(
+    "Could not find `npx` or `bunx` on PATH.",
+    "Install Node.js (https://nodejs.org) or Bun (https://bun.sh), then re-run.",
+  );
+}
+
+function forwardSignals(child: ChildProcess): void {
+  const signals: NodeJS.Signals[] = ["SIGINT", "SIGTERM"];
+  for (const sig of signals) {
+    process.on(sig, () => {
+      try {
+        child.kill(sig);
+      } catch {
+        // child already exited
+      }
+    });
+  }
+}
+
+function printRefreshHint(): void {
+  console.log("");
+  console.log(
+    chalk.dim(
+      "Re-run `releases skills install` to refresh. Skills are symlinked by default,\n" +
+        "so most updates flow without re-running. For a single skill: `npx skills update releases-cli`.",
+    ),
+  );
+}
+
+export function registerSkillsCommand(parent: Command): void {
+  const skills = parent
+    .command("skills")
+    .description("Install the bundled agent skills into your coding agent")
+    .showSuggestionAfterError(true);
+
+  skills
+    .command("install")
+    .description(
+      "Install the bundled releases skills (releases-mcp, releases-cli, finding-changelogs, ...) into the detected coding agent",
+    )
+    .argument("[skills...]", "specific skills to install (default: all 8 bundled skills)")
+    .option("-g, --global", "install to user dir instead of the current project")
+    .option("-a, --agent <name>", "override agent auto-detection (e.g. claude-code, cursor, codex)")
+    .option("--copy", "copy files instead of symlinking")
+    .option("-l, --list", "list available skills without installing")
+    .option("-y, --yes", "skip confirmation prompts", true)
+    .addHelpText(
+      "after",
+      [
+        "",
+        "Examples:",
+        "  $ releases skills install                       # install all bundled skills into the detected agent",
+        "  $ releases skills install releases-mcp          # just the user-facing lookup skill",
+        "  $ releases skills install --global              # user-wide instead of project",
+        "  $ releases skills install --agent cursor        # override detection",
+        "  $ releases skills install --list                # show available skills, exit",
+        "",
+        `Under the hood this runs \`npx skills add ${SKILLS_SOURCE}\` from`,
+        "the open agent-skills ecosystem (vercel-labs/skills). Run",
+        "`npx skills add --help` for the full flag list.",
+      ].join("\n"),
+    )
+    .action(
+      async (
+        skillNames: string[],
+        opts: {
+          global?: boolean;
+          agent?: string;
+          copy?: boolean;
+          list?: boolean;
+          yes?: boolean;
+        },
+      ) => {
+        const runner = resolveRunner();
+        const args = buildSkillsArgs({
+          skills: skillNames,
+          global: opts.global,
+          agent: opts.agent,
+          copy: opts.copy,
+          list: opts.list,
+          yes: opts.yes,
+        });
+
+        const child = spawn(runner, args, { stdio: "inherit" });
+        forwardSignals(child);
+
+        const code = await new Promise<number>((resolve) => {
+          child.on("exit", (c) => resolve(c ?? 0));
+          child.on("error", () => resolve(1));
+        });
+
+        if (code !== 0) {
+          process.exit(code);
+        }
+
+        if (process.stdout.isTTY && !opts.list) {
+          printRefreshHint();
+        }
+      },
+    );
+}

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -40,6 +40,7 @@ import { registerWhoamiCommand } from "./commands/whoami.js";
 import { registerWebhookCommand } from "./commands/webhook.js";
 import { registerAgentContextCommand } from "./commands/agent-context.js";
 import { registerCompletionCommand } from "./commands/completion.js";
+import { registerSkillsCommand } from "./commands/skills.js";
 import { CATEGORIES } from "@buildinternet/releases-core/categories";
 import { isAdminMode } from "../lib/mode.js";
 import { VERSION } from "./version.js";
@@ -184,6 +185,7 @@ registerTelemetryCommand(program);
 registerWhoamiCommand(program);
 registerAgentContextCommand(program);
 registerCompletionCommand(program);
+registerSkillsCommand(program);
 
 const admin = program
   .command("admin")

--- a/src/cli/skills/build-args.ts
+++ b/src/cli/skills/build-args.ts
@@ -1,0 +1,28 @@
+export const SKILLS_SOURCE = "buildinternet/releases-cli";
+
+export interface InstallOptions {
+  skills?: string[];
+  global?: boolean;
+  agent?: string;
+  copy?: boolean;
+  list?: boolean;
+  yes?: boolean;
+  /** Extra args forwarded verbatim after our explicit flags. */
+  passthrough?: string[];
+}
+
+export function buildSkillsArgs(opts: InstallOptions): string[] {
+  const args = ["--yes", "skills", "add", SKILLS_SOURCE];
+
+  for (const skill of opts.skills ?? []) {
+    args.push("--skill", skill);
+  }
+  if (opts.yes !== false) args.push("--yes");
+  if (opts.global) args.push("--global");
+  if (opts.agent) args.push("--agent", opts.agent);
+  if (opts.copy) args.push("--copy");
+  if (opts.list) args.push("--list");
+  if (opts.passthrough && opts.passthrough.length > 0) args.push(...opts.passthrough);
+
+  return args;
+}

--- a/tests/cli/skills-install.test.ts
+++ b/tests/cli/skills-install.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "bun:test";
+import { buildSkillsArgs, SKILLS_SOURCE } from "../../src/cli/skills/build-args.js";
+
+describe("buildSkillsArgs", () => {
+  it("defaults to installing all skills from the GitHub coordinate", () => {
+    expect(buildSkillsArgs({})).toEqual(["--yes", "skills", "add", SKILLS_SOURCE, "--yes"]);
+  });
+
+  it("uses the buildinternet/releases-cli coordinate", () => {
+    expect(SKILLS_SOURCE).toBe("buildinternet/releases-cli");
+  });
+
+  it("emits --skill <name> for each positional", () => {
+    const args = buildSkillsArgs({ skills: ["releases-mcp", "releases-cli"] });
+    expect(args).toContain("--skill");
+    expect(args.filter((a) => a === "--skill")).toHaveLength(2);
+    const i1 = args.indexOf("--skill");
+    expect(args[i1 + 1]).toBe("releases-mcp");
+    const i2 = args.indexOf("--skill", i1 + 1);
+    expect(args[i2 + 1]).toBe("releases-cli");
+  });
+
+  it("includes --yes by default and drops it when yes is explicitly false", () => {
+    expect(buildSkillsArgs({}).filter((a) => a === "--yes")).toHaveLength(2); // npx --yes + skills --yes
+    expect(buildSkillsArgs({ yes: false }).filter((a) => a === "--yes")).toHaveLength(1); // only npx --yes
+  });
+
+  it("forwards --global", () => {
+    expect(buildSkillsArgs({ global: true })).toContain("--global");
+    expect(buildSkillsArgs({ global: false })).not.toContain("--global");
+  });
+
+  it("forwards --agent <name>", () => {
+    const args = buildSkillsArgs({ agent: "cursor" });
+    const i = args.indexOf("--agent");
+    expect(i).toBeGreaterThan(-1);
+    expect(args[i + 1]).toBe("cursor");
+  });
+
+  it("forwards --copy and --list", () => {
+    expect(buildSkillsArgs({ copy: true })).toContain("--copy");
+    expect(buildSkillsArgs({ list: true })).toContain("--list");
+  });
+
+  it("appends passthrough args last", () => {
+    const args = buildSkillsArgs({ passthrough: ["--something-new", "value"] });
+    expect(args.slice(-2)).toEqual(["--something-new", "value"]);
+  });
+
+  it("composes flags in a predictable order", () => {
+    const args = buildSkillsArgs({
+      skills: ["releases-mcp"],
+      global: true,
+      agent: "cursor",
+      copy: true,
+    });
+    expect(args).toEqual([
+      "--yes",
+      "skills",
+      "add",
+      SKILLS_SOURCE,
+      "--skill",
+      "releases-mcp",
+      "--yes",
+      "--global",
+      "--agent",
+      "cursor",
+      "--copy",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `releases skills install` — a thin wrapper around `npx skills add buildinternet/releases-cli` from the open agent-skills ecosystem ([`vercel-labs/skills`](https://github.com/vercel-labs/skills)) — so users on Cursor, Codex, Gemini CLI, Windsurf, GitHub Copilot, and ~45 other supported agents can install the 8 bundled skills without going through the Claude Code marketplace plugin.
- Forwards `--global`, `--agent <name>`, `--copy`, `--list`, `--no-yes` to `skills add`. Re-running the command refreshes content via the symlink default.
- Skills detection, format conversion, and per-agent path logic all live in `skills` — this CLI just calls it.

Closes #187. Follow-up out-of-date nag (mirroring `src/lib/update-check.ts`) tracked as #188.

## Why pass through to `skills`?

`browse` (Browserbase's CLI) ships the same shape — `browse skills install` shells out to `npx skills add`. Building agent detection, format conversion, and install paths in our CLI duplicates ~50 agents' worth of work that the open ecosystem already maintains. Pure passthrough keeps our surface ~30 LOC and zero ongoing maintenance against agent drift.

## Changes

- **New:** `src/cli/commands/skills.ts` — commander wiring, runner detection (`npx` → `bunx` fallback), signal forwarding, exit-code passthrough, refresh hint after success.
- **New:** `src/cli/skills/build-args.ts` — pure argv construction (tested independently of `spawn`).
- **New:** `tests/cli/skills-install.test.ts` — 9 tests covering every flag combination.
- **Edit:** `src/cli/program.ts` — register the command alongside `completion`.
- **Docs:** README (Standalone skills section now leads with `releases skills install`), AGENTS.md, the `releases-cli` skill itself, and the Claude Code plugin README.
- **Sync:** Plugin mirror of `releases-cli/references/reader.md` had drift; the sync script realigned it.
- **Changeset:** minor bump targeting the fixed group.

## Test plan

- [x] `bun run lint` — 0 warnings, 0 errors
- [x] `bun run typecheck` — clean (4 pre-existing errors in `src/lib/formatters.ts` resolved by `bun install` to pull `@buildinternet/releases-api-types@0.21.0`)
- [x] `bun test` — 361 pass (9 new in `tests/cli/skills-install.test.ts`)
- [x] `bun run format:check` — all files match style
- [x] Smoke: `bun src/index.ts skills install --help` renders correctly
- [ ] Manual: run `releases skills install` against a real Cursor / Codex install to confirm the underlying `skills` invocation works end-to-end (reviewer's call)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI command to install/refresh bundled skills with options for project vs global install, agent override, copy vs symlink behavior, listing, and confirmation controls; supports rerun-based atomic refresh.

* **Documentation**
  * Updated installation and architecture docs to describe the new skills installation workflow, cross-agent installation, and the alternative direct install path.

* **Tests**
  * Added tests validating CLI argument construction for the skills install flow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/buildinternet/releases-cli/pull/189?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->