### PR TITLE
fix(release): pin Node 24 instead of self-upgrading npm (unblocks release.yml)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,15 +26,16 @@ jobs:
         with:
           bun-version: 1.3.13
 
-      # npm OIDC trusted publishing needs npm >= 11.5.1 and Node >= 22.14.0.
-      # bun runs the build + scripts; npm is only invoked by `changeset publish`
-      # to perform the registry PUT and the OIDC token exchange. We deliberately
-      # do NOT set registry-url here — that writes an empty _authToken line to
-      # ~/.npmrc when no token is present, which breaks OIDC (npm/cli#8976).
+      # OIDC trusted publishing needs npm >= 11.5.1 / Node >= 22.14.0. Node 24
+      # bundles npm 11.12.1, clearing the bar without an in-place
+      # `npm i -g npm@latest` self-upgrade (that races and dies with
+      # MODULE_NOT_FOUND 'promise-retry'). bun runs the build + scripts; npm is
+      # only invoked by `changeset publish` for the registry PUT + OIDC token
+      # exchange. No registry-url here on purpose — an empty _authToken line
+      # would break OIDC (npm/cli#8976).
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 22
-      - run: npm install -g npm@latest
+          node-version: 24
 
       - run: bun install --frozen-lockfile
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       # would break OIDC (npm/cli#8976).
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 24
+          node-version: 24.15.0 # pinned: bundles npm 11.12.1 (see comment above)
 
       - run: bun install --frozen-lockfile
 


### PR DESCRIPTION
## Why

The OIDC migration (#202) added `npm install -g npm@latest` to reach npm ≥ 11.5.1 on a Node 22 runner. That in-place self-upgrade races and dies with `MODULE_NOT_FOUND: Cannot find module 'promise-retry'`, which **red-failed `release.yml` on the #202 merge** — before any publish step, so nothing was published, but the pipeline is now red on every push to main.

## Fix

Node 24 (latest = v24.15.0) bundles **npm 11.12.1**, which clears the OIDC bar with no self-upgrade. Pin `node-version: 24` and drop the `npm install -g npm@latest` step.

Verified: `curl nodejs.org/dist/index.json` → Node v24.15.0 → npm 11.12.1 (≥ 11.5.1). The companion monorepo fix is buildinternet/releases (publish-core.yml / publish-api-types.yml had the same pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI release workflow to use Node.js 24 (pinned) and simplified the npm publishing pipeline.
  * Removed the global npm self-upgrade step and added notes documenting the bundled npm version (11.12.1) and the reason for the change.
  * Retained existing build/publish tools and token-based publish flow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/buildinternet/releases-cli/pull/203?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->