### PR TITLE
feat(cli): add --metadata-set / --metadata-unset to admin source update

### DIFF
--- a/.changeset/admin-source-metadata-flags.md
+++ b/.changeset/admin-source-metadata-flags.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": minor
+---
+
+Add `--metadata-set <key=value>` and `--metadata-unset <key>` flags to `releases admin source update`. Both are repeatable and thread through the existing `updateSourceMeta` client-side merge, so one-off source metadata patches (e.g. `--metadata-set crawlEnabled=true --metadata-set githubUrl=https://github.com/docker/compose`) no longer require custom scripts. Value coercion follows standard CLI conventions: `true`/`false`/`null` become JSON literals, finite number strings become numbers, values starting with `{` or `[` are parsed as JSON, and everything else is kept as a string.

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -300,6 +300,10 @@ export async function updateSourceAction(
   // last-write-wins is documented so we honour it via iteration order).
   if (opts.metadataUnset && opts.metadataUnset.length > 0) {
     for (const key of opts.metadataUnset) {
+      if (key.trim() === "") {
+        logger.error(`Invalid --metadata-unset key: key must be non-empty`);
+        process.exit(2);
+      }
       if (key.includes(".") || key.includes("[")) {
         logger.error(
           `Invalid --metadata-unset key "${key}": nested paths (keys containing "." or "[") are not supported.`,

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -13,6 +13,7 @@ import { toSlug } from "@buildinternet/releases-core/slug";
 import { logger } from "@releases/lib/logger";
 import { writeJson } from "../../lib/output.js";
 import { readContentArg } from "../../lib/input.js";
+import { parseMetadataSetFlag } from "../../lib/flags.js";
 
 const VALID_TYPES = ["github", "scrape", "feed", "agent"] as const;
 
@@ -46,6 +47,8 @@ export type UpdateSourceOpts = {
   enable?: boolean;
   changelogPaths?: string | boolean;
   dryRun?: boolean;
+  metadataSet?: string[];
+  metadataUnset?: string[];
 };
 
 // Match the API worker cap (CHANGELOG_MAX_FILES) so we fail fast instead of
@@ -291,6 +294,34 @@ export async function updateSourceAction(
     changes.push(`changelog paths → ${paths.length} path(s) [${paths.join(", ")}]`);
   }
 
+  // --metadata-set / --metadata-unset
+  // When the same key appears in both, unset runs first so that a set on the
+  // same key in the same invocation is a no-op (users should avoid it, but
+  // last-write-wins is documented so we honour it via iteration order).
+  if (opts.metadataUnset && opts.metadataUnset.length > 0) {
+    for (const key of opts.metadataUnset) {
+      if (key.includes(".") || key.includes("[")) {
+        logger.error(
+          `Invalid --metadata-unset key "${key}": nested paths (keys containing "." or "[") are not supported.`,
+        );
+        process.exit(2);
+      }
+      metaUpdates[key] = undefined;
+      changes.push(`metadata.${key} removed`);
+    }
+  }
+
+  if (opts.metadataSet && opts.metadataSet.length > 0) {
+    for (const token of opts.metadataSet) {
+      const [key, value] = parseMetadataSetFlag(token);
+      metaUpdates[key] = value;
+      const preview = JSON.stringify(value);
+      changes.push(
+        `metadata.${key} → ${preview.length > 60 ? preview.slice(0, 60) + "..." : preview}`,
+      );
+    }
+  }
+
   if (changes.length === 0) {
     if (!opts.json) logger.warn("No changes specified. Use --help to see options.");
     return;
@@ -376,6 +407,27 @@ export function attachUpdateOptions(cmd: Command): Command {
       "Comma-separated list of CHANGELOG paths (relative to repo root) for monorepo sources, e.g. 'packages/core/CHANGELOG.md,packages/cli/CHANGELOG.md'",
     )
     .option("--no-changelog-paths", "Clear the changelog paths override (return to auto-discovery)")
+    .option(
+      "--metadata-set <key=value>",
+      "Set a source metadata key. Repeatable; if the same key appears more than once, the last value wins. " +
+        "Value coercion: true/false/null → JSON literal; finite number string → number; " +
+        "value starting with { or [ → parsed as JSON; otherwise → string. " +
+        'Keys containing "." or "[" are rejected (use --metadata-set key=\'{"nested":"value"}\' for objects).',
+      (val: string, acc: string[]) => {
+        acc.push(val);
+        return acc;
+      },
+      [] as string[],
+    )
+    .option(
+      "--metadata-unset <key>",
+      'Delete a source metadata key. Repeatable. Keys containing "." or "[" are rejected.',
+      (val: string, acc: string[]) => {
+        acc.push(val);
+        return acc;
+      },
+      [] as string[],
+    )
     .option("--json", "Output as JSON")
     .option("--dry-run", "Show what would change without writing");
 }
@@ -388,7 +440,13 @@ export function registerUpdateCommand(program: Command) {
 Examples:
   releases update src_abc123 --primary
   releases update src_abc123 --parse-instructions-file parse.md
-  cat parse.md | releases update src_abc123 --parse-instructions-file -`,
+  cat parse.md | releases update src_abc123 --parse-instructions-file -
+  releases update redis-software-release-notes \\
+    --metadata-set crawlEnabled=true \\
+    --metadata-set crawlIncludePathPrefix=/docs/latest/operate/rs/release-notes/
+  releases update docker-compose-release-notes \\
+    --metadata-set githubUrl=https://github.com/docker/compose
+  releases update some-source --metadata-unset legacyFlag`,
     )
     .action(updateSourceAction);
 }

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -46,3 +46,75 @@ export function parseTagList(raw: string | undefined): string[] {
     .map((t) => t.trim())
     .filter(Boolean);
 }
+
+/**
+ * Parse a `--metadata-set key=value` token into a `[key, coercedValue]` pair.
+ *
+ * Value coercion rules (applied in order):
+ *   - `true` / `false` / `null`   → JSON literal (boolean / null)
+ *   - Finite number string         → number
+ *   - Starts with `{` or `[`      → parsed as JSON (exits on invalid JSON)
+ *   - Otherwise                    → string
+ *
+ * Key constraints:
+ *   - Must contain `=` (first `=` splits key and value)
+ *   - Key must not be empty
+ *   - Key must not contain `.` or `[` (nested-path mutation is not supported)
+ *
+ * Exits with code 2 on any validation failure.
+ */
+export function parseMetadataSetFlag(raw: string): [string, unknown] {
+  const eqIdx = raw.indexOf("=");
+  if (eqIdx < 1) {
+    console.error(
+      chalk.red(
+        `Invalid --metadata-set "${raw}": expected key=value (key must be non-empty and separated by "=")`,
+      ),
+    );
+    process.exit(2);
+  }
+  const key = raw.slice(0, eqIdx);
+  const value = raw.slice(eqIdx + 1);
+
+  if (key.includes(".") || key.includes("[")) {
+    console.error(
+      chalk.red(
+        `Invalid --metadata-set key "${key}": nested paths (keys containing "." or "[") are not supported. ` +
+          `To mutate nested structure, pass the whole object: --metadata-set ${key}='{"...": "..."}'`,
+      ),
+    );
+    process.exit(2);
+  }
+
+  return [key, coerceMetadataValue(value)];
+}
+
+/**
+ * Coerce a raw CLI string value to the appropriate JSON type.
+ * Called by `parseMetadataSetFlag`; also exported for unit-testing.
+ */
+export function coerceMetadataValue(value: string): unknown {
+  if (value === "true") return true;
+  if (value === "false") return false;
+  if (value === "null") return null;
+
+  // Number: must be finite; guard against the empty-string edge case.
+  if (value.length > 0) {
+    const n = Number(value);
+    if (Number.isFinite(n)) return n;
+  }
+
+  // JSON object or array
+  if (value.startsWith("{") || value.startsWith("[")) {
+    try {
+      return JSON.parse(value);
+    } catch {
+      console.error(
+        chalk.red(`Invalid --metadata-set value: could not parse as JSON: ${value.slice(0, 80)}`),
+      );
+      process.exit(2);
+    }
+  }
+
+  return value;
+}

--- a/tests/unit/flags.test.ts
+++ b/tests/unit/flags.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, spyOn } from "bun:test";
-import { parsePositiveIntFlag, parseNonNegIntFlag } from "../../src/lib/flags.js";
+import {
+  parsePositiveIntFlag,
+  parseNonNegIntFlag,
+  coerceMetadataValue,
+  parseMetadataSetFlag,
+} from "../../src/lib/flags.js";
 
 // Intercept process.exit so invalid-input tests don't kill the runner.
 function withExitTrap(fn: () => void): void {
@@ -82,6 +87,149 @@ describe("parseNonNegIntFlag", () => {
   it("rejects a negative integer", () => {
     withExitTrap(() => {
       expect(() => parseNonNegIntFlag("offset", "-1")).toThrow("process.exit called");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// coerceMetadataValue — value-type coercion for --metadata-set
+// ---------------------------------------------------------------------------
+
+describe("coerceMetadataValue", () => {
+  it("coerces 'true' to boolean true", () => {
+    expect(coerceMetadataValue("true")).toBe(true);
+  });
+
+  it("coerces 'false' to boolean false", () => {
+    expect(coerceMetadataValue("false")).toBe(false);
+  });
+
+  it("false is not treated as falsy — it is the boolean value false, not undefined/null", () => {
+    const result = coerceMetadataValue("false");
+    expect(result).toBe(false);
+    expect(result).not.toBeNull();
+    expect(result).not.toBeUndefined();
+  });
+
+  it("coerces 'null' to null", () => {
+    expect(coerceMetadataValue("null")).toBeNull();
+  });
+
+  it("coerces a positive integer string to a number", () => {
+    expect(coerceMetadataValue("42")).toBe(42);
+  });
+
+  it("coerces '0' to the number 0, not falsy-undefined", () => {
+    const result = coerceMetadataValue("0");
+    expect(result).toBe(0);
+    expect(typeof result).toBe("number");
+  });
+
+  it("coerces a negative integer string to a number", () => {
+    expect(coerceMetadataValue("-7")).toBe(-7);
+  });
+
+  it("coerces a decimal string to a number", () => {
+    expect(coerceMetadataValue("3.14")).toBeCloseTo(3.14);
+  });
+
+  it("coerces a JSON object string to an object", () => {
+    expect(coerceMetadataValue('{"foo":"bar"}')).toEqual({ foo: "bar" });
+  });
+
+  it("coerces a JSON array string to an array", () => {
+    expect(coerceMetadataValue("[1,2,3]")).toEqual([1, 2, 3]);
+  });
+
+  it("treats a plain URL string as a string (not a number, not JSON)", () => {
+    const url = "https://github.com/docker/compose";
+    expect(coerceMetadataValue(url)).toBe(url);
+  });
+
+  it("treats a plain path string as a string", () => {
+    const path = "/docs/latest/operate/rs/release-notes/";
+    expect(coerceMetadataValue(path)).toBe(path);
+  });
+
+  it("treats an arbitrary string as a string", () => {
+    expect(coerceMetadataValue("hello world")).toBe("hello world");
+  });
+
+  it("exits on invalid JSON starting with {", () => {
+    withExitTrap(() => {
+      expect(() => coerceMetadataValue("{not valid json}")).toThrow("process.exit called");
+    });
+  });
+
+  it("exits on invalid JSON starting with [", () => {
+    withExitTrap(() => {
+      expect(() => coerceMetadataValue("[1,2,")).toThrow("process.exit called");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseMetadataSetFlag — full key=value parsing
+// ---------------------------------------------------------------------------
+
+describe("parseMetadataSetFlag", () => {
+  it("parses a simple string value", () => {
+    expect(parseMetadataSetFlag("myKey=hello")).toEqual(["myKey", "hello"]);
+  });
+
+  it("parses a boolean true value", () => {
+    expect(parseMetadataSetFlag("crawlEnabled=true")).toEqual(["crawlEnabled", true]);
+  });
+
+  it("parses a boolean false value", () => {
+    expect(parseMetadataSetFlag("renderRequired=false")).toEqual(["renderRequired", false]);
+  });
+
+  it("parses a numeric value", () => {
+    expect(parseMetadataSetFlag("maxItems=20")).toEqual(["maxItems", 20]);
+  });
+
+  it("parses a URL value as a string", () => {
+    const token = "githubUrl=https://github.com/docker/compose";
+    const [key, value] = parseMetadataSetFlag(token);
+    expect(key).toBe("githubUrl");
+    expect(value).toBe("https://github.com/docker/compose");
+  });
+
+  it("splits only on the first '=' so values containing '=' are preserved", () => {
+    const token = "redirectUrl=https://example.com?a=1&b=2";
+    const [key, value] = parseMetadataSetFlag(token);
+    expect(key).toBe("redirectUrl");
+    expect(value).toBe("https://example.com?a=1&b=2");
+  });
+
+  it("parses a JSON object value", () => {
+    const [key, value] = parseMetadataSetFlag('config={"timeout":30}');
+    expect(key).toBe("config");
+    expect(value).toEqual({ timeout: 30 });
+  });
+
+  it("exits when no '=' is present", () => {
+    withExitTrap(() => {
+      expect(() => parseMetadataSetFlag("noequals")).toThrow("process.exit called");
+    });
+  });
+
+  it("exits when the key is empty (starts with '=')", () => {
+    withExitTrap(() => {
+      expect(() => parseMetadataSetFlag("=value")).toThrow("process.exit called");
+    });
+  });
+
+  it("exits when the key contains '.'", () => {
+    withExitTrap(() => {
+      expect(() => parseMetadataSetFlag("foo.bar=value")).toThrow("process.exit called");
+    });
+  });
+
+  it("exits when the key contains '['", () => {
+    withExitTrap(() => {
+      expect(() => parseMetadataSetFlag("foo[0]=value")).toThrow("process.exit called");
     });
   });
 });


### PR DESCRIPTION
## Summary

- Add `--metadata-set <key=value>` and `--metadata-unset <key>` flags to `releases admin source update`.
- Both flags are repeatable. When the same key appears more than once in `--metadata-set`, the last value wins (documented in `--help`).
- Thread through the existing `updateSourceMeta` client-side merge — no new API endpoint needed.

## Why this matters

One-off source metadata patches previously required custom scripts that fetched the current metadata, merged a value, and sent the full JSON back. These flags cover that entire workflow inline:

```
releases admin source update redis-software-release-notes \
  --metadata-set crawlEnabled=true \
  --metadata-set crawlIncludePathPrefix=/docs/latest/operate/rs/release-notes/

releases admin source update docker-compose-release-notes \
  --metadata-set githubUrl=https://github.com/docker/compose

releases admin source update some-source --metadata-unset legacyFlag
```

Motivated by [buildinternet/releases#1074](https://github.com/buildinternet/releases/issues/1074) (monorepo context issue — this PR lives in the CLI repo).

## Value coercion

| Input | Type |
|-------|------|
| `true` / `false` / `null` | JSON literal |
| `42`, `-7`, `3.14`, `0` | number |
| `{"key":"val"}` / `[1,2]` | parsed JSON (exits loudly on invalid JSON) |
| anything else | string |

Keys containing `.` or `[` are rejected — flat mutations only. Pass a JSON object as the value if you need to set a nested structure (e.g. `--metadata-set config='{"timeout":30}'`).

## Test plan

- [x] Unit tests in `tests/unit/flags.test.ts` cover `coerceMetadataValue` and `parseMetadataSetFlag`:
  - Booleans (`true`, `false`) — including the edge case that `false` is not silently coerced to falsy
  - `null` literal
  - Integers, `0`, negative numbers, decimals
  - URL strings kept as strings
  - JSON object and array values
  - Invalid JSON exits with code 2
  - Missing `=`, empty key, nested key (`.` / `[`) all exit with code 2
  - First `=` splits the key so values containing `=` (e.g. query strings) are preserved intact
- [x] 409 tests pass, 0 fail (`bun test`)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — 0 warnings, 0 errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added repeatable --metadata-set <key=value> and --metadata-unset <key> flags to manage source metadata from the CLI.
  * Key validation rejects nested paths (keys with "." or "["); when both flags target the same key, unset runs before set (last-write-wins).
  * CLI help/examples updated to show usage and value coercion rules.

* **Tests**
  * Added tests covering flag parsing, validation, and value coercion behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/buildinternet/releases-cli/pull/193?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->