### PR TITLE
fix(cli): strip null/undefined from createSource POST body

### DIFF
--- a/.changeset/create-source-strip-null.md
+++ b/.changeset/create-source-strip-null.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": patch
+---
+
+Strip null/undefined fields from the `POST /v1/sources` request body in `createSource()`. The API's Zod schema treats `z.string().optional()` as "string or absent" — an explicit `"productId": null` in the JSON body trips the validator and 400s. Sending `--org <slug>` without `--product` previously triggered this. The fix filters null/undefined values before serialization so optional fields drop out cleanly.

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -733,9 +733,14 @@ export async function createSource(data: {
   productId?: string | null;
   metadata?: string;
 }): Promise<Source> {
+  // Strip null/undefined values so the API's z.string().optional() schema
+  // doesn't reject an explicit `"productId": null` in the JSON body.
+  const body = Object.fromEntries(
+    Object.entries(data).filter(([, v]) => v !== null && v !== undefined),
+  );
   return apiFetch<Source>("/v1/sources", {
     method: "POST",
-    body: JSON.stringify(data),
+    body: JSON.stringify(body),
   });
 }
 


### PR DESCRIPTION
## Summary

- `createSource()` was sending `"productId": null` when no `--product` was supplied, tripping the API's `z.string().optional()` schema and returning 400.
- Filter null/undefined values out of the body before `JSON.stringify` so optional fields drop out of the request entirely.
- Patch changeset cascades the version bump across the fixed group.

## Repro

Pre-fix, with the CLI on `main`:

```bash
releases admin source create "Blog" --url https://example.com/blog --org example
# → 400 bad_request from /v1/sources
```

Post-fix, the same command succeeds because `productId` is absent from the body rather than `null`.

Surfaced during an onboarding session that needed `--org` without `--product`. There's no fetch-mock harness on the CLI for a regression test today, so the fix is verified manually.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint src/api/client.ts`
- [x] Manual: `releases admin source create … --org … --json` returns 201 with the created source
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where optional fields with null values in source creation requests were causing validation errors. The API now correctly ignores explicitly null or undefined values for optional fields.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/buildinternet/releases-cli/pull/198?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->