### PR TITLE
fix: show overview updated freshness

### DIFF
--- a/.changeset/overview-updated-freshness.md
+++ b/.changeset/overview-updated-freshness.md
@@ -1,0 +1,12 @@
+---
+"@buildinternet/releases": patch
+"@buildinternet/releases-darwin-arm64": patch
+"@buildinternet/releases-darwin-x64": patch
+"@buildinternet/releases-linux-arm64": patch
+"@buildinternet/releases-linux-x64": patch
+"@buildinternet/releases-windows-x64": patch
+"@buildinternet/releases-lib": patch
+"@buildinternet/releases-skills": patch
+---
+
+`releases admin overview get` now shows the overview's most recent update time when it differs from the original generation time, while keeping the release and citation counts in the summary line.

--- a/src/cli/commands/admin/overview.ts
+++ b/src/cli/commands/admin/overview.ts
@@ -95,7 +95,47 @@ interface OverviewBatchOpts {
   traceDir?: string;
 }
 
+interface OverviewFreshnessInput {
+  generatedAt?: string | null;
+  updatedAt?: string | null;
+  releaseCount: number;
+  citationCount?: number;
+}
+
 // ── Action handlers ───────────────────────────────────────────────────────────
+
+function ageLabel(iso: string | null | undefined): string {
+  return iso ? (timeAgo(iso) ?? "?") : "?";
+}
+
+function timestampsDifferMeaningfully(
+  first: string | null | undefined,
+  second: string | null | undefined,
+): boolean {
+  if (!first || !second) return first !== second;
+
+  const firstMs = Date.parse(first);
+  const secondMs = Date.parse(second);
+  if (!Number.isFinite(firstMs) || !Number.isFinite(secondMs)) return first !== second;
+
+  return firstMs !== secondMs;
+}
+
+export function formatOverviewFreshnessLine(overview: OverviewFreshnessInput): string {
+  const generatedLabel = ageLabel(overview.generatedAt);
+  const releaseLabel = `${overview.releaseCount} releases contributing`;
+  const citationLabel =
+    overview.citationCount === undefined ? "" : ` · ${overview.citationCount} citations`;
+
+  if (
+    overview.updatedAt &&
+    timestampsDifferMeaningfully(overview.updatedAt, overview.generatedAt)
+  ) {
+    return `updated ${ageLabel(overview.updatedAt)} · generated ${generatedLabel} · ${releaseLabel}${citationLabel}`;
+  }
+
+  return `generated ${generatedLabel} · ${releaseLabel}${citationLabel}`;
+}
 
 async function overviewGetAction(orgIdentifier: string, opts: OverviewGetOpts): Promise<void> {
   const org = await findOrg(orgIdentifier);
@@ -131,12 +171,9 @@ async function overviewGetAction(orgIdentifier: string, opts: OverviewGetOpts): 
     return;
   }
 
-  const ageLabel = overview.generatedAt ? (timeAgo(overview.generatedAt) ?? "?") : "?";
   console.log(chalk.bold(`${org.name} — overview`));
   console.log(
-    chalk.dim(
-      `  generated ${ageLabel} · ${overview.releaseCount} releases contributing · ${citations.length} citations`,
-    ),
+    chalk.dim(`  ${formatOverviewFreshnessLine({ ...overview, citationCount: citations.length })}`),
   );
   console.log();
   console.log(overview.content);

--- a/src/cli/commands/admin/overview.ts
+++ b/src/cli/commands/admin/overview.ts
@@ -104,10 +104,17 @@ interface OverviewFreshnessInput {
 
 // ── Action handlers ───────────────────────────────────────────────────────────
 
+/**
+ * Formats an overview timestamp for compact status output.
+ */
 function ageLabel(iso: string | null | undefined): string {
   return iso ? (timeAgo(iso) ?? "?") : "?";
 }
 
+/**
+ * Compares overview timestamps by instant, falling back to raw value comparison
+ * when either value is missing or cannot be parsed.
+ */
 function timestampsDifferMeaningfully(
   first: string | null | undefined,
   second: string | null | undefined,
@@ -121,6 +128,9 @@ function timestampsDifferMeaningfully(
   return firstMs !== secondMs;
 }
 
+/**
+ * Builds the human-readable freshness line shown above an org overview.
+ */
 export function formatOverviewFreshnessLine(overview: OverviewFreshnessInput): string {
   const generatedLabel = ageLabel(overview.generatedAt);
   const releaseLabel = `${overview.releaseCount} releases contributing`;

--- a/tests/cli/overview-freshness.test.ts
+++ b/tests/cli/overview-freshness.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "bun:test";
+import { daysAgoIso } from "@buildinternet/releases-core/dates";
+import { formatOverviewFreshnessLine } from "../../src/cli/commands/admin/overview.js";
+
+describe("overview freshness line", () => {
+  it("keeps the generated-only label when the overview has not been amended", () => {
+    const generatedAt = new Date().toISOString();
+
+    const line = formatOverviewFreshnessLine({
+      generatedAt,
+      updatedAt: generatedAt,
+      releaseCount: 10,
+    });
+
+    expect(line).toBe("generated just now · 10 releases contributing");
+  });
+
+  it("keeps the citation count when freshness details are formatted", () => {
+    const generatedAt = new Date().toISOString();
+
+    const line = formatOverviewFreshnessLine({
+      generatedAt,
+      updatedAt: generatedAt,
+      releaseCount: 10,
+      citationCount: 2,
+    });
+
+    expect(line).toBe("generated just now · 10 releases contributing · 2 citations");
+  });
+
+  it("surfaces updated freshness when an amended overview has an older generation time", () => {
+    const line = formatOverviewFreshnessLine({
+      generatedAt: daysAgoIso(12),
+      updatedAt: new Date().toISOString(),
+      releaseCount: 10,
+    });
+
+    expect(line).toBe("updated just now · generated 12d ago · 10 releases contributing");
+  });
+});


### PR DESCRIPTION
Closes #45.

## Summary
- Adds a tested overview freshness formatter for the admin overview read path.
- Shows `updated ... · generated ...` when `updatedAt` differs from `generatedAt`, while keeping the existing generated-only line for never-amended overviews.

## Verification
- `bun test tests/cli/overview-freshness.test.ts tests/cli/overview-subcommands.test.ts tests/cli/overview-stale-filter.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bunx prettier --check src/cli/commands/admin/overview.ts tests/cli/overview-freshness.test.ts`

AI assistance was used to prepare this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized and improved the overview freshness display so age labels more accurately indicate "generated" vs "updated" times and handle missing/unparseable timestamps.

* **Tests**
  * Added tests for the freshness formatter covering matching timestamps, inclusion of citation counts, and cases where updates are more recent (showing both "updated" and prior "generated" ages).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/buildinternet/releases-cli/pull/200?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->