### PR TITLE
fix(release): chmod +x platform binaries before gzip

### DIFF
--- a/.changeset/fix-binary-exec-permissions.md
+++ b/.changeset/fix-binary-exec-permissions.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": patch
+---
+
+Set +x on the cross-compiled platform binaries before they're gzipped for distribution. Bun's `--compile` produces 0644 outputs for cross-targets on Linux runners, so the Homebrew formula's `bin.install` (which preserves source mode) landed a non-executable binary. v0.38.0 added a completion-generation step that exec'd the binary during install and failed with EACCES; the formula template now also chmods the binary defensively before install.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,13 @@ jobs:
           bun build --compile src/index.ts --outfile npm/releases-linux-x64/releases --target=bun-linux-x64
           bun build --compile src/index.ts --outfile npm/releases-linux-arm64/releases --target=bun-linux-arm64
           bun build --compile src/index.ts --outfile npm/releases-windows-x64/releases.exe --target=bun-windows-x64
+          # bun --compile on a Linux runner produces 0644 outputs for cross-targets;
+          # set +x so gzip preserves the bit and downstream installers (Homebrew,
+          # curl|sh, manual gunzip) get an executable file.
+          chmod +x npm/releases-darwin-arm64/releases
+          chmod +x npm/releases-darwin-x64/releases
+          chmod +x npm/releases-linux-x64/releases
+          chmod +x npm/releases-linux-arm64/releases
 
       - name: Configure npm auth
         env:
@@ -157,6 +164,7 @@ jobs:
               # Single-binary .gz decompresses to a platform-suffixed filename
               # (e.g. releases-darwin-arm64). Rename to "releases" on install.
               binary = Dir["releases-*"].find { |f| File.file?(f) }
+              chmod 0755, binary
               bin.install binary => "releases"
 
               generate_completions_from_executable(bin/"releases", "completion", shells: [:bash, :zsh, :fish])


### PR DESCRIPTION
## Summary

- `bun build --compile --target=bun-darwin-arm64` on the Linux GH runner produces a `0644` binary. After `cp` + `gzip -k`, the `.gz` carries the same mode, and Homebrew's `bin.install` (which preserves source mode) lands a non-executable file.
- v0.38.0 added `generate_completions_from_executable(bin/"releases", "completion", ...)` to the formula template. That step `exec`s the just-installed binary during `def install` and fails with `EACCES`, rolling back the whole brew install.
- This patch sets `+x` on the cross-target binaries right after `bun build --compile`, so the bit propagates through `cp` → `gzip` → `gunzip` to every downstream consumer (Homebrew, `curl|sh`, manual unpack). The formula template also gains a defensive `chmod 0755, binary` before `bin.install`.

## Why it worked through v0.37.0

The previous formula only ran `bin.install` — nothing exec'd the binary during install. Homebrew's later `Cleaner` step strips write bits and lands a `0555` file, which is why `/opt/homebrew/Cellar/releases/0.37.0/bin/releases` looks executable on disk. The completion step in v0.38.0 runs *before* `Cleaner`, while the binary is still `0644`.

## Test plan

- [ ] Cut v0.38.1 by merging this PR — confirm `gunzip < releases-darwin-arm64.gz | file -` reports an executable and that `brew install buildinternet/tap/releases` completes cleanly on a fresh tap clone.
- [ ] Verify `releases completion bash` and `releases completion zsh` print non-empty output post-install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed executable permission issues with cross-compiled binaries that prevented successful Homebrew installation. Binaries are now properly configured with executable permissions before packaging and deployment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/buildinternet/releases-cli/pull/191?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->