### PR TITLE
fix(ci): drop `bun test --isolate` to stop the flaky 10m test-job hang (#211)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,11 @@ jobs:
         run: npx tsc --noEmit
 
       - name: Test
-        run: bun test --isolate
+        # Single-process runner. `--isolate` (per-file VM isolation) was dropped
+        # in favor of de-leaking the mode.js mocks (see api-client.test.ts /
+        # search-lookup.test.ts) — its runner intermittently wedged a per-file
+        # isolate on the 2-vCPU runner, hanging the job to the 10m cap (#211).
+        run: bun test
 
   smoke-windows:
     name: Windows binary smoke test

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "changeset": "changeset",
     "changeset:version": "changeset version && bun scripts/sync-version.ts && bun install",
     "changeset:publish": "changeset publish",
-    "test": "bun test --isolate",
+    "test": "bun test",
     "typecheck": "tsc --noEmit",
     "lint": "oxlint",
     "lint:fix": "oxlint --fix",

--- a/packages/lib/src/config.ts
+++ b/packages/lib/src/config.ts
@@ -4,10 +4,18 @@ import { homedir } from "os";
 import { legacyEnv } from "./legacy-env";
 
 let _dataDir: string | null = null;
+let _dataDirEnv: string | undefined;
 
 export function getDataDir(): string {
-  if (!_dataDir) {
-    _dataDir = legacyEnv("RELEASES_DATA_DIR", "RELEASED_DATA_DIR") || join(homedir(), ".releases");
+  // Cache the resolved dir, but invalidate when the env var changes. In prod
+  // the env is fixed at startup so this stays memoized (mkdir runs once); in
+  // tests, each file points RELEASED_DATA_DIR at its own temp dir, and the
+  // comparison re-resolves instead of returning a stale dir cached by another
+  // file. (This is what `bun test --isolate` used to paper over — see #211.)
+  const env = legacyEnv("RELEASES_DATA_DIR", "RELEASED_DATA_DIR");
+  if (_dataDir === null || env !== _dataDirEnv) {
+    _dataDirEnv = env;
+    _dataDir = env || join(homedir(), ".releases");
     mkdirSync(_dataDir, { recursive: true });
   }
   return _dataDir;

--- a/tests/unit/api-client.test.ts
+++ b/tests/unit/api-client.test.ts
@@ -1,15 +1,29 @@
-import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, rmSync, readFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { SourceWithOrg } from "../../src/api/types.js";
 
-// Mock mode.ts before importing the client — apiFetch calls getApiUrl/getApiKey.
-mock.module("../../src/lib/mode.js", () => ({
-  getApiUrl: () => "https://test.example.com",
-  getApiKey: () => "test-key",
-  isAdminMode: () => true,
-}));
+// Drive the real mode.ts via env rather than mocking the module. A top-level
+// mock.module("mode.js") is process-global — it leaks into every other test
+// file (e.g. mode-credential.test.ts), which was the sole reason the suite
+// needed `bun test --isolate`. apiFetch reads getApiUrl/getApiKey/isAdminMode
+// lazily, so setting env before the tests run reproduces the old stub
+// (getApiUrl → test URL, getApiKey → test-key, isAdminMode → true). Restored in
+// afterAll so the key never bleeds into resolveCredential tests.
+const prevEnv: { url?: string; key?: string } = {};
+beforeAll(() => {
+  prevEnv.url = process.env.RELEASES_API_URL;
+  prevEnv.key = process.env.RELEASES_API_KEY;
+  process.env.RELEASES_API_URL = "https://test.example.com";
+  process.env.RELEASES_API_KEY = "test-key";
+});
+afterAll(() => {
+  if (prevEnv.url === undefined) delete process.env.RELEASES_API_URL;
+  else process.env.RELEASES_API_URL = prevEnv.url;
+  if (prevEnv.key === undefined) delete process.env.RELEASES_API_KEY;
+  else process.env.RELEASES_API_KEY = prevEnv.key;
+});
 
 const client = await import("../../src/api/client.js");
 

--- a/tests/unit/search-lookup.test.ts
+++ b/tests/unit/search-lookup.test.ts
@@ -4,18 +4,30 @@
  * We capture console.log output and verify the lookup rail renders correctly
  * for each LookupStatus value.
  */
-import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
 import type { LookupResultPayload } from "../../src/api/types.js";
 
 // ---------------------------------------------------------------------------
-// Mock dependencies before importing the command module
+// Drive the real mode.ts via env instead of a process-global mock.module
+// (which leaked mode.js across files and forced `bun test --isolate`).
+// unifiedSearch → apiFetch reads getApiUrl/getApiKey lazily; the assertions
+// below only inspect the returned lookup payload, so the auth/admin values
+// don't matter. Restored in afterAll so the key never bleeds into other files.
 // ---------------------------------------------------------------------------
 
-mock.module("../../src/lib/mode.js", () => ({
-  getApiUrl: () => "https://test.example.com",
-  getApiKey: () => "test-key",
-  isAdminMode: () => false,
-}));
+const prevEnv: { url?: string; key?: string } = {};
+beforeAll(() => {
+  prevEnv.url = process.env.RELEASES_API_URL;
+  prevEnv.key = process.env.RELEASES_API_KEY;
+  process.env.RELEASES_API_URL = "https://test.example.com";
+  process.env.RELEASES_API_KEY = "test-key";
+});
+afterAll(() => {
+  if (prevEnv.url === undefined) delete process.env.RELEASES_API_URL;
+  else process.env.RELEASES_API_URL = prevEnv.url;
+  if (prevEnv.key === undefined) delete process.env.RELEASES_API_KEY;
+  else process.env.RELEASES_API_KEY = prevEnv.key;
+});
 
 // We'll inject a controlled response via fetch mock
 function mockSearch(response: unknown) {


### PR DESCRIPTION
## Summary

Fixes the flaky **"Type-check and test"** hang tracked in #211 — the job intermittently stalled to the 10-minute cap and got canceled with `Terminate orphan process: pid (…) (bun)`.

## Root cause

The trigger is **`bun test --isolate`**, introduced in #201 (2026-05-20). Before that the suite ran single-process `bun test` and the job never hung (29 clean pre-isolate runs; the one pre-isolate "cancelled" was a 22s supersede-cancel). `--isolate` moves the suite onto Bun's per-file VM-isolation runner, which on the 2-vCPU runner intermittently:

- wedges a per-file isolate → orphan `bun` → 10-minute cancel, or
- races an fd registration → `EEXIST: file already exists, epoll_ctl` at Bun's internal `fs/streams`, plus `Cannot call describe() after the test run has completed`. That crash hit a **pure** unit test (`fetch-wait.test.ts`, no spawning/IO) — proving the fault is runner-internal, not test logic.

The mechanism the issue hypothesized (`runCli`'s `spawnSync` 30s timeout not firing because a child holds the stdout pipe open) does **not** hold: on Bun 1.3.13 a hung child is killed at the timeout (SIGTERM/ETIMEDOUT), and a detached grandchild holding the pipe still returns on direct-child exit. #204 fixed a separate real contributor (the `auth.test.ts` stub server not `unref()`'d), but hangs continued after it.

## Why `--isolate` was there

It only masked two process-global leaks the single-process runner exposes. Plain `bun test` runs in ~7s without hanging and surfaced exactly these:

1. **`mock.module("mode.js")` leak** — `api-client.test.ts` and `search-lookup.test.ts` mock `mode.js` at module top level. `mock.module` is process-global, so it permanently shadowed `mode.js` for any file importing it later (`mode-credential.test.ts` → `resolveCredential is not a function`).
2. **`getDataDir()` memoization** — `_dataDir` was cached for the whole process, so each test file's own `RELEASED_DATA_DIR` temp dir collided (e.g. `getWorkDir` returned another file's dir).

## Fix

- Drive the real `mode.ts` off env (`RELEASES_API_URL` / `RELEASES_API_KEY`) in `beforeAll`/`afterAll` instead of mocking the module — `apiFetch` reads `getApiUrl`/`getApiKey`/`isAdminMode` lazily, and the env is restored after each file so the key never bleeds into the credential tests.
- Invalidate the `getDataDir()` cache when the env value changes. No-op in prod (env is fixed at startup; `mkdir` still runs once), correct under tests.
- Drop `--isolate` from `package.json` and `.github/workflows/test.yml`, returning CI to the single-process runner that never hung.

## Verification

- `bun test` (plain) — **9/9 green locally, ~7s each, no hang, no orphan processes**.
- `bun test --isolate` — still green (backward-safe).
- `npx tsc --noEmit`, `bun run lint`, `bun run format:check` — all green.

Closes #211.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test execution pipeline to remove per-test isolation mode while adopting alternative test cleanup strategies to improve runner stability.
  * Enhanced environment variable tracking in configuration caching to prevent stale values and ensure proper cache invalidation.
  * Refactored test infrastructure to configure API credentials through process environment instead of module-level mocking, preventing credential leakage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/buildinternet/releases-cli/pull/214?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->