### PR TITLE
ci(release): migrate npm publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ concurrency:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write # OIDC: mint a short-lived npm publish credential (no NPM_TOKEN)
 
 jobs:
   release:
@@ -24,6 +25,16 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.13
+
+      # npm OIDC trusted publishing needs npm >= 11.5.1 and Node >= 22.14.0.
+      # bun runs the build + scripts; npm is only invoked by `changeset publish`
+      # to perform the registry PUT and the OIDC token exchange. We deliberately
+      # do NOT set registry-url here — that writes an empty _authToken line to
+      # ~/.npmrc when no token is present, which breaks OIDC (npm/cli#8976).
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+      - run: npm install -g npm@latest
 
       - run: bun install --frozen-lockfile
 
@@ -45,19 +56,15 @@ jobs:
           chmod +x npm/releases-linux-x64/releases
           chmod +x npm/releases-linux-arm64/releases
 
-      - name: Configure npm auth
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_PUBLISHING_TOKEN }}
-        run: |
-          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
-          echo "registry=https://registry.npmjs.org/" >> ~/.npmrc
-
-      - name: Create Release PR or Publish
+      # Versioning only. With changesets present this opens/updates the
+      # "Version Packages" PR; with none it no-ops. We deliberately do NOT pass
+      # `publish:` here — changesets/action writes a token-based ~/.npmrc, which
+      # is incompatible with OIDC. The publish runs as its own step below.
+      - name: Create Release PR
         id: changesets
         uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
         with:
           version: bun run changeset:version
-          publish: bun run changeset:publish
           commit: "chore: version packages"
           title: "chore: version packages"
           # The consolidated `v*` release (created below) carries the
@@ -66,10 +73,28 @@ jobs:
           createGithubReleases: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_PUBLISHING_TOKEN }}
+
+      # Publish via npm OIDC trusted publishing — no NPM_TOKEN. Fires only when
+      # no changesets remain (the Version Packages PR was just merged), which
+      # reproduces the previous "publish on version bump" behaviour. `changeset
+      # publish` calls `npm publish`, which performs the OIDC token exchange and
+      # attaches provenance automatically (npm >= 11.5.1). Each package needs a
+      # trusted publisher configured on npmjs.com (repo buildinternet/releases-cli,
+      # workflow release.yml) or the registry PUT 404s.
+      - name: Publish to npm (OIDC trusted publishing)
+        id: publish
+        if: steps.changesets.outputs.hasChangesets == 'false'
+        run: |
+          set -o pipefail
+          bun run changeset:publish | tee publish.log
+          if grep -q "New tag:" publish.log; then
+            echo "published=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "published=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Prepare release assets
-        if: steps.changesets.outputs.published == 'true'
+        if: steps.publish.outputs.published == 'true'
         run: |
           mkdir -p dist/release
           for target in darwin-arm64 darwin-x64 linux-x64 linux-arm64; do
@@ -85,7 +110,7 @@ jobs:
           sha256sum dist/release/*.gz dist/release/*.zip > dist/release/checksums.txt
 
       - name: Publish binaries to GitHub Releases
-        if: steps.changesets.outputs.published == 'true'
+        if: steps.publish.outputs.published == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -121,7 +146,7 @@ jobs:
         # Requires TAP_PUBLISH_TOKEN secret (fine-grained PAT with write access to
         # buildinternet/homebrew-tap). The download URLs below point to this repo's
         # releases — adjust if the tap's formula points elsewhere.
-        if: steps.changesets.outputs.published == 'true'
+        if: steps.publish.outputs.published == 'true'
         env:
           TAP_TOKEN: ${{ secrets.TAP_PUBLISH_TOKEN }}
         run: |

--- a/npm/releases-darwin-arm64/package.json
+++ b/npm/releases-darwin-arm64/package.json
@@ -11,5 +11,10 @@
   "files": [
     "releases"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/buildinternet/releases-cli.git",
+    "directory": "npm/releases-darwin-arm64"
+  }
 }

--- a/npm/releases-darwin-x64/package.json
+++ b/npm/releases-darwin-x64/package.json
@@ -11,5 +11,10 @@
   "files": [
     "releases"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/buildinternet/releases-cli.git",
+    "directory": "npm/releases-darwin-x64"
+  }
 }

--- a/npm/releases-linux-arm64/package.json
+++ b/npm/releases-linux-arm64/package.json
@@ -11,5 +11,10 @@
   "files": [
     "releases"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/buildinternet/releases-cli.git",
+    "directory": "npm/releases-linux-arm64"
+  }
 }

--- a/npm/releases-linux-x64/package.json
+++ b/npm/releases-linux-x64/package.json
@@ -11,5 +11,10 @@
   "files": [
     "releases"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/buildinternet/releases-cli.git",
+    "directory": "npm/releases-linux-x64"
+  }
 }

--- a/npm/releases-windows-x64/package.json
+++ b/npm/releases-windows-x64/package.json
@@ -11,5 +11,10 @@
   "files": [
     "releases.exe"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/buildinternet/releases-cli.git",
+    "directory": "npm/releases-windows-x64"
+  }
 }

--- a/npm/releases/package.json
+++ b/npm/releases/package.json
@@ -29,5 +29,10 @@
   "license": "MIT",
   "engines": {
     "node": ">=18"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/buildinternet/releases-cli.git",
+    "directory": "npm/releases"
   }
 }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/zachdunn/releases-cli.git",
+    "url": "git+https://github.com/buildinternet/releases-cli.git",
     "directory": "packages/lib"
   },
   "exports": {

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/zachdunn/releases-cli.git",
+    "url": "git+https://github.com/buildinternet/releases-cli.git",
     "directory": "packages/skills"
   },
   "exports": {


### PR DESCRIPTION
## Why

The `NPM_PUBLISHING_TOKEN` secret expired and blocked the `0.40.0` release (every package 404'd on the registry `PUT`). npm retired classic, non-expiring automation tokens on **2025-12-09**, so the only token option left is a granular token with a ~90-day max lifetime — i.e. recurring manual rotation. This migrates the publish to **npm OIDC trusted publishing**: the job authenticates with its own short-lived OIDC identity, so there's no long-lived secret to expire, and provenance attestations come for free.

## What changed

**`.github/workflows/release.yml`**
- Add `id-token: write` permission (lets the runner mint the OIDC credential).
- Add `actions/setup-node@v6.4.0` (Node 22) + `npm install -g npm@latest`. OIDC requires **npm ≥ 11.5.1 / Node ≥ 22.14.0**, and `changeset publish` shells out to `npm` for the actual registry `PUT`. Deliberately **no `registry-url`** — that writes an empty `_authToken` line to `~/.npmrc`, which shadows OIDC and is the usual cause of [npm/cli#8976](https://github.com/npm/cli/issues/8976).
- **Split version from publish.** `changesets/action` has no documented OIDC support and writes a token-based `~/.npmrc`. It now runs **version-only** (manages the "Version Packages" PR); a dedicated step runs `changeset publish` under OIDC, gated on `hasChangesets == 'false'` (fires only when the version PR is merged — same trigger as before).
- Drop the `Configure npm auth` step and the `NPM_TOKEN` env entirely.
- Re-gate `Prepare release assets` / `Publish binaries` / `Update Homebrew tap` on the new `steps.publish.outputs.published` signal.

**Package manifests (provenance requirement)**
- Add `repository` (+ `directory`) to the 6 `npm/*` packages — they had none, and the auto-generated provenance attestation requires it.
- Fix the stale `zachdunn/releases-cli` → `buildinternet/releases-cli` URL on `packages/lib` and `packages/skills` so provenance validates against the building repo.

## Required before merge (npmjs.com — manual)

Configure a **trusted publisher** for **each of the 8 packages** at *Package → Settings → Trusted publishing → GitHub Actions*:

- Organization or user: `buildinternet`
- Repository: `releases-cli`
- Workflow filename: `release.yml` (filename only, not the path)
- Environment name: *(leave blank)*

Packages: `releases`, `releases-darwin-arm64`, `releases-darwin-x64`, `releases-linux-arm64`, `releases-linux-x64`, `releases-windows-x64`, `releases-lib`, `releases-skills`.

Configuring them early is harmless — they stay dormant until a run presents an OIDC token with no `NPM_TOKEN`.

## Validation & rollback

- First real release after merge is the live test (watch for the scoped-package E404 in #8976). Keep the `NPM_PUBLISHING_TOKEN` secret around as rollback — reverting this commit restores the token-based publish.
- Draft until the trusted publishers are configured.

## Public vs private repo note

This repo is **public**, so OIDC + provenance is a clean win (provenance metadata — repo URL, commit SHA, workflow — is published to Sigstore's public Rekor log, which is fine for a public repo). The **monorepo** is a different story and is intentionally **out of scope** here: its publish is manual/local (OIDC is CI-only), and provenance from a *private* repo routes through GitHub's internal Sigstore instance rather than the public log — worth deciding deliberately before doing the same there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated npm publishing workflow to use OIDC trusted publishing instead of token-based authentication, restructuring versioning and publishing as separate workflow steps.
  * Added repository metadata (type, URL, and directory paths) to npm package configurations across all platform-specific distributions and core packages.
  * Updated repository URL references in multiple package configuration files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/buildinternet/releases-cli/pull/202?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->