### PR TITLE
feat(cli): --kind support for source/product taxonomy (Phase B of #1080)

### DIFF
--- a/.changeset/source-kind.md
+++ b/.changeset/source-kind.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": minor
+---
+
+Add `--kind <value>` support for the new source/product taxonomy (`platform | sdk | mobile | desktop | docs | integration | tool`). Write paths (`releases admin source update`, `releases admin product update`, `releases admin product create`) accept the flag and validate locally via `isValidKind` before hitting the API. Read paths (`releases list`, `releases admin source list`, `releases admin product list`, `releases search`) accept `--kind` as a filter and pass it through as a query string. The API applies inheritance (`COALESCE(source.kind, product.kind)`) on content-oriented surfaces and direct equality on metadata-oriented surfaces; see the help text for the per-command behavior. Bumps the pinned `@buildinternet/releases-core` and `@buildinternet/releases-api-types` to `^0.22.0`.

--- a/bun.lock
+++ b/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "releases-cli",
       "dependencies": {
-        "@buildinternet/releases-api-types": "^0.21.0",
-        "@buildinternet/releases-core": "^0.21.0",
+        "@buildinternet/releases-api-types": "^0.22.0",
+        "@buildinternet/releases-core": "^0.22.0",
         "@buildinternet/releases-lib": "workspace:*",
         "@buildinternet/releases-skills": "workspace:*",
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -27,7 +27,7 @@
     },
     "npm/releases": {
       "name": "@buildinternet/releases",
-      "version": "0.37.0",
+      "version": "0.38.1",
       "bin": {
         "releases": "bin/releases",
       },
@@ -41,31 +41,31 @@
     },
     "npm/releases-darwin-arm64": {
       "name": "@buildinternet/releases-darwin-arm64",
-      "version": "0.37.0",
+      "version": "0.38.1",
     },
     "npm/releases-darwin-x64": {
       "name": "@buildinternet/releases-darwin-x64",
-      "version": "0.37.0",
+      "version": "0.38.1",
     },
     "npm/releases-linux-arm64": {
       "name": "@buildinternet/releases-linux-arm64",
-      "version": "0.37.0",
+      "version": "0.38.1",
     },
     "npm/releases-linux-x64": {
       "name": "@buildinternet/releases-linux-x64",
-      "version": "0.37.0",
+      "version": "0.38.1",
     },
     "npm/releases-windows-x64": {
       "name": "@buildinternet/releases-windows-x64",
-      "version": "0.37.0",
+      "version": "0.38.1",
     },
     "packages/lib": {
       "name": "@buildinternet/releases-lib",
-      "version": "0.37.0",
+      "version": "0.38.1",
     },
     "packages/skills": {
       "name": "@buildinternet/releases-skills",
-      "version": "0.37.0",
+      "version": "0.38.1",
     },
   },
   "packages": {
@@ -73,9 +73,9 @@
 
     "@buildinternet/releases": ["@buildinternet/releases@workspace:npm/releases"],
 
-    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.21.0", "", { "dependencies": { "@buildinternet/releases-core": "^0.21.0", "zod": "^4.4.3" } }, "sha512-2ZTTTxO2GrMXJZFufQ9ADs2YR1BjHLQGP4H/5fUEqrQFzXJJVqfjavELm4NK1koFhR2jsTWEDzIAzPoD6rq+GQ=="],
+    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.22.0", "", { "dependencies": { "@buildinternet/releases-core": "^0.22.0", "zod": "^4.4.3" } }, "sha512-+l5nmZVN+zjWqFQ7ElMjj4SeKHqazm/KrCQ3EcYBX8+7Jvar9xx+LI5nssbKO7sXhcfVRLKb9DBazmfR1m6j1A=="],
 
-    "@buildinternet/releases-core": ["@buildinternet/releases-core@0.21.0", "", { "dependencies": { "drizzle-orm": "^0.45.2", "js-tiktoken": "^1.0.21", "nanoid": "^5.1.7" } }, "sha512-tWLBc3BvBot1Rrb5j3X2RPSogcgm5+hwFlnQocMTHFgF8gtF4jZRM7Mc+HoGNOlMJHacH1uyqt2nDcqTGZaNZQ=="],
+    "@buildinternet/releases-core": ["@buildinternet/releases-core@0.22.0", "", { "dependencies": { "drizzle-orm": "^0.45.2", "js-tiktoken": "^1.0.21", "nanoid": "^5.1.7" } }, "sha512-TwgFg3Z1P01TEsNE9abcoostOSKJB0DGUunVJB1l+vef31qqxzCTDBUt08ZRm7TJjlW2u1QCgYxaqKg5hkiIpw=="],
 
     "@buildinternet/releases-darwin-arm64": ["@buildinternet/releases-darwin-arm64@workspace:npm/releases-darwin-arm64"],
 

--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
   },
   "homepage": "https://releases.sh",
   "dependencies": {
-    "@buildinternet/releases-api-types": "^0.21.0",
-    "@buildinternet/releases-core": "^0.21.0",
+    "@buildinternet/releases-api-types": "^0.22.0",
+    "@buildinternet/releases-core": "^0.22.0",
     "@buildinternet/releases-lib": "workspace:*",
     "@buildinternet/releases-skills": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/plugins/claude/releases/skills/releases-cli/references/admin.md
+++ b/plugins/claude/releases/skills/releases-cli/references/admin.md
@@ -73,7 +73,7 @@ releases admin source update my-blog --slug new-slug --confirm-slug-change
 
 Slug renames require `--confirm-slug-change` because they break existing web links.
 
-`--kind` sets the source's taxonomy. On content-oriented surfaces (releases feed, search release hits) it resolves through the parent product when null; on metadata surfaces (lists, catalog) it matches the row's own kind directly.
+`--kind` sets the source's taxonomy. In **release feeds** and **search release hits**, a source with no kind of its own inherits its parent product's kind — so filtering by `kind=sdk` returns content from any source that's either marked SDK or sits under an SDK product. In **catalog listings** and **source lists** (`releases list`, `admin product list`, `search` catalog hits), the filter matches the row's *own* kind field directly with no inheritance — so the same `kind=sdk` filter only returns rows explicitly classified as SDK.
 
 ### Fetch
 

--- a/plugins/claude/releases/skills/releases-cli/references/admin.md
+++ b/plugins/claude/releases/skills/releases-cli/references/admin.md
@@ -66,10 +66,14 @@ releases admin source update my-blog --type feed                # change adapter
 releases admin source update my-blog --no-feed-url              # clear stored feed URL
 releases admin source update my-blog --markdown-url https://example.com/changelog.md
 releases admin source update my-blog --primary                  # mark as org's primary changelog
+releases admin source update my-blog --kind sdk                 # classify (platform|sdk|mobile|desktop|docs|integration|tool)
+releases admin source update my-blog --no-kind                  # clear; falls back to parent product's kind
 releases admin source update my-blog --slug new-slug --confirm-slug-change
 ```
 
 Slug renames require `--confirm-slug-change` because they break existing web links.
+
+`--kind` sets the source's taxonomy. On content-oriented surfaces (releases feed, search release hits) it resolves through the parent product when null; on metadata surfaces (lists, catalog) it matches the row's own kind directly.
 
 ### Fetch
 
@@ -139,13 +143,19 @@ Products group sources under multi-product orgs (e.g. Vercel → Next.js, Turbor
 
 ```bash
 releases admin product create "Next.js" --org vercel --url https://nextjs.org
+releases admin product create "Stripe Node" --org stripe --kind sdk
 releases admin product list vercel
+releases admin product list openai --kind sdk           # filter by taxonomy
 releases admin product update nextjs --description "React framework for production"
+releases admin product update stripe-node --kind sdk    # classify
+releases admin product update stripe-node --no-kind     # clear
 releases admin product tag add nextjs react
 releases admin product alias add nextjs nextjs.org
 releases admin product delete nextjs          # sources become unlinked, not deleted
 releases admin product adopt nextjs --into vercel   # convert an org into a product
 ```
+
+`--kind` on a product is inherited by its sources (when the source has no kind of its own) on content-oriented surfaces. Use it to classify a whole multi-source product family (e.g. "Stripe's SDKs are all kind=sdk") instead of stamping every source individually.
 
 ## Releases
 

--- a/plugins/claude/releases/skills/releases-cli/references/reader.md
+++ b/plugins/claude/releases/skills/releases-cli/references/reader.md
@@ -10,6 +10,7 @@ Unified search across organizations, the catalog (products + standalone sources)
 releases search "authentication"
 releases search "vercel" --type releases --limit 5
 releases search "react" --type catalog
+releases search "stripe" --kind sdk         # taxonomy filter
 releases search "breaking change" --json
 ```
 
@@ -18,7 +19,8 @@ Flags:
 - `--type <orgs|catalog|releases>` — narrow to one section (default: all three). `products` is accepted as a deprecated alias for `catalog`.
 - `--limit <n>` — max results per section (default: 10).
 - `--mode <lexical|semantic|hybrid>` — pick the release-retrieval strategy. Server default is hybrid; pass `lexical` for pure FTS ranking.
-- `--json` — machine output. Release hits include a `kind: "release" | "changelog_chunk"` discriminator. Catalog hits include `kind: "product" | "source"` so you can route a click to either a product page or a standalone source.
+- `--kind <platform|sdk|mobile|desktop|docs|integration|tool>` — taxonomy filter. Release hits match `COALESCE(source.kind, product.kind)` (a source with no kind inherits from its product); catalog hits match the row's own kind directly.
+- `--json` — machine output. Release hits include a `kind: "release" | "changelog_chunk"` discriminator. Catalog hits include `entryType: "product" | "source"` (the entity discriminator) plus an optional `kind` field carrying the taxonomy classification.
 
 Catalog hits also include the response field `catalog`. Older API deploys will still send the deprecated `products` alias instead — the CLI reads either, but new code should consume `catalog`.
 
@@ -55,6 +57,7 @@ releases list --product nextjs         # filter by product (prod_… or slug)
 releases list --query shadcn           # name / slug / url substring
 releases list --has-feed               # sources with a discovered feed URL
 releases list --category ai            # filter by category
+releases list --kind sdk               # filter by taxonomy (platform|sdk|mobile|desktop|docs|integration|tool)
 releases list --json                   # machine-readable output
 releases list --json --compact         # lightweight JSON (id, slug, name, type, org, date)
 releases list --json --limit 20 --page 2  # pagination (server-side)

--- a/skills/releases-cli/references/admin.md
+++ b/skills/releases-cli/references/admin.md
@@ -73,7 +73,7 @@ releases admin source update my-blog --slug new-slug --confirm-slug-change
 
 Slug renames require `--confirm-slug-change` because they break existing web links.
 
-`--kind` sets the source's taxonomy. On content-oriented surfaces (releases feed, search release hits) it resolves through the parent product when null; on metadata surfaces (lists, catalog) it matches the row's own kind directly.
+`--kind` sets the source's taxonomy. In **release feeds** and **search release hits**, a source with no kind of its own inherits its parent product's kind — so filtering by `kind=sdk` returns content from any source that's either marked SDK or sits under an SDK product. In **catalog listings** and **source lists** (`releases list`, `admin product list`, `search` catalog hits), the filter matches the row's *own* kind field directly with no inheritance — so the same `kind=sdk` filter only returns rows explicitly classified as SDK.
 
 ### Fetch
 

--- a/skills/releases-cli/references/admin.md
+++ b/skills/releases-cli/references/admin.md
@@ -66,10 +66,14 @@ releases admin source update my-blog --type feed                # change adapter
 releases admin source update my-blog --no-feed-url              # clear stored feed URL
 releases admin source update my-blog --markdown-url https://example.com/changelog.md
 releases admin source update my-blog --primary                  # mark as org's primary changelog
+releases admin source update my-blog --kind sdk                 # classify (platform|sdk|mobile|desktop|docs|integration|tool)
+releases admin source update my-blog --no-kind                  # clear; falls back to parent product's kind
 releases admin source update my-blog --slug new-slug --confirm-slug-change
 ```
 
 Slug renames require `--confirm-slug-change` because they break existing web links.
+
+`--kind` sets the source's taxonomy. On content-oriented surfaces (releases feed, search release hits) it resolves through the parent product when null; on metadata surfaces (lists, catalog) it matches the row's own kind directly.
 
 ### Fetch
 
@@ -139,13 +143,19 @@ Products group sources under multi-product orgs (e.g. Vercel → Next.js, Turbor
 
 ```bash
 releases admin product create "Next.js" --org vercel --url https://nextjs.org
+releases admin product create "Stripe Node" --org stripe --kind sdk
 releases admin product list vercel
+releases admin product list openai --kind sdk           # filter by taxonomy
 releases admin product update nextjs --description "React framework for production"
+releases admin product update stripe-node --kind sdk    # classify
+releases admin product update stripe-node --no-kind     # clear
 releases admin product tag add nextjs react
 releases admin product alias add nextjs nextjs.org
 releases admin product delete nextjs          # sources become unlinked, not deleted
 releases admin product adopt nextjs --into vercel   # convert an org into a product
 ```
+
+`--kind` on a product is inherited by its sources (when the source has no kind of its own) on content-oriented surfaces. Use it to classify a whole multi-source product family (e.g. "Stripe's SDKs are all kind=sdk") instead of stamping every source individually.
 
 ## Releases
 

--- a/skills/releases-cli/references/reader.md
+++ b/skills/releases-cli/references/reader.md
@@ -10,6 +10,7 @@ Unified search across organizations, the catalog (products + standalone sources)
 releases search "authentication"
 releases search "vercel" --type releases --limit 5
 releases search "react" --type catalog
+releases search "stripe" --kind sdk         # taxonomy filter
 releases search "breaking change" --json
 ```
 
@@ -18,7 +19,8 @@ Flags:
 - `--type <orgs|catalog|releases>` — narrow to one section (default: all three). `products` is accepted as a deprecated alias for `catalog`.
 - `--limit <n>` — max results per section (default: 10).
 - `--mode <lexical|semantic|hybrid>` — pick the release-retrieval strategy. Server default is hybrid; pass `lexical` for pure FTS ranking.
-- `--json` — machine output. Release hits include a `kind: "release" | "changelog_chunk"` discriminator. Catalog hits include `kind: "product" | "source"` so you can route a click to either a product page or a standalone source.
+- `--kind <platform|sdk|mobile|desktop|docs|integration|tool>` — taxonomy filter. Release hits match `COALESCE(source.kind, product.kind)` (a source with no kind inherits from its product); catalog hits match the row's own kind directly.
+- `--json` — machine output. Release hits include a `kind: "release" | "changelog_chunk"` discriminator. Catalog hits include `entryType: "product" | "source"` (the entity discriminator) plus an optional `kind` field carrying the taxonomy classification.
 
 Catalog hits also include the response field `catalog`. Older API deploys will still send the deprecated `products` alias instead — the CLI reads either, but new code should consume `catalog`.
 
@@ -55,6 +57,7 @@ releases list --product nextjs         # filter by product (prod_… or slug)
 releases list --query shadcn           # name / slug / url substring
 releases list --has-feed               # sources with a discovered feed URL
 releases list --category ai            # filter by category
+releases list --kind sdk               # filter by taxonomy (platform|sdk|mobile|desktop|docs|integration|tool)
 releases list --json                   # machine-readable output
 releases list --json --compact         # lightweight JSON (id, slug, name, type, org, date)
 releases list --json --limit 20 --page 2  # pagination (server-side)

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,6 +1,7 @@
 import { getApiUrl, getApiKey, isAdminMode } from "../lib/mode.js";
 import { logger } from "@releases/lib/logger";
 import { daysAgoIso } from "@buildinternet/releases-core/dates";
+import type { Kind } from "@buildinternet/releases-core/kinds";
 import { RELEASES_CLI_UA } from "../lib/user-agent.js";
 import type {
   Source,
@@ -366,12 +367,14 @@ export async function unifiedSearch(
     org?: string;
     domain?: string;
     mode?: "lexical" | "semantic" | "hybrid";
+    kind?: Kind;
   },
 ): Promise<UnifiedSearchResponse> {
   const params = new URLSearchParams({ q: query, limit: String(limit) });
   if (opts?.org) params.set("org", opts.org);
   if (opts?.domain) params.set("domain", opts.domain);
   if (opts?.mode) params.set("mode", opts.mode);
+  if (opts?.kind) params.set("kind", opts.kind);
   return apiFetch<UnifiedSearchResponse>(`/v1/search?${params}`);
 }
 
@@ -392,6 +395,7 @@ type ListSourcesOpts = {
   query?: string;
   includeHidden?: boolean;
   category?: string;
+  kind?: Kind;
   limit?: number;
   page?: number;
 };
@@ -410,6 +414,7 @@ export async function listSourcesWithOrg(
   if (opts?.query) params.set("query", opts.query);
   if (opts?.includeHidden) params.set("include_hidden", "true");
   if (opts?.category) params.set("category", opts.category);
+  if (opts?.kind) params.set("kind", opts.kind);
   if (opts?.limit != null) params.set("limit", String(opts.limit));
   if (opts?.page != null) params.set("page", String(opts.page));
   if (opts?.envelope) params.set("envelope", "true");
@@ -824,7 +829,7 @@ export async function unlinkOrgAccount(
 export async function createProduct(
   orgId: string,
   name: string,
-  opts?: { slug?: string; url?: string; description?: string; category?: string },
+  opts?: { slug?: string; url?: string; description?: string; category?: string; kind?: Kind },
 ): Promise<Product> {
   return apiFetch<Product>(`/v1/products`, {
     method: "POST",
@@ -835,6 +840,7 @@ export async function createProduct(
       url: opts?.url,
       description: opts?.description,
       category: opts?.category,
+      kind: opts?.kind,
     }),
   });
 }
@@ -878,6 +884,7 @@ export async function findProduct(identifier: string): Promise<Product | null> {
 
 export async function getProductsByOrg(
   orgId: string,
+  opts?: { kind?: Kind },
 ): Promise<Array<Product & { sourceCount: number }>> {
   // /v1/products returns a paginated envelope; tolerate the legacy bare-array
   // shape too in case an old worker is ever in the path. Without the unwrap,
@@ -885,7 +892,9 @@ export async function getProductsByOrg(
   // iterating an object and yielding nothing — which is what made
   // `releases org get` skip the Products section even when the org had them.
   type Row = Product & { sourceCount: number };
-  const raw = await apiFetch<Row[] | ListResponse<Row>>(`/v1/products?orgId=${orgId}`);
+  const params = new URLSearchParams({ orgId });
+  if (opts?.kind) params.set("kind", opts.kind);
+  const raw = await apiFetch<Row[] | ListResponse<Row>>(`/v1/products?${params}`);
   if (!raw) return [];
   return Array.isArray(raw) ? raw : raw.items;
 }

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -12,6 +12,7 @@ import {
   formatTruncationWarning,
   type ListResponse,
 } from "@buildinternet/releases-core/cli-contracts";
+import { isValidKind, KIND_VALUES, type Kind } from "@buildinternet/releases-core/kinds";
 
 function getFetchMethod(type: string, meta: Record<string, unknown> | null): string {
   if (type === "github") return "github";
@@ -36,6 +37,10 @@ export function registerListCommand(program: Command) {
     .option("--has-feed", "Only show sources that have a discovered feed URL")
     .option("--query <text>", "Filter by name, slug, or URL")
     .option("--category <category>", "Filter by organization or product category")
+    .option(
+      "--kind <kind>",
+      `Filter by source taxonomy (${KIND_VALUES.join(", ")}). Matches the source's own kind only (no inheritance).`,
+    )
     .option("--include-disabled", "Include disabled sources in the list")
     .option("--compact", "Return lightweight fields only")
     .option("--limit <n>", `Limit the number of results (default ${DEFAULT_PAGE_SIZE})`)
@@ -49,6 +54,7 @@ export function registerListCommand(program: Command) {
           org?: string;
           product?: string;
           category?: string;
+          kind?: string;
           hasFeed?: boolean;
           query?: string;
           includeDisabled?: boolean;
@@ -58,6 +64,11 @@ export function registerListCommand(program: Command) {
           flat?: boolean;
         },
       ) => {
+        if (opts.kind !== undefined && !isValidKind(opts.kind)) {
+          logger.error(`Invalid kind "${opts.kind}". Must be one of: ${KIND_VALUES.join(", ")}`);
+          process.exit(1);
+        }
+        const kind = opts.kind as Kind | undefined;
         // Validate pagination flags before the slug fast path so malformed
         // --limit / --page still error consistently, even when ignored by the
         // single-source branch.
@@ -110,6 +121,7 @@ export function registerListCommand(program: Command) {
           orgSlug: opts.org,
           productSlug: opts.product,
           category: opts.category,
+          kind,
           hasFeed: opts.hasFeed,
           query: opts.query,
           includeHidden: opts.includeDisabled,

--- a/src/cli/commands/product.ts
+++ b/src/cli/commands/product.ts
@@ -21,6 +21,7 @@ import {
 } from "../../api/client.js";
 import { toSlug } from "@buildinternet/releases-core/slug";
 import { isValidCategory, CATEGORIES } from "@buildinternet/releases-core/categories";
+import { isValidKind, KIND_VALUES, type Kind } from "@buildinternet/releases-core/kinds";
 import { writeJson } from "../../lib/output.js";
 import { computePagination, type ListResponse } from "@buildinternet/releases-core/cli-contracts";
 import { warnDeprecatedAlias } from "../../lib/deprecated-alias.js";
@@ -70,6 +71,7 @@ type ProductCreateOpts = {
   url?: string;
   description?: string;
   category?: string;
+  kind?: string;
   tags?: string;
   json?: boolean;
   dryRun?: boolean;
@@ -91,6 +93,14 @@ async function productCreateAction(name: string, opts: ProductCreateOpts): Promi
     process.exit(1);
   }
 
+  if (opts.kind !== undefined && !isValidKind(opts.kind)) {
+    console.error(
+      chalk.red(`Invalid kind "${opts.kind}". Must be one of: ${KIND_VALUES.join(", ")}`),
+    );
+    process.exit(1);
+  }
+  const kind = opts.kind as Kind | undefined;
+
   if (opts.dryRun) {
     const tagList = parseTagList(opts.tags);
     const plan = {
@@ -101,6 +111,7 @@ async function productCreateAction(name: string, opts: ProductCreateOpts): Promi
       url: opts.url ?? null,
       description: opts.description ?? null,
       category: opts.category ?? null,
+      kind: kind ?? null,
       tagsToAdd: tagList,
     };
     if (opts.json) await writeJson(plan);
@@ -120,6 +131,7 @@ async function productCreateAction(name: string, opts: ProductCreateOpts): Promi
       url: opts.url,
       description: opts.description,
       category: opts.category,
+      kind,
     });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
@@ -152,6 +164,7 @@ type ProductUpdateOpts = {
   url?: string;
   description?: string;
   category?: string | boolean;
+  kind?: string | boolean;
   json?: boolean;
   dryRun?: boolean;
 };
@@ -178,6 +191,18 @@ async function productUpdateAction(slug: string, opts: ProductUpdateOpts): Promi
       process.exit(1);
     }
     updates.category = opts.category;
+  }
+
+  if (opts.kind === false) {
+    updates.kind = null;
+  } else if (typeof opts.kind === "string") {
+    if (!isValidKind(opts.kind)) {
+      console.error(
+        chalk.red(`Invalid kind "${opts.kind}". Must be one of: ${KIND_VALUES.join(", ")}`),
+      );
+      process.exit(1);
+    }
+    updates.kind = opts.kind satisfies Kind;
   }
 
   if (Object.keys(updates).length === 0) {
@@ -232,11 +257,23 @@ export function registerProductCommand(program: Command) {
     .description("List products for an organization")
     .argument("[org]", "Organization (org_…, slug, domain, name, or handle)")
     .option("--json", "Output as JSON")
-    .action(async (orgIdentifier: string | undefined, opts: { json?: boolean }) => {
+    .option(
+      "--kind <kind>",
+      `Filter by product taxonomy (${KIND_VALUES.join(", ")}). Matches the product's own kind only.`,
+    )
+    .action(async (orgIdentifier: string | undefined, opts: { json?: boolean; kind?: string }) => {
       if (!orgIdentifier) {
         console.error(chalk.red("Please specify an organization"));
         process.exit(1);
       }
+
+      if (opts.kind !== undefined && !isValidKind(opts.kind)) {
+        console.error(
+          chalk.red(`Invalid kind "${opts.kind}". Must be one of: ${KIND_VALUES.join(", ")}`),
+        );
+        process.exit(1);
+      }
+      const kind = opts.kind as Kind | undefined;
 
       const org = await findOrg(orgIdentifier);
       if (!org) {
@@ -244,7 +281,7 @@ export function registerProductCommand(program: Command) {
         process.exit(1);
       }
 
-      const productList = await getProductsByOrg(org.id);
+      const productList = await getProductsByOrg(org.id, { kind });
 
       if (productList.length === 0) {
         if (opts.json) await writeJson([]);
@@ -285,6 +322,10 @@ export function registerProductCommand(program: Command) {
     .option("--url <url>", "Product URL")
     .option("--description <text>", "Brief product description")
     .option("--category <category>", "Category")
+    .option(
+      "--kind <kind>",
+      `Product taxonomy (${KIND_VALUES.join(", ")}). Sources without their own kind inherit this on content surfaces.`,
+    )
     .option("--tags <tags>", "Comma-separated tags")
     .option("--json", "Output as JSON")
     .option("--dry-run", "Show what would be created without writing")
@@ -299,6 +340,10 @@ export function registerProductCommand(program: Command) {
     .option("--url <url>", "Product URL")
     .option("--description <text>", "Brief product description")
     .option("--category <category>", "Category")
+    .option(
+      "--kind <kind>",
+      `Product taxonomy (${KIND_VALUES.join(", ")}). Sources without their own kind inherit this on content surfaces.`,
+    )
     .option("--tags <tags>", "Comma-separated tags")
     .option("--json", "Output as JSON")
     .option("--dry-run", "Show what would be created without writing")
@@ -314,6 +359,8 @@ export function registerProductCommand(program: Command) {
     .option("--description <text>", "New product description")
     .option("--category <category>", "Set category")
     .option("--no-category", "Clear category")
+    .option("--kind <kind>", `Set product taxonomy (${KIND_VALUES.join(", ")})`)
+    .option("--no-kind", "Clear product kind")
     .option("--json", "Output as JSON")
     .option("--dry-run", "Show what would change without writing")
     .action(productUpdateAction);
@@ -327,6 +374,8 @@ export function registerProductCommand(program: Command) {
     .option("--description <text>", "New product description")
     .option("--category <category>", "Set category")
     .option("--no-category", "Clear category")
+    .option("--kind <kind>", `Set product taxonomy (${KIND_VALUES.join(", ")})`)
+    .option("--no-kind", "Clear product kind")
     .option("--json", "Output as JSON")
     .option("--dry-run", "Show what would change without writing")
     .action(

--- a/src/cli/commands/product.ts
+++ b/src/cli/commands/product.ts
@@ -22,6 +22,7 @@ import {
 import { toSlug } from "@buildinternet/releases-core/slug";
 import { isValidCategory, CATEGORIES } from "@buildinternet/releases-core/categories";
 import { isValidKind, KIND_VALUES, type Kind } from "@buildinternet/releases-core/kinds";
+import { logger } from "@releases/lib/logger";
 import { writeJson } from "../../lib/output.js";
 import { computePagination, type ListResponse } from "@buildinternet/releases-core/cli-contracts";
 import { warnDeprecatedAlias } from "../../lib/deprecated-alias.js";
@@ -94,9 +95,7 @@ async function productCreateAction(name: string, opts: ProductCreateOpts): Promi
   }
 
   if (opts.kind !== undefined && !isValidKind(opts.kind)) {
-    console.error(
-      chalk.red(`Invalid kind "${opts.kind}". Must be one of: ${KIND_VALUES.join(", ")}`),
-    );
+    logger.error(`Invalid kind "${opts.kind}". Must be one of: ${KIND_VALUES.join(", ")}`);
     process.exit(1);
   }
   const kind = opts.kind as Kind | undefined;
@@ -197,9 +196,7 @@ async function productUpdateAction(slug: string, opts: ProductUpdateOpts): Promi
     updates.kind = null;
   } else if (typeof opts.kind === "string") {
     if (!isValidKind(opts.kind)) {
-      console.error(
-        chalk.red(`Invalid kind "${opts.kind}". Must be one of: ${KIND_VALUES.join(", ")}`),
-      );
+      logger.error(`Invalid kind "${opts.kind}". Must be one of: ${KIND_VALUES.join(", ")}`);
       process.exit(1);
     }
     updates.kind = opts.kind satisfies Kind;
@@ -268,9 +265,7 @@ export function registerProductCommand(program: Command) {
       }
 
       if (opts.kind !== undefined && !isValidKind(opts.kind)) {
-        console.error(
-          chalk.red(`Invalid kind "${opts.kind}". Must be one of: ${KIND_VALUES.join(", ")}`),
-        );
+        logger.error(`Invalid kind "${opts.kind}". Must be one of: ${KIND_VALUES.join(", ")}`);
         process.exit(1);
       }
       const kind = opts.kind as Kind | undefined;

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -3,6 +3,7 @@ import chalk from "chalk";
 import { unifiedSearch } from "../../api/client.js";
 import { stripAnsi } from "../../lib/sanitize.js";
 import { logger } from "@releases/lib/logger";
+import { isValidKind, KIND_VALUES, type Kind } from "@buildinternet/releases-core/kinds";
 import type { LookupResultPayload, UnifiedSearchResponse } from "../../api/types.js";
 import { writeJson } from "../../lib/output.js";
 
@@ -126,6 +127,10 @@ export function registerSearchCommand(program: Command) {
       "--domain <domain>",
       "Scope to the org owning this domain (URL-shaped input is normalized)",
     )
+    .option(
+      "--kind <kind>",
+      `Filter by taxonomy (${KIND_VALUES.join(", ")}). Release hits use COALESCE(source.kind, product.kind); catalog hits match the row's own kind only.`,
+    )
     .option("--json", "Output as JSON")
     .action(
       async (
@@ -135,6 +140,7 @@ export function registerSearchCommand(program: Command) {
           type?: string;
           mode?: string;
           domain?: string;
+          kind?: string;
           json?: boolean;
         },
       ) => {
@@ -148,6 +154,14 @@ export function registerSearchCommand(program: Command) {
           process.exit(1);
         }
 
+        if (opts.kind !== undefined && !isValidKind(opts.kind)) {
+          logger.error(
+            `Invalid --kind value: "${opts.kind}". Must be one of: ${KIND_VALUES.join(", ")}`,
+          );
+          process.exit(1);
+        }
+        const kind = opts.kind as Kind | undefined;
+
         let types: readonly SearchSection[];
         try {
           types = opts.type
@@ -158,9 +172,10 @@ export function registerSearchCommand(program: Command) {
           process.exit(1);
         }
 
-        const searchOpts: { mode?: SearchMode; domain?: string } = {};
+        const searchOpts: { mode?: SearchMode; domain?: string; kind?: Kind } = {};
         if (mode) searchOpts.mode = mode;
         if (opts.domain) searchOpts.domain = opts.domain;
+        if (kind) searchOpts.kind = kind;
         const response = await unifiedSearch(
           query,
           limit,

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -218,9 +218,7 @@ export async function updateSourceAction(
     changes.push("kind cleared");
   } else if (typeof opts.kind === "string") {
     if (!isValidKind(opts.kind)) {
-      console.error(
-        chalk.red(`Invalid kind "${opts.kind}". Must be one of: ${KIND_VALUES.join(", ")}`),
-      );
+      logger.error(`Invalid kind "${opts.kind}". Must be one of: ${KIND_VALUES.join(", ")}`);
       process.exit(1);
     }
     updates.kind = opts.kind satisfies Kind;

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -10,6 +10,7 @@ import {
 } from "../../api/client.js";
 import { sourceNotFound } from "../suggest.js";
 import { toSlug } from "@buildinternet/releases-core/slug";
+import { isValidKind, KIND_VALUES, type Kind } from "@buildinternet/releases-core/kinds";
 import { logger } from "@releases/lib/logger";
 import { writeJson } from "../../lib/output.js";
 import { readContentArg } from "../../lib/input.js";
@@ -46,6 +47,7 @@ export type UpdateSourceOpts = {
   disable?: boolean;
   enable?: boolean;
   changelogPaths?: string | boolean;
+  kind?: string | boolean;
   dryRun?: boolean;
   metadataSet?: string[];
   metadataUnset?: string[];
@@ -209,6 +211,20 @@ export async function updateSourceAction(
   } else if (opts.enable) {
     updates.isHidden = false;
     changes.push("enabled");
+  }
+
+  if (opts.kind === false) {
+    updates.kind = null;
+    changes.push("kind cleared");
+  } else if (typeof opts.kind === "string") {
+    if (!isValidKind(opts.kind)) {
+      console.error(
+        chalk.red(`Invalid kind "${opts.kind}". Must be one of: ${KIND_VALUES.join(", ")}`),
+      );
+      process.exit(1);
+    }
+    updates.kind = opts.kind satisfies Kind;
+    changes.push(`kind → ${opts.kind}`);
   }
 
   const metaUpdates: Record<string, unknown> = {};
@@ -406,6 +422,11 @@ export function attachUpdateOptions(cmd: Command): Command {
     .option("--priority <level>", "Set fetch priority (normal, low, paused)")
     .option("--disable", "Disable source")
     .option("--enable", "Re-enable a disabled source")
+    .option(
+      "--kind <kind>",
+      `Set source taxonomy (${KIND_VALUES.join(", ")}). Resolves through the parent product on content-oriented surfaces (releases feed, search release hits) and matches directly on metadata surfaces (lists, catalog).`,
+    )
+    .option("--no-kind", "Clear the source's kind (falls back to inheriting from parent product)")
     .option(
       "--changelog-paths <paths>",
       "Comma-separated list of CHANGELOG paths (relative to repo root) for monorepo sources, e.g. 'packages/core/CHANGELOG.md,packages/cli/CHANGELOG.md'",

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -382,7 +382,8 @@ export function searchToMarkdown(results: UnifiedSearchResponse, opts: FormatOpt
     lines.push("");
     for (const p of catalog) {
       const orgInfo = p.orgSlug ? ` (${p.orgName})` : "";
-      const viewSlug = p.kind === "source" && p.sourceSlug ? p.sourceSlug : `product/${p.slug}`;
+      const viewSlug =
+        p.entryType === "source" && p.sourceSlug ? p.sourceSlug : `product/${p.slug}`;
       const url =
         opts.baseUrl && p.orgSlug ? ` — [view](${opts.baseUrl}/${p.orgSlug}/${viewSlug})` : "";
       lines.push(

--- a/tests/cli/source-kind.test.ts
+++ b/tests/cli/source-kind.test.ts
@@ -30,30 +30,35 @@ describe("--kind flag exposure", () => {
     expect(exitCode).toBe(0);
     expect(stdout).toContain("--kind <kind>");
     expect(stdout).toContain("--no-kind");
+    expect(stdout).toContain("platform, sdk");
   });
 
   it("admin product create --help lists --kind", () => {
     const { stdout, exitCode } = runCli(["admin", "product", "create", "--help"]);
     expect(exitCode).toBe(0);
     expect(stdout).toContain("--kind <kind>");
+    expect(stdout).toContain("platform, sdk");
   });
 
   it("admin product list --help lists --kind", () => {
     const { stdout, exitCode } = runCli(["admin", "product", "list", "--help"]);
     expect(exitCode).toBe(0);
     expect(stdout).toContain("--kind <kind>");
+    expect(stdout).toContain("platform, sdk");
   });
 
   it("list --help lists --kind", () => {
     const { stdout, exitCode } = runCli(["list", "--help"]);
     expect(exitCode).toBe(0);
     expect(stdout).toContain("--kind <kind>");
+    expect(stdout).toContain("platform, sdk");
   });
 
   it("search --help lists --kind", () => {
     const { stdout, exitCode } = runCli(["search", "--help"]);
     expect(exitCode).toBe(0);
     expect(stdout).toContain("--kind <kind>");
+    expect(stdout).toContain("platform, sdk");
   });
 });
 
@@ -69,6 +74,7 @@ describe("--kind validation", () => {
     const { stderr, exitCode } = runCli(["search", "anything", "--kind", "nope"]);
     expect(exitCode).not.toBe(0);
     expect(stderr).toContain('Invalid --kind value: "nope"');
+    expect(stderr).toContain("platform, sdk, mobile, desktop, docs, integration, tool");
   });
 
   it("list accepts a valid kind through flag parsing (network call may fail; flag parse must not)", () => {

--- a/tests/cli/source-kind.test.ts
+++ b/tests/cli/source-kind.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "bun:test";
+import { runCli } from "../utils.js";
+
+/**
+ * Coverage for the `--kind` flag added in Phase B of the source-kind enum
+ * (issue #1080). Writes (`admin source update`, `admin product update`,
+ * `admin product create`) and reads (`list`, `admin product list`, `search`)
+ * each accept `--kind <value>`. The behavior the CLI is responsible for is
+ * local validation against KIND_VALUES — wire-level filter behavior is
+ * covered in the API + MCP test suites.
+ *
+ * Most assertions are help-output checks because the write paths resolve an
+ * entity over the network before validating optional flags; behavioral
+ * rejection is verified on the two read commands that validate `--kind`
+ * before any API call.
+ */
+describe("--kind flag exposure", () => {
+  it("admin source update --help lists --kind and --no-kind", () => {
+    const { stdout, exitCode } = runCli(["admin", "source", "update", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--kind <kind>");
+    expect(stdout).toContain("--no-kind");
+    // commander wraps long descriptions across lines, so assert the prefix
+    // rather than the full enum spelled out.
+    expect(stdout).toContain("platform, sdk");
+  });
+
+  it("admin product update --help lists --kind and --no-kind", () => {
+    const { stdout, exitCode } = runCli(["admin", "product", "update", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--kind <kind>");
+    expect(stdout).toContain("--no-kind");
+  });
+
+  it("admin product create --help lists --kind", () => {
+    const { stdout, exitCode } = runCli(["admin", "product", "create", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--kind <kind>");
+  });
+
+  it("admin product list --help lists --kind", () => {
+    const { stdout, exitCode } = runCli(["admin", "product", "list", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--kind <kind>");
+  });
+
+  it("list --help lists --kind", () => {
+    const { stdout, exitCode } = runCli(["list", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--kind <kind>");
+  });
+
+  it("search --help lists --kind", () => {
+    const { stdout, exitCode } = runCli(["search", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--kind <kind>");
+  });
+});
+
+describe("--kind validation", () => {
+  it("list rejects unknown kind before any API call", () => {
+    const { stderr, exitCode } = runCli(["list", "--kind", "nope"]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain('Invalid kind "nope"');
+    expect(stderr).toContain("platform, sdk, mobile, desktop, docs, integration, tool");
+  });
+
+  it("search rejects unknown kind before any API call", () => {
+    const { stderr, exitCode } = runCli(["search", "anything", "--kind", "nope"]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain('Invalid --kind value: "nope"');
+  });
+
+  it("list accepts a valid kind through flag parsing (network call may fail; flag parse must not)", () => {
+    // We can't assert on API response (tests run against a fake URL) but we
+    // can confirm `--kind sdk` doesn't trip the local validator the way
+    // `--kind nope` does. Failure here would surface as "Invalid kind …" on
+    // stderr, which the negative test above guards.
+    const { stderr } = runCli(["list", "--kind", "sdk"]);
+    expect(stderr).not.toContain('Invalid kind "sdk"');
+  });
+});

--- a/tests/unit/formatters-markdown.test.ts
+++ b/tests/unit/formatters-markdown.test.ts
@@ -55,7 +55,7 @@ const catalogHits: UnifiedSearchResponse["catalog"] = [
     orgSlug: "meta",
     orgName: "Meta",
     category: "frontend",
-    kind: "product",
+    entryType: "product",
   },
   {
     slug: "react-native",
@@ -63,7 +63,7 @@ const catalogHits: UnifiedSearchResponse["catalog"] = [
     orgSlug: "meta",
     orgName: "Meta",
     category: null,
-    kind: "source",
+    entryType: "source",
     sourceSlug: "react-native",
   },
 ];


### PR DESCRIPTION
Tracks: buildinternet/releases#1080 (Phase B)

## Summary

Adds CLI write + read support for the `kind` enum that landed on the wire in [buildinternet/releases#1081](https://github.com/buildinternet/releases/pull/1081). The new flag is `--kind <value>` and accepts `platform | sdk | mobile | desktop | docs | integration | tool`.

**Filter asymmetry** (mirrors the API):

| Surface | Behavior |
|---|---|
| `releases list`, `admin product list`, `search` catalog hits | Matches the row's own `kind` only |
| `search` release hits | `COALESCE(source.kind, product.kind)` — inheritance |
| `admin source update --kind`, `admin product update --kind` | Sets the row's own `kind` |
| `--no-kind` on update | Clears the row's `kind` (source falls back to inheriting from parent product) |

Local validation via `isValidKind` from `@buildinternet/releases-core/kinds`: invalid values exit non-zero with `KIND_VALUES` echoed back.

## What changed

- **package.json:** pin bump for `@buildinternet/releases-core` and `@buildinternet/releases-api-types` from `^0.21.0` → `^0.22.0`.
- **API client (`src/api/client.ts`):** optional `kind?: Kind` on `unifiedSearch` opts, `ListSourcesOpts`, `createProduct` opts, and `getProductsByOrg` opts. Threaded into query strings / POST bodies.
- **Write paths:**
  - `admin source update`: `--kind <value>` + `--no-kind`.
  - `admin product update`: `--kind <value>` + `--no-kind`.
  - `admin product create`: `--kind <value>`.
- **Read paths:**
  - `list` / `admin source list`: `--kind <value>`.
  - `admin product list`: `--kind <value>`.
  - `search`: `--kind <value>`.
- **Plugin skill docs:** `skills/releases-cli/references/admin.md` + `reader.md` updated with examples and the filter-asymmetry note, then synced to `plugins/` via `bun run sync:plugin-skills`.
- **Phase A ripple fix:** the catalog discriminator was renamed `kind → entryType` on the wire to free `kind` for the entity taxonomy. `src/lib/formatters.ts:385` and the test fixture in `tests/unit/formatters-markdown.test.ts` were reading the old field; switched to `entryType`. The taxonomy `kind` field now coexists with `entryType` on each catalog hit.
- **Changeset:** `.changeset/source-kind.md` targeting `@buildinternet/releases` (fixed-group minor bump).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `bun run lint` clean
- [x] `bun run format:check` clean
- [x] `bun test` — 418/418 pass (new file `tests/cli/source-kind.test.ts` adds 9 of those: `--help` exposure on the six affected commands + invalid-kind rejection on the two read commands that validate before any network call). Write-path validation happens after `findSource` / `findProduct`, so it's smoke-tested manually rather than in CI.
- [x] Manual smoke: `releases list --kind nope` → exit 1, "Invalid kind". `releases search foo --kind nope` → exit 1, "Invalid --kind value". `releases list --kind sdk` → no validator error.
- [ ] Merge → `bun run changeset:version` → publish via the existing release workflow.

## Out of scope (tracked in buildinternet/releases#1080)

- Curated backfill of noisy multi-source orgs (AWS, Stripe, OpenAI, Anthropic, Vercel, Cloudflare).
- Discovery agent product-wrapping proposals.
- Overview generation downweighting by kind.
- Web display of kind chips.
- MCP `kind` filter on the non-search tools (`search_releases`, `get_latest_releases`, `list_sources`, `list_organizations`).
- `_meta.search` echo of applied `kind` filter to MCP callers.
- Future name cleanup (`sources.type → sources.adapter`; promote `kind → type`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--kind` taxonomy to classify and filter sources and products (`platform`, `sdk`, `mobile`, `desktop`, `docs`, `integration`, `tool`) across search, list, and product/admin commands; CLI validates values locally.

* **Documentation**
  * Expanded CLI docs with `--kind`/`--no-kind` examples, filtering semantics, and inheritance notes for content vs. metadata surfaces.

* **Tests**
  * Added CLI tests covering `--kind` help, validation, and examples.

* **Other**
  * Search/list JSON output updated to include an `entryType` discriminator plus optional `kind`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/buildinternet/releases-cli/pull/195?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->