### PR TITLE
feat: releases auth — store & verify API tokens

### DIFF
--- a/.changeset/cli-auth-token-storage.md
+++ b/.changeset/cli-auth-token-storage.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": minor
+---
+
+Add `releases auth` commands (`login`, `logout`, `status`, `token`) to store a verified API token in `~/.releases/credentials` (0600). `whoami` now aliases `auth status`. Tokens are verified against `GET /v1/tokens/me` before saving; the env var `RELEASED_API_KEY` still takes precedence.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
         run: npx tsc --noEmit
 
       - name: Test
-        run: bun test
+        run: bun test --isolate
 
   smoke-windows:
     name: Windows binary smoke test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Least-privilege default token: every job here only reads the repo.
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint & Format

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ releases auth logout                    # remove the stored token
 
 **Credential precedence:** if `RELEASED_API_KEY` is set in the environment it takes priority over any stored credential — useful for CI or per-command overrides.
 
-**Storage:** credentials are written to `~/.releases/credentials` with `0600` permissions (owner-read-only). The file is JSON and contains the token, name, scopes, the API URL the token was verified against, and a `savedAt` timestamp.
+**Storage:** credentials are written to `~/.releases/credentials` with `0600` permissions (owner read/write, rw-------). The file is JSON and contains the token, name, scopes, the API URL the token was verified against, and a `savedAt` timestamp.
 
 ## Environment
 

--- a/README.md
+++ b/README.md
@@ -156,11 +156,37 @@ npx skills add buildinternet/releases-cli
 
 Use this path when you only want the skill behavior (auto-triggering on release/CLI questions) without also registering the hosted MCP connection, agents, and `/releases` command that the plugin provides. Skills are symlinked by default, so re-running `releases skills install` (or `npx skills update releases-cli`) refreshes everything atomically.
 
+## Authentication
+
+Admin commands require an API token. You can store one persistently using the `auth` command namespace so you don't need to set `RELEASED_API_KEY` in your shell every time.
+
+```bash
+releases auth login                     # interactive prompt (masked input)
+releases auth login --token <token>     # pass directly
+releases auth login --token -           # read from stdin (pipe-friendly)
+```
+
+The token is verified against `GET /v1/tokens/me` before being saved. If verification fails, nothing is written.
+
+```bash
+releases auth status                    # show current auth state
+releases auth status --json             # machine-readable (authenticated, source, scopes, …)
+releases auth status --verify           # re-check the token against the API live
+releases auth token                     # print the raw token (for scripts)
+releases auth logout                    # remove the stored token
+```
+
+`whoami` is an alias for `auth status`.
+
+**Credential precedence:** if `RELEASED_API_KEY` is set in the environment it takes priority over any stored credential — useful for CI or per-command overrides.
+
+**Storage:** credentials are written to `~/.releases/credentials` with `0600` permissions (owner-read-only). The file is JSON and contains the token, name, scopes, the API URL the token was verified against, and a `savedAt` timestamp.
+
 ## Environment
 
 Nothing is required for reader access. For admin operations (closed beta — see above):
 
-- `RELEASED_API_KEY` — Bearer token for write endpoints. Required for any `releases admin …` command that mutates state. Keys are not self-serve right now.
+- `RELEASED_API_KEY` — Bearer token for write endpoints. Overrides any stored credential from `releases auth login`. Required for any `releases admin …` command that mutates state if no stored credential is present. Keys are not self-serve right now.
 - `RELEASED_API_URL` — Override the default `https://api.releases.sh` endpoint (useful for staging).
 - `RELEASED_TELEMETRY_DISABLED=1` — Opt out of anonymous usage pings. `DO_NOT_TRACK=1` is also honored.
 - `RELEASES_DISABLE_SKILL_UPDATE_CHECK=1` — Silence the "skills are behind, run `releases skills install`" stderr nag that fires (at most once per 24h) when the GitHub `skills/` tree has moved since your last install.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "changeset": "changeset",
     "changeset:version": "changeset version && bun scripts/sync-version.ts && bun install",
     "changeset:publish": "changeset publish",
-    "test": "bun test",
+    "test": "bun test --isolate",
     "typecheck": "tsc --noEmit",
     "lint": "oxlint",
     "lint:fix": "oxlint --fix",

--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -1,0 +1,182 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { join } from "node:path";
+import { getDataDir } from "@releases/lib/config";
+import { getApiUrl, resolveCredential } from "../../lib/mode.js";
+import { writeCredential, clearCredential, type StoredCredential } from "../../lib/credentials.js";
+import { hiddenPromptReader } from "../../lib/prompt-hidden.js";
+import type { PromptReader } from "../../lib/confirm.js";
+import { writeJson } from "../../lib/output.js";
+import { RELEASES_CLI_UA } from "../../lib/user-agent.js";
+
+export interface TokenIdentity {
+  kind: "root" | "token";
+  name: string;
+  scopes: string[];
+  principalType?: string;
+  principalId?: string | null;
+  expiresAt?: string | null;
+  lastUsedAt?: string | null;
+}
+
+/** Verify a token against GET /v1/tokens/me. Throws a friendly Error on failure. */
+export async function verifyToken(
+  token: string,
+  apiUrl: string,
+  fetchFn: typeof fetch = fetch,
+): Promise<TokenIdentity> {
+  const res = await fetchFn(`${apiUrl}/v1/tokens/me`, {
+    headers: { Authorization: `Bearer ${token}`, "User-Agent": RELEASES_CLI_UA },
+  });
+  if (res.status === 401) throw new Error("Token rejected by the server (401).");
+  if (!res.ok) throw new Error(`Server returned ${res.status} verifying the token.`);
+  return (await res.json()) as TokenIdentity;
+}
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
+  return Buffer.concat(chunks).toString("utf8").trim();
+}
+
+/** Resolve the token from --token (value or "-"), stdin, or an interactive prompt. */
+export async function resolveTokenInput(
+  optToken: string | undefined,
+  reader: PromptReader,
+): Promise<string> {
+  if (optToken === "-") return readStdin();
+  if (optToken) return optToken.trim();
+  const entered = await reader("Paste your API token: ");
+  if (entered === null) {
+    throw new Error("No token provided. Pass --token <token> (or '-' to read from stdin).");
+  }
+  return entered.trim();
+}
+
+/** Shared status renderer used by `auth status` and `whoami`. */
+export async function printAuthStatus(opts: { json?: boolean; verify?: boolean }): Promise<void> {
+  const cred = resolveCredential();
+  const apiUrl = getApiUrl();
+  let identity: TokenIdentity | null = null;
+  let verifyError: string | null = null;
+  // Env-sourced tokens have no stored metadata, so verify to learn name/scopes.
+  if (cred.token && (opts.verify || cred.source === "env")) {
+    try {
+      identity = await verifyToken(cred.token, apiUrl);
+    } catch (err) {
+      verifyError = (err as Error).message;
+    }
+  }
+  const scopes = identity?.scopes ?? cred.scopes ?? null;
+  const name = identity?.name ?? cred.name ?? null;
+
+  if (opts.json) {
+    await writeJson({
+      authenticated: cred.token !== null,
+      source: cred.source,
+      apiUrl,
+      name,
+      scopes,
+      verified: identity !== null,
+      verifyError,
+    });
+    return;
+  }
+
+  const label = (k: string) => chalk.dim(k.padEnd(10));
+  console.log(chalk.bold("releases auth\n"));
+  console.log(
+    `${label("Status")}${cred.token ? chalk.green("authenticated") : chalk.red("not authenticated")}`,
+  );
+  console.log(`${label("Source")}${cred.source === "none" ? chalk.dim("—") : cred.source}`);
+  console.log(`${label("API URL")}${apiUrl}`);
+  console.log(`${label("Name")}${name ?? chalk.dim("—")}`);
+  console.log(`${label("Scopes")}${scopes ? scopes.join(", ") : chalk.dim("—")}`);
+  if (verifyError) console.log(`${label("Verify")}${chalk.red(verifyError)}`);
+  else if (identity) console.log(`${label("Verify")}${chalk.green("✓ live")}`);
+}
+
+export function registerAuthCommand(parent: Command): void {
+  const auth = parent.command("auth").description("Manage CLI authentication");
+
+  auth
+    .command("login")
+    .description("Verify and store an API token")
+    .option("--token <token>", "Token value, or '-' to read from stdin")
+    .action(async (opts: { token?: string }) => {
+      let token: string;
+      try {
+        token = await resolveTokenInput(opts.token, hiddenPromptReader);
+      } catch (err) {
+        console.error(chalk.red((err as Error).message));
+        process.exit(1);
+      }
+      if (!token) {
+        console.error(chalk.red("No token provided."));
+        process.exit(1);
+      }
+      const apiUrl = getApiUrl();
+      let identity: TokenIdentity;
+      try {
+        identity = await verifyToken(token, apiUrl);
+      } catch (err) {
+        console.error(chalk.red(`✗ ${(err as Error).message} Not saved.`));
+        process.exit(1);
+      }
+      const cred: StoredCredential = {
+        token,
+        name: identity.name,
+        scopes: identity.scopes,
+        apiUrl,
+        savedAt: new Date().toISOString(),
+      };
+      writeCredential(cred);
+      console.log(
+        `${chalk.green("✓")} Verified — ${chalk.bold(identity.name)} ${chalk.dim(
+          `(scopes: ${identity.scopes.join(", ")})`,
+        )}`,
+      );
+      console.log(chalk.dim(`  Saved to ${join(getDataDir(), "credentials")}`));
+    });
+
+  auth
+    .command("logout")
+    .description("Remove the stored API token")
+    .action(() => {
+      const removed = clearCredential();
+      if (process.env.RELEASED_API_KEY) {
+        console.log(
+          chalk.yellow(
+            "Removed any stored token, but RELEASED_API_KEY is still set in your environment.",
+          ),
+        );
+      } else if (removed) {
+        console.log(`${chalk.green("✓")} Logged out (stored token removed).`);
+      } else {
+        console.log(chalk.dim("No stored token to remove."));
+      }
+    });
+
+  auth
+    .command("status")
+    .description("Show authentication status")
+    .option("--json", "Output as JSON")
+    .option("--verify", "Re-check the token against the API")
+    .action(async (opts: { json?: boolean; verify?: boolean }) => {
+      await printAuthStatus(opts);
+    });
+
+  auth
+    .command("token")
+    .description("Print the current API token (for scripts)")
+    .action(() => {
+      const { token } = resolveCredential();
+      if (!token) {
+        console.error(
+          chalk.red("Not authenticated. Run `releases auth login` or set RELEASED_API_KEY."),
+        );
+        process.exit(1);
+      }
+      process.stdout.write(`${token}\n`);
+    });
+}

--- a/src/cli/commands/whoami.ts
+++ b/src/cli/commands/whoami.ts
@@ -1,101 +1,22 @@
 import { Command } from "commander";
-import chalk from "chalk";
-import { getApiKey, getApiUrl, isAdminMode } from "../../lib/mode.js";
-import { VERSION } from "../version.js";
-import { writeJson } from "../../lib/output.js";
-import { RELEASES_CLI_UA } from "../../lib/user-agent.js";
+import { printAuthStatus } from "./auth.js";
 
-export type WhoamiStatus = {
-  version: string;
-  apiUrl: string;
-  apiUrlSource: "default" | "env";
-  mode: "admin" | "public";
-  apiKey: { set: boolean; hint: string | null };
-  check?: { ok: boolean; status: number | null; message: string | null };
-};
-
+/**
+ * Kept for back-compat — still exported because tests/unit/whoami.test.ts
+ * imports it directly. The whoami command no longer calls it.
+ */
 export function redactApiKey(key: string): string {
   if (key.length <= 8) return "****";
   return `${key.slice(0, 4)}…${key.slice(-4)}`;
 }
 
-export function collectWhoami(): WhoamiStatus {
-  const envUrl = process.env.RELEASED_API_URL;
-  const rawKey = process.env.RELEASED_API_KEY;
-  return {
-    version: VERSION,
-    apiUrl: getApiUrl(),
-    apiUrlSource: envUrl ? "env" : "default",
-    mode: isAdminMode() ? "admin" : "public",
-    apiKey: {
-      set: !!rawKey,
-      hint: rawKey ? redactApiKey(rawKey) : null,
-    },
-  };
-}
-
-async function probeApi(mode: WhoamiStatus["mode"]): Promise<NonNullable<WhoamiStatus["check"]>> {
-  // Admin probe hits an auth-gated read so a bad key surfaces as 401.
-  // Public probe hits a public read to confirm connectivity.
-  // We call fetch directly (not apiFetch) because apiFetch returns null on
-  // GET 404 — which would false-positive the probe for a misconfigured URL.
-  const path = mode === "admin" ? "/v1/admin/blocklist?limit=1" : "/v1/sources?limit=1";
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-    "User-Agent": RELEASES_CLI_UA,
-  };
-  if (mode === "admin") headers["Authorization"] = `Bearer ${getApiKey()}`;
-  try {
-    const res = await fetch(`${getApiUrl()}${path}`, { headers });
-    res.body?.cancel();
-    return res.ok
-      ? { ok: true, status: res.status, message: null }
-      : { ok: false, status: res.status, message: `HTTP ${res.status} ${res.statusText}` };
-  } catch (err) {
-    return { ok: false, status: null, message: err instanceof Error ? err.message : String(err) };
-  }
-}
-
 export function registerWhoamiCommand(parent: Command): void {
   parent
     .command("whoami")
-    .description("Show current CLI mode, API URL, and auth status")
+    .description("Show current CLI auth status (alias for `auth status`)")
     .option("--json", "Output as JSON")
-    .option("--check", "Probe the API to verify connectivity and auth")
+    .option("--check", "Probe the API to verify the token")
     .action(async (opts: { json?: boolean; check?: boolean }) => {
-      const status: WhoamiStatus = collectWhoami();
-      if (opts.check) status.check = await probeApi(status.mode);
-
-      if (opts.json) {
-        await writeJson(status);
-        return;
-      }
-
-      const label = (k: string) => chalk.dim(k.padEnd(10));
-      const row = (k: string, v: string) => console.log(`${label(k)} ${v}`);
-
-      console.log(`${chalk.bold("releases")} ${chalk.dim(`v${status.version}`)}`);
-      const urlSuffix = status.apiUrlSource === "default" ? " (default)" : " (RELEASED_API_URL)";
-      row("API URL", `${status.apiUrl}${chalk.dim(urlSuffix)}`);
-      row("Mode", status.mode === "admin" ? chalk.green("admin") : chalk.cyan("public"));
-      row(
-        "Auth",
-        status.apiKey.set
-          ? `${chalk.green("✓")} RELEASED_API_KEY set ${chalk.dim(`(${status.apiKey.hint})`)}`
-          : `${chalk.dim("—")} RELEASED_API_KEY not set`,
-      );
-
-      if (status.check) {
-        const probeLabel = status.mode === "admin" ? "API + auth" : "API";
-        row(
-          "Probe",
-          status.check.ok
-            ? `${chalk.green("✓")} ${probeLabel} reachable`
-            : `${chalk.red("✗")} ${status.check.message}`,
-        );
-      } else {
-        console.log("");
-        console.log(chalk.dim('Run "releases whoami --check" to verify connectivity.'));
-      }
+      await printAuthStatus({ json: opts.json, verify: opts.check });
     });
 }

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -57,7 +57,7 @@ function adminKeyError(name = "admin"): never {
   console.error(
     chalk.red(`"${name}" requires an API key.`) +
       " " +
-      chalk.dim("Set RELEASED_API_KEY to enable it."),
+      chalk.dim("Run `releases auth login` or set RELEASED_API_KEY."),
   );
   process.exit(1);
 }

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -42,7 +42,7 @@ import { registerAgentContextCommand } from "./commands/agent-context.js";
 import { registerCompletionCommand } from "./commands/completion.js";
 import { registerSkillsCommand } from "./commands/skills.js";
 import { CATEGORIES } from "@buildinternet/releases-core/categories";
-import { isAdminMode, isAuthenticated } from "../lib/mode.js";
+import { isAuthenticated } from "../lib/mode.js";
 import { preflightScopeWarning } from "../lib/preflight.js";
 import { registerAuthCommand } from "./commands/auth.js";
 import { VERSION } from "./version.js";

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -42,7 +42,9 @@ import { registerAgentContextCommand } from "./commands/agent-context.js";
 import { registerCompletionCommand } from "./commands/completion.js";
 import { registerSkillsCommand } from "./commands/skills.js";
 import { CATEGORIES } from "@buildinternet/releases-core/categories";
-import { isAdminMode } from "../lib/mode.js";
+import { isAdminMode, isAuthenticated } from "../lib/mode.js";
+import { preflightScopeWarning } from "../lib/preflight.js";
+import { registerAuthCommand } from "./commands/auth.js";
 import { VERSION } from "./version.js";
 import { writeJson } from "../lib/output.js";
 
@@ -60,6 +62,12 @@ function adminKeyError(name = "admin"): never {
   process.exit(1);
 }
 
+function adminGate(): void {
+  if (!isAuthenticated()) adminKeyError("admin");
+  const warn = preflightScopeWarning();
+  if (warn) console.error(chalk.yellow(`⚠ ${warn}`));
+}
+
 function row(name: string, desc: string, pad = 22): string {
   const gap = " ".repeat(Math.max(2, pad - name.length));
   return `  ${chalk.bold(name)}${gap}${chalk.dim(desc)}`;
@@ -68,9 +76,7 @@ function row(name: string, desc: string, pad = 22): string {
 function gateAdminSubtree(root: Command): void {
   for (const sub of root.commands) {
     sub.hook("preAction", () => {
-      if (!isAdminMode()) {
-        adminKeyError("admin");
-      }
+      adminGate();
     });
     gateAdminSubtree(sub);
   }
@@ -146,8 +152,8 @@ export const program = new Command()
   // to its own position. (Issue releases-cli#133.)
   .enablePositionalOptions()
   .hook("preAction", (_thisCommand, actionCommand) => {
-    if (actionCommand.name() !== "admin" && isWithinAdminCommand(actionCommand) && !isAdminMode()) {
-      adminKeyError("admin");
+    if (actionCommand.name() !== "admin" && isWithinAdminCommand(actionCommand)) {
+      adminGate();
     }
   })
   .configureHelp({
@@ -183,6 +189,7 @@ registerShowCommand(program);
 registerCollectionReadCommands(program);
 registerTelemetryCommand(program);
 registerWhoamiCommand(program);
+registerAuthCommand(program);
 registerAgentContextCommand(program);
 registerCompletionCommand(program);
 registerSkillsCommand(program);
@@ -192,8 +199,8 @@ const admin = program
   .description("Operator workflows for onboarding, curation, and ingestion")
   .showSuggestionAfterError(true)
   .hook("preAction", (_thisCommand, actionCommand) => {
-    if (!isAdminMode() && actionCommand.name() !== "admin") {
-      adminKeyError("admin");
+    if (actionCommand.name() !== "admin") {
+      adminGate();
     }
   })
   .action(() => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 import { program } from "./cli/program.js";
-import { validateConfig } from "./lib/mode.js";
+import { validateConfig, isAuthenticated } from "./lib/mode.js";
 import { logger } from "@releases/lib/logger";
 import { recordEvent, maybeShowFirstRunNotice } from "./lib/telemetry.js";
 import { checkForUpdate } from "./lib/update-check.js";
@@ -43,7 +43,7 @@ function rewriteLegacyCommand(argv: string[]): string[] {
 function gateAdminArgv(argv: string[]): void {
   const args = argv.slice(2);
   if (args[0] !== "admin") return;
-  if (process.env.RELEASED_API_KEY) return;
+  if (isAuthenticated()) return;
 
   const isHelpInvocation =
     args.length === 1 || args.includes("--help") || args.includes("-h") || args[1] === "help";

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,7 @@ function gateAdminArgv(argv: string[]): void {
     args.length === 1 || args.includes("--help") || args.includes("-h") || args[1] === "help";
 
   if (!isHelpInvocation) {
-    logger.error('"admin" requires an API key. Set RELEASED_API_KEY to enable it.');
+    logger.error('"admin" requires an API key. Run `releases auth login` or set RELEASED_API_KEY.');
     process.exit(1);
   }
 }

--- a/src/lib/credentials.ts
+++ b/src/lib/credentials.ts
@@ -29,6 +29,15 @@ export function readCredential(): StoredCredential | null {
   try {
     const parsed = JSON.parse(readFileSync(path, "utf8")) as StoredCredential;
     if (typeof parsed?.token !== "string" || !parsed.token) return null;
+    // `scopes` is optional, but if present it must be a string array. A
+    // malformed value (e.g. a hand-edited string) would otherwise crash callers
+    // that iterate or `.join` it (auth status, the admin scope pre-flight).
+    if (
+      parsed.scopes !== undefined &&
+      (!Array.isArray(parsed.scopes) || !parsed.scopes.every((s) => typeof s === "string"))
+    ) {
+      return null;
+    }
     return parsed;
   } catch {
     return null;

--- a/src/lib/credentials.ts
+++ b/src/lib/credentials.ts
@@ -1,0 +1,55 @@
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { getDataDir } from "@releases/lib/config";
+
+export interface StoredCredential {
+  token: string;
+  name?: string;
+  scopes?: string[];
+  /** API URL the token was verified against (prod/staging tokens don't cross DBs). */
+  apiUrl: string;
+  savedAt: string;
+}
+
+function credentialPath(): string {
+  return join(getDataDir(), "credentials");
+}
+
+export function readCredential(): StoredCredential | null {
+  const path = credentialPath();
+  if (!existsSync(path)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as StoredCredential;
+    if (typeof parsed?.token !== "string" || !parsed.token) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function writeCredential(cred: StoredCredential): void {
+  const path = credentialPath();
+  mkdirSync(dirname(path), { recursive: true });
+  // Atomic write: temp file + rename so a crash never leaves a partial file.
+  const tmp = `${path}.${process.pid}.tmp`;
+  writeFileSync(tmp, JSON.stringify(cred, null, 2), { mode: 0o600 });
+  chmodSync(tmp, 0o600);
+  renameSync(tmp, path);
+  chmodSync(path, 0o600);
+}
+
+/** Remove the stored credential. Returns true if a file was actually removed. */
+export function clearCredential(): boolean {
+  const path = credentialPath();
+  if (!existsSync(path)) return false;
+  rmSync(path);
+  return true;
+}

--- a/src/lib/credentials.ts
+++ b/src/lib/credentials.ts
@@ -28,10 +28,16 @@ export function readCredential(): StoredCredential | null {
   if (!existsSync(path)) return null;
   try {
     const parsed = JSON.parse(readFileSync(path, "utf8")) as StoredCredential;
+    // The file is a trust boundary (it may be hand-edited or corrupt), so
+    // validate the full shape and return null on any mismatch — callers can then
+    // trust the returned StoredCredential matches its declared type.
     if (typeof parsed?.token !== "string" || !parsed.token) return null;
-    // `scopes` is optional, but if present it must be a string array. A
-    // malformed value (e.g. a hand-edited string) would otherwise crash callers
-    // that iterate or `.join` it (auth status, the admin scope pre-flight).
+    if (typeof parsed.apiUrl !== "string" || !parsed.apiUrl) return null;
+    if (typeof parsed.savedAt !== "string" || !parsed.savedAt) return null;
+    if (parsed.name !== undefined && typeof parsed.name !== "string") return null;
+    // `scopes` is optional, but if present it must be a string array — a malformed
+    // value (e.g. a hand-edited string) would crash callers that iterate or
+    // `.join` it (auth status, the admin scope pre-flight).
     if (
       parsed.scopes !== undefined &&
       (!Array.isArray(parsed.scopes) || !parsed.scopes.every((s) => typeof s === "string"))

--- a/src/lib/mode.ts
+++ b/src/lib/mode.ts
@@ -1,15 +1,42 @@
 import { logger } from "@releases/lib/logger";
+import { readCredential } from "./credentials.js";
 
 const DEFAULT_API_URL = "https://api.releases.sh";
 
 let _apiUrl: string | null = null;
-let _apiKey: string | null = null;
-let _admin: boolean | null = null;
 
-export function isAdminMode(): boolean {
-  if (_admin === null) _admin = !!process.env.RELEASED_API_KEY;
-  return _admin;
+export interface ResolvedCredential {
+  token: string | null;
+  source: "env" | "file" | "none";
+  scopes?: string[];
+  name?: string;
+  apiUrl?: string;
 }
+
+/** Resolve the active credential: explicit env var wins, then the stored file. */
+export function resolveCredential(): ResolvedCredential {
+  const envKey = process.env.RELEASED_API_KEY;
+  if (envKey) return { token: envKey, source: "env" };
+  const stored = readCredential();
+  if (stored) {
+    return {
+      token: stored.token,
+      source: "file",
+      scopes: stored.scopes,
+      name: stored.name,
+      apiUrl: stored.apiUrl,
+    };
+  }
+  return { token: null, source: "none" };
+}
+
+/** True when any credential resolves (env var or stored file). */
+export function isAuthenticated(): boolean {
+  return resolveCredential().token !== null;
+}
+
+/** Back-compat alias — historically "admin mode" meant "a credential is present". */
+export const isAdminMode = isAuthenticated;
 
 export function getApiUrl(): string {
   if (!_apiUrl) {
@@ -20,25 +47,29 @@ export function getApiUrl(): string {
 }
 
 export function getApiKey(): string {
-  if (!_apiKey) {
-    const key = process.env.RELEASED_API_KEY;
-    if (!key) throw new Error("RELEASED_API_KEY is not set");
-    _apiKey = key;
+  const { token } = resolveCredential();
+  if (!token) {
+    throw new Error("Not authenticated. Run `releases auth login` or set RELEASED_API_KEY.");
   }
-  return _apiKey;
+  return token;
 }
 
 /**
- * Call at CLI startup. If RELEASED_API_URL is explicitly set without an
- * RELEASED_API_KEY we treat that as a misconfigured admin setup and bail.
- * Otherwise we fall through to the default public endpoint.
+ * Call at CLI startup. With stored credentials, a custom RELEASED_API_URL is no
+ * longer fatal (you may be about to `releases auth login`, or doing anonymous
+ * reads) — it downgrades to a warning. Also warns when a stored token was
+ * verified against a different environment than the active URL.
  */
 export function validateConfig(): void {
-  if (process.env.RELEASED_API_URL && !process.env.RELEASED_API_KEY) {
-    logger.error("RELEASED_API_URL is set but RELEASED_API_KEY is missing.");
-    logger.error(
-      "Set RELEASED_API_KEY to authenticate with the remote API, or unset RELEASED_API_URL for public access.",
+  const cred = resolveCredential();
+  if (process.env.RELEASED_API_URL && cred.source === "none") {
+    logger.warn(
+      "RELEASED_API_URL is set but no API token is configured. Requests will be unauthenticated — run `releases auth login` to authenticate.",
     );
-    process.exit(1);
+  }
+  if (cred.source === "file" && cred.apiUrl && cred.apiUrl !== getApiUrl()) {
+    logger.warn(
+      `Stored token was verified against ${cred.apiUrl}, but the active API URL is ${getApiUrl()}. It may not be accepted.`,
+    );
   }
 }

--- a/src/lib/preflight.ts
+++ b/src/lib/preflight.ts
@@ -1,0 +1,28 @@
+import { resolveCredential } from "./mode.js";
+
+const SCOPE_RANK: Record<string, number> = { read: 1, write: 2, admin: 3 };
+
+/**
+ * True if the held scopes satisfy the required scope level. The wildcard `*`
+ * grants everything; otherwise any held scope of equal-or-higher rank satisfies
+ * the requirement (admin ⊇ write ⊇ read).
+ */
+function scopeSatisfies(tokenScopes: string[], required: string): boolean {
+  if (tokenScopes.includes("*")) return true;
+  const reqRank = SCOPE_RANK[required] ?? Number.POSITIVE_INFINITY;
+  return tokenScopes.some((s) => (SCOPE_RANK[s] ?? 0) >= reqRank);
+}
+
+/**
+ * Coarse pre-flight check for the admin subtree. Returns a warning string when a
+ * file-sourced token's cached scopes don't satisfy `write` (so an admin command
+ * is likely to 403), or null. Env-sourced tokens have unknown scopes → no
+ * warning; the server stays authoritative either way.
+ */
+export function preflightScopeWarning(): string | null {
+  const cred = resolveCredential();
+  if (cred.source === "file" && cred.scopes && !scopeSatisfies(cred.scopes, "write")) {
+    return `Your stored token's scopes (${cred.scopes.join(", ")}) may not cover this command. Trying anyway…`;
+  }
+  return null;
+}

--- a/src/lib/preflight.ts
+++ b/src/lib/preflight.ts
@@ -2,6 +2,7 @@ import { resolveCredential } from "./mode.js";
 
 const SCOPE_RANK: Record<string, number> = { read: 1, write: 2, admin: 3 };
 
+// Inlined rather than imported from @buildinternet/releases-core/api-token because the CLI's pinned core@0.22.0 predates that export.
 /**
  * True if the held scopes satisfy the required scope level. The wildcard `*`
  * grants everything; otherwise any held scope of equal-or-higher rank satisfies

--- a/src/lib/prompt-hidden.ts
+++ b/src/lib/prompt-hidden.ts
@@ -1,0 +1,30 @@
+import { createInterface } from "node:readline";
+import { Writable } from "node:stream";
+import type { PromptReader } from "./confirm.js";
+
+/**
+ * Reads a single line from the TTY without echoing keystrokes. Returns null when
+ * stdin is not a TTY (so callers fall back to --token / stdin). Mirrors the
+ * injectable-reader pattern in confirm.ts.
+ */
+export const hiddenPromptReader: PromptReader = async (question) => {
+  if (!process.stdin.isTTY) return null;
+  let muted = false;
+  const out = new Writable({
+    write(chunk, _enc, cb) {
+      if (!muted) process.stderr.write(chunk);
+      cb();
+    },
+  });
+  const rl = createInterface({ input: process.stdin, output: out, terminal: true });
+  try {
+    const answer = await new Promise<string>((resolve) => {
+      rl.question(question, (a) => resolve(a));
+      muted = true; // mute echo right after the prompt text is written
+    });
+    process.stderr.write("\n");
+    return answer;
+  } finally {
+    rl.close();
+  }
+};

--- a/tests/cli/auth.test.ts
+++ b/tests/cli/auth.test.ts
@@ -9,18 +9,17 @@ let serverProc: ChildProcess | null = null;
 let baseUrl = "";
 let dataDir = "";
 
-const PORT = 19877;
-
 beforeAll(async () => {
   dataDir = mkdtempSync(join(tmpdir(), "rel-authcli-"));
 
-  // Spawn the stub server as a detached child process so spawned CLI
-  // subprocesses can reach it (Bun.serve in-process is network-sandboxed
-  // in some environments, but a detached OS process is always reachable).
+  // Spawned CLI subprocesses can't reach a `Bun.serve` bound inside the
+  // test-runner process in this sandbox, so run the stub as a detached OS
+  // process. It binds an ephemeral port (port: 0) and reports it back via the
+  // READY line to avoid hardcoded-port collisions on shared/CI machines.
   const serverScript = `
 const server = Bun.serve({
-  port: ${PORT},
-  hostname: "0.0.0.0",
+  port: 0,
+  hostname: "127.0.0.1",
   fetch(req) {
     const url = new URL(req.url);
     if (url.pathname === "/v1/tokens/me") {
@@ -31,7 +30,7 @@ const server = Bun.serve({
     return Response.json({ sources: [] });
   },
 });
-process.stdout.write("READY\\n");
+process.stdout.write("READY:" + server.port + "\\n");
 await Bun.sleep(60000);
 `;
   const scriptPath = join(dataDir, "stub-server.ts");
@@ -42,18 +41,20 @@ await Bun.sleep(60000);
     detached: true,
   });
 
-  baseUrl = `http://localhost:${PORT}`;
-
-  // Wait until the server is ready.
+  // Wait until the server is ready and capture the ephemeral port it bound.
   await new Promise<void>((resolve, reject) => {
     const timer = setTimeout(() => reject(new Error("stub server start timeout")), 5000);
+    let buf = "";
     serverProc!.stdout!.on("data", (d: Buffer) => {
-      if (d.toString().includes("READY")) {
+      buf += d.toString();
+      const m = buf.match(/READY:(\d+)/);
+      if (m) {
+        baseUrl = `http://localhost:${m[1]}`;
         clearTimeout(timer);
         resolve();
       }
     });
-    serverProc!.on("error", (e) => {
+    serverProc!.on("error", (e: Error) => {
       clearTimeout(timer);
       reject(e);
     });

--- a/tests/cli/auth.test.ts
+++ b/tests/cli/auth.test.ts
@@ -27,7 +27,12 @@ const server = Bun.serve({
       if (auth !== "Bearer relk_good_token") return new Response("{}", { status: 401 });
       return Response.json({ kind: "token", name: "laptop", scopes: ["read", "write"] });
     }
-    return Response.json({ sources: [] });
+    // Catalog page-based pagination shape, so \`admin source list\` runs to
+    // completion (exits 0) after clearing the admin-key gate.
+    return Response.json({
+      items: [],
+      pagination: { page: 1, pageSize: 50, returned: 0, totalItems: 0, totalPages: 0, hasMore: false },
+    });
   },
 });
 process.stdout.write("READY:" + server.port + "\\n");
@@ -119,8 +124,10 @@ describe("releases auth (e2e)", () => {
 
   it("an admin command is allowed with a stored write-capable token", () => {
     const r = runCli(["admin", "source", "list"], { env: env() });
-    // Not blocked by the admin-key gate (stored token present).
+    // Not blocked by the admin-key gate (stored token present)…
     expect(r.stderr).not.toMatch(/requires an API key/);
+    // …and the command actually ran to completion past the gate.
+    expect(r.exitCode).toBe(0);
   });
 
   it("logout removes the stored token", () => {

--- a/tests/cli/auth.test.ts
+++ b/tests/cli/auth.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, rmSync, existsSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawn, type ChildProcess } from "node:child_process";
+import { runCli } from "../utils.js";
+
+let serverProc: ChildProcess | null = null;
+let baseUrl = "";
+let dataDir = "";
+
+const PORT = 19877;
+
+beforeAll(async () => {
+  dataDir = mkdtempSync(join(tmpdir(), "rel-authcli-"));
+
+  // Spawn the stub server as a detached child process so spawned CLI
+  // subprocesses can reach it (Bun.serve in-process is network-sandboxed
+  // in some environments, but a detached OS process is always reachable).
+  const serverScript = `
+const server = Bun.serve({
+  port: ${PORT},
+  hostname: "0.0.0.0",
+  fetch(req) {
+    const url = new URL(req.url);
+    if (url.pathname === "/v1/tokens/me") {
+      const auth = req.headers.get("authorization") ?? "";
+      if (auth !== "Bearer relk_good_token") return new Response("{}", { status: 401 });
+      return Response.json({ kind: "token", name: "laptop", scopes: ["read", "write"] });
+    }
+    return Response.json({ sources: [] });
+  },
+});
+process.stdout.write("READY\\n");
+await Bun.sleep(60000);
+`;
+  const scriptPath = join(dataDir, "stub-server.ts");
+  writeFileSync(scriptPath, serverScript);
+
+  serverProc = spawn("bun", [scriptPath], {
+    stdio: ["ignore", "pipe", "pipe"],
+    detached: true,
+  });
+
+  baseUrl = `http://localhost:${PORT}`;
+
+  // Wait until the server is ready.
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("stub server start timeout")), 5000);
+    serverProc!.stdout!.on("data", (d: Buffer) => {
+      if (d.toString().includes("READY")) {
+        clearTimeout(timer);
+        resolve();
+      }
+    });
+    serverProc!.on("error", (e) => {
+      clearTimeout(timer);
+      reject(e);
+    });
+  });
+});
+
+afterAll(() => {
+  if (serverProc) {
+    serverProc.kill();
+    serverProc = null;
+  }
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+const env = () => ({
+  RELEASED_API_KEY: "",
+  RELEASED_API_URL: baseUrl,
+  RELEASED_DATA_DIR: dataDir,
+  RELEASED_TELEMETRY_DISABLED: "1",
+});
+
+describe("releases auth (e2e)", () => {
+  it("login --token verifies and stores the credential", () => {
+    const r = runCli(["auth", "login", "--token", "relk_good_token"], { env: env() });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout + r.stderr).toMatch(/Verified/);
+    expect(existsSync(join(dataDir, "credentials"))).toBe(true);
+  });
+
+  it("token prints the stored token", () => {
+    const r = runCli(["auth", "token"], { env: env() });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout.trim()).toBe("relk_good_token");
+  });
+
+  it("status --json reports authenticated + file source", () => {
+    const r = runCli(["auth", "status", "--json"], { env: env() });
+    const body = JSON.parse(r.stdout) as {
+      authenticated: boolean;
+      source: string;
+      scopes: string[];
+    };
+    expect(body.authenticated).toBe(true);
+    expect(body.source).toBe("file");
+    expect(body.scopes).toEqual(["read", "write"]);
+  });
+
+  it("login rejects a bad token without saving", () => {
+    const bad = mkdtempSync(join(tmpdir(), "rel-authbad-"));
+    const r = runCli(["auth", "login", "--token", "relk_bad"], {
+      env: {
+        RELEASED_API_KEY: "",
+        RELEASED_API_URL: baseUrl,
+        RELEASED_DATA_DIR: bad,
+        RELEASED_TELEMETRY_DISABLED: "1",
+      },
+    });
+    expect(r.exitCode).toBe(1);
+    expect(existsSync(join(bad, "credentials"))).toBe(false);
+    rmSync(bad, { recursive: true, force: true });
+  });
+
+  it("an admin command is allowed with a stored write-capable token", () => {
+    const r = runCli(["admin", "source", "list"], { env: env() });
+    // Not blocked by the admin-key gate (stored token present).
+    expect(r.stderr).not.toMatch(/requires an API key/);
+  });
+
+  it("logout removes the stored token", () => {
+    const r = runCli(["auth", "logout"], { env: env() });
+    expect(r.exitCode).toBe(0);
+    expect(existsSync(join(dataDir, "credentials"))).toBe(false);
+  });
+});

--- a/tests/unit/auth-login.test.ts
+++ b/tests/unit/auth-login.test.ts
@@ -8,6 +8,10 @@ function jsonResponse(body: unknown, status = 200): Response {
   });
 }
 
+const unusedReader = async () => "should-not-be-used";
+const promptReader = async () => "  relk_from_prompt ";
+const nullReader = async () => null;
+
 describe("verifyToken", () => {
   it("returns the identity on 200", async () => {
     const fetchFn = (async () =>
@@ -34,17 +38,14 @@ describe("verifyToken", () => {
 
 describe("resolveTokenInput", () => {
   it("returns a provided --token value (trimmed)", async () => {
-    const reader = async () => "should-not-be-used";
-    expect(await resolveTokenInput("  relk_a_b  ", reader)).toBe("relk_a_b");
+    expect(await resolveTokenInput("  relk_a_b  ", unusedReader)).toBe("relk_a_b");
   });
 
   it("uses the reader when no --token and a value comes back", async () => {
-    const reader = async () => "  relk_from_prompt ";
-    expect(await resolveTokenInput(undefined, reader)).toBe("relk_from_prompt");
+    expect(await resolveTokenInput(undefined, promptReader)).toBe("relk_from_prompt");
   });
 
   it("throws when no --token and not a TTY (reader returns null)", async () => {
-    const reader = async () => null;
-    await expect(resolveTokenInput(undefined, reader)).rejects.toThrow(/No token/i);
+    await expect(resolveTokenInput(undefined, nullReader)).rejects.toThrow(/No token/i);
   });
 });

--- a/tests/unit/auth-login.test.ts
+++ b/tests/unit/auth-login.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "bun:test";
+import { verifyToken, resolveTokenInput } from "../../src/cli/commands/auth.js";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("verifyToken", () => {
+  it("returns the identity on 200", async () => {
+    const fetchFn = (async () =>
+      jsonResponse({ kind: "token", name: "laptop", scopes: ["read", "write"] })) as typeof fetch;
+    const id = await verifyToken("relk_x_y", "https://api.releases.sh", fetchFn);
+    expect(id.name).toBe("laptop");
+    expect(id.scopes).toEqual(["read", "write"]);
+  });
+
+  it("throws on 401", async () => {
+    const fetchFn = (async () => jsonResponse({ error: "unauthorized" }, 401)) as typeof fetch;
+    await expect(verifyToken("relk_bad", "https://api.releases.sh", fetchFn)).rejects.toThrow(
+      /rejected/i,
+    );
+  });
+
+  it("throws on 500", async () => {
+    const fetchFn = (async () => jsonResponse({}, 500)) as typeof fetch;
+    await expect(verifyToken("relk_x_y", "https://api.releases.sh", fetchFn)).rejects.toThrow(
+      /500/,
+    );
+  });
+});
+
+describe("resolveTokenInput", () => {
+  it("returns a provided --token value (trimmed)", async () => {
+    const reader = async () => "should-not-be-used";
+    expect(await resolveTokenInput("  relk_a_b  ", reader)).toBe("relk_a_b");
+  });
+
+  it("uses the reader when no --token and a value comes back", async () => {
+    const reader = async () => "  relk_from_prompt ";
+    expect(await resolveTokenInput(undefined, reader)).toBe("relk_from_prompt");
+  });
+
+  it("throws when no --token and not a TTY (reader returns null)", async () => {
+    const reader = async () => null;
+    await expect(resolveTokenInput(undefined, reader)).rejects.toThrow(/No token/i);
+  });
+});

--- a/tests/unit/credentials.test.ts
+++ b/tests/unit/credentials.test.ts
@@ -33,9 +33,32 @@ describe("credentials", () => {
   });
 
   it("returns null when scopes is malformed (not a string array)", () => {
-    writeFileSync(join(dir, "credentials"), JSON.stringify({ token: "relk_x_y", scopes: "read" }));
+    const base = {
+      token: "relk_x_y",
+      apiUrl: "https://api.releases.sh",
+      savedAt: "2026-05-20T00:00:00.000Z",
+    };
+    writeFileSync(join(dir, "credentials"), JSON.stringify({ ...base, scopes: "read" }));
     expect(readCredential()).toBeNull();
-    writeFileSync(join(dir, "credentials"), JSON.stringify({ token: "relk_x_y", scopes: [1, 2] }));
+    writeFileSync(join(dir, "credentials"), JSON.stringify({ ...base, scopes: [1, 2] }));
+    expect(readCredential()).toBeNull();
+  });
+
+  it("returns null when required fields are missing or wrong-typed", () => {
+    // only token — apiUrl and savedAt missing
+    writeFileSync(join(dir, "credentials"), JSON.stringify({ token: "relk_x_y" }));
+    expect(readCredential()).toBeNull();
+    // apiUrl wrong type (number)
+    writeFileSync(
+      join(dir, "credentials"),
+      JSON.stringify({ token: "relk_x_y", apiUrl: 123, savedAt: "t" }),
+    );
+    expect(readCredential()).toBeNull();
+    // name wrong type (number)
+    writeFileSync(
+      join(dir, "credentials"),
+      JSON.stringify({ token: "relk_x_y", apiUrl: "u", savedAt: "t", name: 42 }),
+    );
     expect(readCredential()).toBeNull();
   });
 

--- a/tests/unit/credentials.test.ts
+++ b/tests/unit/credentials.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, afterAll } from "bun:test";
+import { mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const dir = mkdtempSync(join(tmpdir(), "rel-creds-"));
+process.env.RELEASED_DATA_DIR = dir;
+
+const { readCredential, writeCredential, clearCredential } =
+  await import("../../src/lib/credentials.js");
+
+afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+describe("credentials", () => {
+  it("round-trips a credential and stores it 0600", () => {
+    writeCredential({
+      token: "relk_abc_def",
+      name: "laptop",
+      scopes: ["read", "write"],
+      apiUrl: "https://api.releases.sh",
+      savedAt: "2026-05-20T00:00:00.000Z",
+    });
+    const read = readCredential();
+    expect(read?.token).toBe("relk_abc_def");
+    expect(read?.scopes).toEqual(["read", "write"]);
+    const mode = statSync(join(dir, "credentials")).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  it("returns null on a corrupt file", () => {
+    writeFileSync(join(dir, "credentials"), "{ not json");
+    expect(readCredential()).toBeNull();
+  });
+
+  it("clear removes the file and reports it", () => {
+    writeCredential({ token: "relk_x_y", apiUrl: "u", savedAt: "t" });
+    expect(clearCredential()).toBe(true);
+    expect(readCredential()).toBeNull();
+    expect(clearCredential()).toBe(false);
+  });
+});

--- a/tests/unit/credentials.test.ts
+++ b/tests/unit/credentials.test.ts
@@ -32,6 +32,13 @@ describe("credentials", () => {
     expect(readCredential()).toBeNull();
   });
 
+  it("returns null when scopes is malformed (not a string array)", () => {
+    writeFileSync(join(dir, "credentials"), JSON.stringify({ token: "relk_x_y", scopes: "read" }));
+    expect(readCredential()).toBeNull();
+    writeFileSync(join(dir, "credentials"), JSON.stringify({ token: "relk_x_y", scopes: [1, 2] }));
+    expect(readCredential()).toBeNull();
+  });
+
   it("clear removes the file and reports it", () => {
     writeCredential({ token: "relk_x_y", apiUrl: "u", savedAt: "t" });
     expect(clearCredential()).toBe(true);

--- a/tests/unit/mode-credential.test.ts
+++ b/tests/unit/mode-credential.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const dir = mkdtempSync(join(tmpdir(), "rel-mode-"));
+process.env.RELEASED_DATA_DIR = dir;
+
+const { writeCredential, clearCredential } = await import("../../src/lib/credentials.js");
+const { resolveCredential, isAuthenticated, getApiKey } = await import("../../src/lib/mode.js");
+
+afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+beforeEach(() => {
+  delete process.env.RELEASED_API_KEY;
+  clearCredential();
+});
+
+describe("resolveCredential precedence", () => {
+  it("none when nothing is configured", () => {
+    const c = resolveCredential();
+    expect(c.token).toBeNull();
+    expect(c.source).toBe("none");
+    expect(isAuthenticated()).toBe(false);
+  });
+
+  it("uses the stored file when present", () => {
+    writeCredential({
+      token: "relk_file_tok",
+      name: "laptop",
+      scopes: ["read"],
+      apiUrl: "https://api.releases.sh",
+      savedAt: "t",
+    });
+    const c = resolveCredential();
+    expect(c.source).toBe("file");
+    expect(c.token).toBe("relk_file_tok");
+    expect(c.scopes).toEqual(["read"]);
+    expect(getApiKey()).toBe("relk_file_tok");
+  });
+
+  it("env var wins over the stored file", () => {
+    writeCredential({ token: "relk_file_tok", apiUrl: "u", savedAt: "t" });
+    process.env.RELEASED_API_KEY = "env-key";
+    const c = resolveCredential();
+    expect(c.source).toBe("env");
+    expect(c.token).toBe("env-key");
+  });
+
+  it("getApiKey throws when unauthenticated", () => {
+    expect(() => getApiKey()).toThrow();
+  });
+});

--- a/tests/unit/preflight.test.ts
+++ b/tests/unit/preflight.test.ts
@@ -26,6 +26,16 @@ describe("preflightScopeWarning", () => {
     expect(preflightScopeWarning()).toBeNull();
   });
 
+  it("no warning when the file token has admin (admin implies write)", () => {
+    writeCredential({ token: "relk_a_b", scopes: ["admin"], apiUrl: "u", savedAt: "t" });
+    expect(preflightScopeWarning()).toBeNull();
+  });
+
+  it("no warning when the file token has the wildcard scope", () => {
+    writeCredential({ token: "relk_a_b", scopes: ["*"], apiUrl: "u", savedAt: "t" });
+    expect(preflightScopeWarning()).toBeNull();
+  });
+
   it("no warning for env-sourced tokens (scopes unknown)", () => {
     process.env.RELEASED_API_KEY = "env-key";
     expect(preflightScopeWarning()).toBeNull();

--- a/tests/unit/preflight.test.ts
+++ b/tests/unit/preflight.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const dir = mkdtempSync(join(tmpdir(), "rel-pf-"));
+process.env.RELEASED_DATA_DIR = dir;
+
+const { writeCredential, clearCredential } = await import("../../src/lib/credentials.js");
+const { preflightScopeWarning } = await import("../../src/lib/preflight.js");
+
+afterAll(() => rmSync(dir, { recursive: true, force: true }));
+beforeEach(() => {
+  delete process.env.RELEASED_API_KEY;
+  clearCredential();
+});
+
+describe("preflightScopeWarning", () => {
+  it("warns for a file token without write scope", () => {
+    writeCredential({ token: "relk_a_b", scopes: ["read"], apiUrl: "u", savedAt: "t" });
+    expect(preflightScopeWarning()).toMatch(/read/);
+  });
+
+  it("no warning when the file token has write", () => {
+    writeCredential({ token: "relk_a_b", scopes: ["read", "write"], apiUrl: "u", savedAt: "t" });
+    expect(preflightScopeWarning()).toBeNull();
+  });
+
+  it("no warning for env-sourced tokens (scopes unknown)", () => {
+    process.env.RELEASED_API_KEY = "env-key";
+    expect(preflightScopeWarning()).toBeNull();
+  });
+});

--- a/tests/unit/prompt-hidden.test.ts
+++ b/tests/unit/prompt-hidden.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from "bun:test";
+import { hiddenPromptReader } from "../../src/lib/prompt-hidden.js";
+
+describe("hiddenPromptReader", () => {
+  it("returns null when stdin is not a TTY", async () => {
+    // In the test runner stdin is not a TTY.
+    expect(await hiddenPromptReader("token: ")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a `releases auth` command namespace to store an API token you already hold, verified against the server before saving.

- `releases auth login [--token <t>|-]` — interactive masked prompt, `--token`, or stdin; verifies via `GET /v1/tokens/me` and stores to `~/.releases/credentials` (`0600`, atomic write). Rejects bad/revoked tokens without saving.
- `releases auth status [--json] [--verify]`, `releases auth token` (prints the raw token for scripts), `releases auth logout`. `whoami` now aliases `auth status`.
- **Env-over-file precedence:** `RELEASED_API_KEY` still wins; the stored file is the fallback. `validateConfig` relaxed accordingly.
- **Hybrid scope pre-flight:** a file-sourced token lacking `write` gets a ⚠ warning before an `admin` command; the server stays authoritative (403 on under-scope). Env-sourced tokens (unknown scopes) skip the warning.
- `gateAdminArgv` + the admin gate now honor a stored credential, not just the env var.
- The token is never logged; the only plaintext emission is the intentional `auth token` stdout print.

Also fixes a pre-existing `mock.module` cross-file test leak by switching `bun test` → `bun test --isolate` (package.json + CI workflow). Includes a changeset (minor).

**Depends on** the `buildinternet/releases` PR adding `GET /v1/tokens/me` — `auth login` verification needs that endpoint deployed (prod/staging) to work end-to-end.

## Test Plan

- [x] Unit: credentials (round-trip, `0600`, corrupt→null), resolver precedence (env>file>none), `verifyToken`/`resolveTokenInput`, preflight scope ladder (read/write/admin/`*`).
- [x] e2e (`tests/cli/auth.test.ts`): login stores, `token` prints, `status --json`, bad-token rejected (not saved), admin command allowed with a stored token, logout removes. Stub server on a dynamic port; non-flaky across reruns.
- [x] `bun test --isolate` 443 pass; `bun run lint` 0/0; `bun run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `releases auth` subcommands (`login`, `logout`, `status`, `token`) with token verification and secure local storage (~/.releases/credentials, 0600)
  * `whoami` now aliases `auth status`
  * Admin commands honor CLI authentication and may display scope preflight warnings

* **Documentation**
  * New Authentication section and clarified RELEASED_API_KEY precedence and usage

* **Tests**
  * New end-to-end and unit tests covering auth flows, credential storage, mode resolution, preflight, and hidden prompt

* **Chores**
  * Test runner now uses isolated mode (`bun test --isolate`)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/buildinternet/releases-cli/pull/201?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->