### PR TITLE
feat(cli): unknown-command suggestions, sources alias, and --help examples

### DIFF
--- a/.changeset/cli-agent-ergonomics.md
+++ b/.changeset/cli-agent-ergonomics.md
@@ -1,0 +1,9 @@
+---
+"@buildinternet/releases": patch
+---
+
+Better unknown-command suggestions, `--help` examples, and a `sources` alias for `list`.
+
+- **Unknown-command suggestions:** `releases serch foo` now prints `(Did you mean search?)` instead of the misleading "too many arguments" error. Root cause was the root `.action()` swallowing unrecognised tokens before Commander's suggestion engine could fire; fixed by allowing excess args on the root and delegating to `unknownCommand()`.
+- **`releases sources` alias:** `releases list` now accepts `sources` as an alias, so `releases sources --kind sdk` works. The alias is top-level only — `releases admin source` is unchanged.
+- **`--help` examples:** Added `Examples:` blocks to `list`, `search`, `admin source update`, `admin product create`, and `admin product update`.

--- a/skills/releases-cli/SKILL.md
+++ b/skills/releases-cli/SKILL.md
@@ -33,6 +33,13 @@ releases skills install -g     # user-wide install instead
 
 Skills are symlinked by default — re-running `releases skills install` refreshes everything atomically.
 
+## Command shape
+
+- **Reads (verb-first):** `releases list` · `releases search` · `releases tail` · `releases get` · `releases stats`
+- **Writes (`admin <noun> <verb>`):** `releases admin source update` · `releases admin source create` · `releases admin product create` · `releases admin org create`
+- List sources with `releases list` (also `releases sources` — alias). Do NOT guess `releases sources list`; that path does not exist.
+- Writes live under `releases admin <noun> <verb>`, not at the top level.
+
 ## What this skill covers
 
 - **[Reader commands](references/reader.md)** — Search, inspect, and export changelog data. No API key required.

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -26,10 +26,12 @@ function paginateExample(json: boolean): string {
   return `releases list${json ? " --json" : ""} --limit <n> --page <p>`;
 }
 
-export function registerListCommand(program: Command) {
-  program
+export function registerListCommand(program: Command, registerOpts?: { alias?: string }) {
+  const cmd = program
     .command("list")
-    .description("List all configured changelog sources, or show details for a single source")
+    .description("List all configured changelog sources, or show details for a single source");
+  if (registerOpts?.alias) cmd.alias(registerOpts.alias);
+  cmd
     .argument("[source]", "Show details for a specific source (src_… or slug)")
     .option("--json", "Output as JSON")
     .option("--org <org>", "Filter by organization (org_…, slug, domain, name, or handle)")
@@ -46,6 +48,15 @@ export function registerListCommand(program: Command) {
     .option("--limit <n>", `Limit the number of results (default ${DEFAULT_PAGE_SIZE})`)
     .option("--page <n>", "Page number for paginated results")
     .option("--flat", "Legacy: return a bare array instead of the paginated envelope (--json only)")
+    .addHelpText(
+      "after",
+      `
+Examples:
+  releases list                                    List all sources
+  releases list src_abc123                         Show details for a specific source
+  releases list --kind sdk                         Filter by kind
+  releases list --org vercel --category ai         Filter by org and category`,
+    )
     .action(
       async (
         slug: string | undefined,

--- a/src/cli/commands/product.ts
+++ b/src/cli/commands/product.ts
@@ -324,6 +324,14 @@ export function registerProductCommand(program: Command) {
     .option("--tags <tags>", "Comma-separated tags")
     .option("--json", "Output as JSON")
     .option("--dry-run", "Show what would be created without writing")
+    .addHelpText(
+      "after",
+      `
+Examples:
+  releases admin product create "Next.js" --org vercel --kind sdk
+  releases admin product create "CLI" --org acme --category developer-tools
+  releases admin product create "Mobile SDK" --org stripe --kind mobile --dry-run`,
+    )
     .action(productCreateAction);
 
   product
@@ -358,6 +366,14 @@ export function registerProductCommand(program: Command) {
     .option("--no-kind", "Clear product kind")
     .option("--json", "Output as JSON")
     .option("--dry-run", "Show what would change without writing")
+    .addHelpText(
+      "after",
+      `
+Examples:
+  releases admin product update next-js --kind sdk
+  releases admin product update prod_abc123 --name "Next.js" --category developer-tools
+  releases admin product update next-js --no-kind`,
+    )
     .action(productUpdateAction);
 
   product

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -132,6 +132,15 @@ export function registerSearchCommand(program: Command) {
       `Filter by taxonomy (${KIND_VALUES.join(", ")}). Release hits use COALESCE(source.kind, product.kind); catalog hits match the row's own kind only.`,
     )
     .option("--json", "Output as JSON")
+    .addHelpText(
+      "after",
+      `
+Examples:
+  releases search "breaking change"               Full-text + semantic search
+  releases search "breaking change" --kind sdk    Narrow to SDK sources
+  releases search vercel --type orgs              Show only org matches
+  releases search shopify/hydrogen                Coordinate lookup (GitHub)`,
+    )
     .action(
       async (
         query: string,

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -461,15 +461,16 @@ export function registerUpdateCommand(program: Command) {
       "after",
       `
 Examples:
-  releases update src_abc123 --primary
-  releases update src_abc123 --parse-instructions-file parse.md
-  cat parse.md | releases update src_abc123 --parse-instructions-file -
-  releases update redis-software-release-notes \\
+  releases admin source update vercel/next-js --kind sdk
+  releases admin source update src_abc123 --primary
+  releases admin source update src_abc123 --parse-instructions-file parse.md
+  cat parse.md | releases admin source update src_abc123 --parse-instructions-file -
+  releases admin source update redis-software-release-notes \\
     --metadata-set crawlEnabled=true \\
     --metadata-set crawlIncludePathPrefix=/docs/latest/operate/rs/release-notes/
-  releases update docker-compose-release-notes \\
+  releases admin source update docker-compose-release-notes \\
     --metadata-set githubUrl=https://github.com/docker/compose
-  releases update some-source --metadata-unset legacyFlag`,
+  releases admin source update some-source --metadata-unset legacyFlag`,
     )
     .action(updateSourceAction);
 }

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -172,7 +172,16 @@ export const program = new Command()
     },
   })
   .showSuggestionAfterError(true)
-  .action(() => {
+  // allowExcessArguments lets us detect unknown tokens in the action below
+  // rather than having Commander throw "too many arguments" before we can
+  // surface a did-you-mean suggestion.
+  .allowExcessArguments(true)
+  .action((_opts, cmd) => {
+    if (cmd.args.length > 0) {
+      // Delegate to Commander's unknownCommand() so showSuggestionAfterError
+      // can fire a did-you-mean hint for the unrecognised token.
+      cmd.unknownCommand();
+    }
     console.log(printStyledHelp());
     process.exit(0);
   });
@@ -182,7 +191,7 @@ registerSearchCommand(program);
 registerLookupCommand(program);
 registerTailCommand(program);
 registerStatsCommand(program);
-registerListCommand(program);
+registerListCommand(program, { alias: "sources" });
 // Canonical verb: get. Deprecated alias: show (emits a warning).
 registerGetCommand(program);
 registerShowCommand(program);

--- a/tests/cli/agent-ergonomics.test.ts
+++ b/tests/cli/agent-ergonomics.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "bun:test";
+import { runCli } from "../utils.js";
+
+describe("unknown-command suggestion (#1)", () => {
+  it("suggests 'search' when the user types a typo like 'serch'", () => {
+    const { stderr, exitCode } = runCli(["serch"]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("unknown command 'serch'");
+    expect(stderr).toContain("search");
+  });
+
+  it("suggests 'search' for multi-arg typo 'serch foo'", () => {
+    const { stderr, exitCode } = runCli(["serch", "foo"]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("unknown command 'serch'");
+    expect(stderr).toContain("search");
+  });
+
+  it("does not error when no arguments are passed — shows styled help", () => {
+    const { stdout, exitCode } = runCli([]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("releases");
+    expect(stdout).toContain("Commands:");
+  });
+
+  it("valid commands still work after the fix", () => {
+    const { exitCode } = runCli(["categories"]);
+    expect(exitCode).toBe(0);
+  });
+});
+
+describe("'sources' alias for 'list' (#3)", () => {
+  it("releases sources --help exits 0 and shows list usage", () => {
+    const { stdout, exitCode } = runCli(["sources", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("list");
+    expect(stdout).toContain("sources");
+  });
+
+  it("releases sources is NOT treated as an unknown command", () => {
+    // The command resolves to the list handler; it will fail at the API call
+    // (test URL), but not with an "unknown command" / "too many arguments" error.
+    const { stderr } = runCli(["sources"]);
+    expect(stderr).not.toContain("unknown command");
+    expect(stderr).not.toContain("too many arguments");
+  });
+
+  it("releases admin source --help does NOT show a 'sources' alias", () => {
+    const { stdout, exitCode } = runCli(["admin", "source", "--help"]);
+    expect(exitCode).toBe(0);
+    // The top-level alias must not leak into the admin subtree
+    expect(stdout).not.toContain("list|sources");
+  });
+});
+
+describe("Examples in --help output (#2)", () => {
+  it("releases list --help contains an Examples block", () => {
+    const { stdout, exitCode } = runCli(["list", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Examples:");
+    expect(stdout).toContain("--kind sdk");
+    expect(stdout).toContain("--org vercel");
+  });
+
+  it("releases sources --help (alias) also contains the Examples block", () => {
+    const { stdout, exitCode } = runCli(["sources", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Examples:");
+    expect(stdout).toContain("--kind sdk");
+  });
+
+  it("releases search --help contains an Examples block", () => {
+    const { stdout, exitCode } = runCli(["search", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Examples:");
+    expect(stdout).toContain("--kind sdk");
+  });
+
+  it("releases admin source update --help contains an Examples block with --kind", () => {
+    const { stdout, exitCode } = runCli(["admin", "source", "update", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Examples:");
+    expect(stdout).toContain("--kind sdk");
+  });
+
+  it("releases admin product create --help contains an Examples block with --kind", () => {
+    const { stdout, exitCode } = runCli(["admin", "product", "create", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Examples:");
+    expect(stdout).toContain("--kind sdk");
+  });
+
+  it("releases admin product update --help contains an Examples block with --kind", () => {
+    const { stdout, exitCode } = runCli(["admin", "product", "update", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Examples:");
+    expect(stdout).toContain("--kind");
+  });
+});


### PR DESCRIPTION
## Summary

- **Unknown-command suggestions (#1):** `releases serch foo` now prints `(Did you mean search?)` instead of the misleading "too many arguments" error. Root cause: the root `.action()` swallowed unrecognised tokens before Commander's suggestion engine could fire. Fix: add `.allowExcessArguments(true)` on the root `program` and delegate to `cmd.unknownCommand()` when extra tokens are present, which runs Commander's built-in `suggestSimilar()` path. `releases` with no args still prints the styled help; valid commands are unchanged.
- **`sources` alias (#3):** `releases list` now has a `sources` alias, so `releases sources --kind sdk` and `releases sources --help` work. The alias is added only at the top-level call site via a new `registerOpts` parameter on `registerListCommand` — `releases admin source` is unaffected.
- **`--help` examples (#2):** Added `Examples:` blocks (via `.addHelpText("after", ...)`) to `list`, `search`, `admin source update`, `admin product create`, and `admin product update`, each with at least one `--kind` example.
- **SKILL.md command map (#4):** Added a "Command shape" section near the top of `skills/releases-cli/SKILL.md` documenting the read/write asymmetry and the `sources` alias, so agents don't guess `releases sources list`.

Closes/follow-up items from buildinternet/releases#1080.

## Root cause

`showSuggestionAfterError(true)` was already set on the root program, but the root's `.action()` unconditionally printed styled help — Commander's argument-count check ran first (`_checkNumberOfArguments` → `_excessArguments`) and threw "too many arguments" before our action could delegate to `unknownCommand()`. Allowing excess args on the root program lets the action run, where we detect leftover tokens and call `cmd.unknownCommand()`, which triggers the built-in `suggestSimilar()` logic.

## Test plan

- [x] `bun test --isolate` — 458 pass, 0 fail
- [x] `npx tsc --noEmit` — clean
- [x] `bun run lint` — 0 warnings, 0 errors
- [x] `bun run format:check` — all files match Prettier style
- [x] New test file `tests/cli/agent-ergonomics.test.ts` (13 tests) covers:
  - `releases serch` → suggestion mentioning `search`
  - `releases serch foo` → same
  - `releases` (no args) → exits 0, shows help
  - `releases sources --help` → exits 0, shows list usage
  - `releases sources` → not treated as unknown command
  - `releases admin source --help` → does NOT show `list|sources` alias
  - `releases list/sources/search/admin source update/admin product create/admin product update --help` → each contains `Examples:` with `--kind`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `releases sources` as a convenient alias for listing sources, improving command discoverability.
  * Enhanced CLI error handling with intelligent "did you mean?" suggestions when users mistype or misuse commands.

* **Documentation**
  * Added comprehensive usage examples and `Examples:` sections to list, search, product, and source update commands.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/buildinternet/releases-cli/pull/205?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->