### PR TITLE
feat: add releases feedback command + admin feedback list

### DIFF
--- a/.changeset/cli-feedback.md
+++ b/.changeset/cli-feedback.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": minor
+---
+
+Add `releases feedback` to send feedback about the CLI (arg, stdin, or interactive; `--contact`, `--type`, `--json`, `--dry-run`), and `releases admin feedback list` to review submissions.

--- a/src/cli/commands/feedback.ts
+++ b/src/cli/commands/feedback.ts
@@ -8,6 +8,7 @@ import { VERSION } from "../version.js";
 import { isTelemetryEnabled, getOrCreateAnonId } from "../../lib/telemetry.js";
 import { apiFetch } from "../../api/client.js";
 import { stripAnsi } from "../../lib/sanitize.js";
+import { logger } from "@releases/lib/logger";
 
 const MIN_MESSAGE = 5;
 const MAX_MESSAGE = 4000;
@@ -72,6 +73,22 @@ export function buildFeedbackPayload(
     runtime: detectRuntime(),
     surface: "cli",
   };
+}
+
+/**
+ * Resolve the telemetry context for the payload. Only touches the anon-id file
+ * when telemetry is enabled — calling getOrCreateAnonId() unconditionally would
+ * create and persist an ID even for users who have opted out of telemetry.
+ * Deps are injectable for testing.
+ */
+export function resolveTelemetry(deps?: { isEnabled?: () => boolean; getAnonId?: () => string }): {
+  telemetryEnabled: boolean;
+  anonId: string;
+} {
+  const isEnabled = deps?.isEnabled ?? isTelemetryEnabled;
+  const getAnonId = deps?.getAnonId ?? getOrCreateAnonId;
+  const telemetryEnabled = isEnabled();
+  return { telemetryEnabled, anonId: telemetryEnabled ? getAnonId() : "" };
 }
 
 async function resolveMessage(arg: string | undefined): Promise<string | null> {
@@ -141,18 +158,18 @@ export function registerFeedbackCommand(parent: Command): void {
         opts: { contact?: string; type?: string; json?: boolean; dryRun?: boolean },
       ) => {
         if (opts.type && !FEEDBACK_TYPES_SET.has(opts.type)) {
-          console.error(chalk.red(`--type must be one of: ${FEEDBACK_TYPES.join(", ")}`));
+          logger.error(`--type must be one of: ${FEEDBACK_TYPES.join(", ")}`);
           process.exit(1);
         }
 
         const raw = await resolveMessage(messageArg);
         if (raw === null) {
-          console.error(chalk.dim("Cancelled — no feedback sent."));
+          logger.info(chalk.dim("Cancelled — no feedback sent."));
           process.exit(0);
         }
         const validated = validateMessage(raw);
         if (!validated.ok) {
-          console.error(chalk.red(validated.error));
+          logger.error(validated.error);
           process.exit(1);
         }
 
@@ -160,12 +177,12 @@ export function registerFeedbackCommand(parent: Command): void {
         const payload = buildFeedbackPayload(
           validated.message,
           { type: opts.type, contact },
-          { telemetryEnabled: isTelemetryEnabled(), anonId: getOrCreateAnonId() },
+          resolveTelemetry(),
         );
 
         if (opts.dryRun) {
           if (opts.json) await writeJson({ dryRun: true, payload });
-          else console.log(chalk.dim("[dry-run] would POST:\n") + JSON.stringify(payload, null, 2));
+          else logger.info(chalk.dim("[dry-run] would POST:\n") + JSON.stringify(payload, null, 2));
           return;
         }
 
@@ -173,15 +190,15 @@ export function registerFeedbackCommand(parent: Command): void {
         if (result.ok) {
           if (opts.json) await writeJson({ ok: true, id: result.id });
           else
-            console.log(
+            logger.info(
               chalk.green("Thanks — feedback received ") + chalk.dim(`(id: ${result.id})`),
             );
           return;
         }
         if (opts.json) await writeJson({ ok: false, error: result.error });
         else {
-          console.error(chalk.red(`Couldn't send feedback: ${result.error}`));
-          console.error(chalk.dim(`You can open an issue instead: ${ISSUES_URL}`));
+          logger.error(`Couldn't send feedback: ${result.error}`);
+          logger.info(chalk.dim(`You can open an issue instead: ${ISSUES_URL}`));
         }
         process.exit(1);
       },
@@ -234,7 +251,7 @@ export function registerFeedbackAdminCommand(parent: Command): void {
           return;
         }
         if (!data.items.length) {
-          console.log(chalk.dim("No feedback yet."));
+          logger.info(chalk.dim("No feedback yet."));
           return;
         }
         for (const r of data.items) {
@@ -244,12 +261,11 @@ export function registerFeedbackAdminCommand(parent: Command): void {
           const when = new Date(r.createdAt).toISOString().slice(0, 16).replace("T", " ");
           const head = `${chalk.bold(r.id)}  ${chalk.dim(when)}  ${chalk.cyan(r.type)}/${r.status}`;
           const contact = r.contact ? chalk.dim(` <${stripAnsi(r.contact)}>`) : "";
-          console.log(`${head}${contact}`);
-          console.log(`  ${stripAnsi(r.message).replace(/\s+/g, " ").slice(0, 200)}`);
+          logger.info(`${head}${contact}`);
+          logger.info(`  ${stripAnsi(r.message).replace(/\s+/g, " ").slice(0, 200)}`);
         }
         if (data.nextCursor) {
-          console.log("");
-          console.log(chalk.dim(`More: releases admin feedback list --cursor ${data.nextCursor}`));
+          logger.info(chalk.dim(`More: releases admin feedback list --cursor ${data.nextCursor}`));
         }
       },
     );

--- a/src/cli/commands/feedback.ts
+++ b/src/cli/commands/feedback.ts
@@ -12,6 +12,7 @@ const MIN_MESSAGE = 5;
 const MAX_MESSAGE = 4000;
 const POST_TIMEOUT_MS = 10_000;
 const FEEDBACK_TYPES = ["bug", "idea", "other"] as const;
+const FEEDBACK_TYPES_SET = new Set<string>(FEEDBACK_TYPES);
 const ISSUES_URL = "https://github.com/buildinternet/releases-cli/issues";
 
 export type ValidateResult = { ok: true; message: string } | { ok: false; error: string };
@@ -54,8 +55,7 @@ export function buildFeedbackPayload(
   opts: { type?: string; contact?: string },
   telemetry: { telemetryEnabled: boolean; anonId: string },
 ): FeedbackPayload {
-  const type =
-    opts.type && (FEEDBACK_TYPES as readonly string[]).includes(opts.type) ? opts.type : "general";
+  const type = opts.type && FEEDBACK_TYPES_SET.has(opts.type) ? opts.type : "general";
   return {
     message,
     type,
@@ -106,7 +106,7 @@ async function postFeedback(
   payload: FeedbackPayload,
 ): Promise<{ ok: true; id: string } | { ok: false; error: string }> {
   const controller = new AbortController();
-  const t = setTimeout(() => controller.abort(), POST_TIMEOUT_MS);
+  const timer = setTimeout(() => controller.abort(), POST_TIMEOUT_MS);
   try {
     const res = await fetch(`${getApiUrl()}/v1/feedback`, {
       method: "POST",
@@ -121,7 +121,7 @@ async function postFeedback(
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : String(err) };
   } finally {
-    clearTimeout(t);
+    clearTimeout(timer);
   }
 }
 
@@ -139,7 +139,7 @@ export function registerFeedbackCommand(parent: Command): void {
         messageArg: string | undefined,
         opts: { contact?: string; type?: string; json?: boolean; dryRun?: boolean },
       ) => {
-        if (opts.type && !(FEEDBACK_TYPES as readonly string[]).includes(opts.type)) {
+        if (opts.type && !FEEDBACK_TYPES_SET.has(opts.type)) {
           console.error(chalk.red(`--type must be one of: ${FEEDBACK_TYPES.join(", ")}`));
           process.exit(1);
         }
@@ -224,8 +224,9 @@ export function registerFeedbackAdminCommand(parent: Command): void {
         if (opts.type) qs.set("type", opts.type);
         if (opts.limit) qs.set("limit", opts.limit);
         if (opts.cursor) qs.set("cursor", opts.cursor);
-        const q = qs.toString();
-        const data = await apiFetch<FeedbackListResponse>(`/v1/admin/feedback${q ? `?${q}` : ""}`);
+        const data = await apiFetch<FeedbackListResponse>(
+          `/v1/admin/feedback${qs.size ? `?${qs}` : ""}`,
+        );
 
         if (opts.json) {
           await writeJson(data);

--- a/src/cli/commands/feedback.ts
+++ b/src/cli/commands/feedback.ts
@@ -7,6 +7,7 @@ import { RELEASES_CLI_UA } from "../../lib/user-agent.js";
 import { VERSION } from "../version.js";
 import { isTelemetryEnabled, getOrCreateAnonId } from "../../lib/telemetry.js";
 import { apiFetch } from "../../api/client.js";
+import { stripAnsi } from "../../lib/sanitize.js";
 
 const MIN_MESSAGE = 5;
 const MAX_MESSAGE = 4000;
@@ -237,11 +238,14 @@ export function registerFeedbackAdminCommand(parent: Command): void {
           return;
         }
         for (const r of data.items) {
+          // Defense-in-depth: the API strips control chars at ingest, but
+          // stripAnsi here protects the operator's terminal from any
+          // pre-existing or otherwise-ingested rows that carry escapes.
           const when = new Date(r.createdAt).toISOString().slice(0, 16).replace("T", " ");
           const head = `${chalk.bold(r.id)}  ${chalk.dim(when)}  ${chalk.cyan(r.type)}/${r.status}`;
-          const contact = r.contact ? chalk.dim(` <${r.contact}>`) : "";
+          const contact = r.contact ? chalk.dim(` <${stripAnsi(r.contact)}>`) : "";
           console.log(`${head}${contact}`);
-          console.log(`  ${r.message.replace(/\s+/g, " ").slice(0, 200)}`);
+          console.log(`  ${stripAnsi(r.message).replace(/\s+/g, " ").slice(0, 200)}`);
         }
         if (data.nextCursor) {
           console.log("");

--- a/src/cli/commands/feedback.ts
+++ b/src/cli/commands/feedback.ts
@@ -1,0 +1,251 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { createInterface } from "node:readline/promises";
+import { getApiUrl } from "../../lib/mode.js";
+import { writeJson } from "../../lib/output.js";
+import { RELEASES_CLI_UA } from "../../lib/user-agent.js";
+import { VERSION } from "../version.js";
+import { isTelemetryEnabled, getOrCreateAnonId } from "../../lib/telemetry.js";
+import { apiFetch } from "../../api/client.js";
+
+const MIN_MESSAGE = 5;
+const MAX_MESSAGE = 4000;
+const POST_TIMEOUT_MS = 10_000;
+const FEEDBACK_TYPES = ["bug", "idea", "other"] as const;
+const ISSUES_URL = "https://github.com/buildinternet/releases-cli/issues";
+
+export type ValidateResult = { ok: true; message: string } | { ok: false; error: string };
+
+export function validateMessage(raw: string): ValidateResult {
+  const message = raw.trim();
+  if (message.length < MIN_MESSAGE) {
+    return { ok: false, error: "Feedback is too short — add a sentence or two." };
+  }
+  if (message.length > MAX_MESSAGE) {
+    return { ok: false, error: `Feedback is too long (max ${MAX_MESSAGE} chars).` };
+  }
+  return { ok: true, message };
+}
+
+function detectRuntime(): string {
+  const bun = (globalThis as { Bun?: { version?: string } }).Bun;
+  if (bun?.version) return `bun-${bun.version}`;
+  if (typeof process !== "undefined" && process.versions?.node) {
+    return `node-${process.versions.node}`;
+  }
+  return "unknown";
+}
+
+export interface FeedbackPayload {
+  message: string;
+  type: string;
+  contact?: string;
+  cliVersion: string;
+  clientKind: string;
+  anonId?: string;
+  os: string;
+  arch: string;
+  runtime: string;
+  surface: "cli";
+}
+
+export function buildFeedbackPayload(
+  message: string,
+  opts: { type?: string; contact?: string },
+  telemetry: { telemetryEnabled: boolean; anonId: string },
+): FeedbackPayload {
+  const type =
+    opts.type && (FEEDBACK_TYPES as readonly string[]).includes(opts.type) ? opts.type : "general";
+  return {
+    message,
+    type,
+    contact: opts.contact?.trim() || undefined,
+    cliVersion: VERSION,
+    clientKind:
+      process.env.CI === "true" || process.env.GITHUB_ACTIONS === "true"
+        ? "internal-ci"
+        : "external",
+    anonId: telemetry.telemetryEnabled ? telemetry.anonId : undefined,
+    os: process.platform,
+    arch: process.arch,
+    runtime: detectRuntime(),
+    surface: "cli",
+  };
+}
+
+async function resolveMessage(arg: string | undefined): Promise<string | null> {
+  if (arg && arg.trim()) return arg;
+  if (!process.stdin.isTTY) {
+    const piped = (await Bun.stdin.text()).trim();
+    return piped.length ? piped : null;
+  }
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  try {
+    const answer = await rl.question(
+      chalk.bold("What's your feedback? ") + chalk.dim("(blank to cancel)\n> "),
+    );
+    return answer.trim().length ? answer : null;
+  } finally {
+    rl.close();
+  }
+}
+
+async function resolveContact(provided: string | undefined): Promise<string | undefined> {
+  if (provided) return provided;
+  if (!process.stdin.isTTY) return undefined;
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  try {
+    const answer = await rl.question(chalk.dim("Contact (optional, blank to skip)\n> "));
+    return answer.trim().length ? answer.trim() : undefined;
+  } finally {
+    rl.close();
+  }
+}
+
+async function postFeedback(
+  payload: FeedbackPayload,
+): Promise<{ ok: true; id: string } | { ok: false; error: string }> {
+  const controller = new AbortController();
+  const t = setTimeout(() => controller.abort(), POST_TIMEOUT_MS);
+  try {
+    const res = await fetch(`${getApiUrl()}/v1/feedback`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "User-Agent": RELEASES_CLI_UA },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+    if (!res.ok) return { ok: false, error: `server returned ${res.status}` };
+    const json = (await res.json()) as { ok?: boolean; id?: string };
+    if (!json.ok || !json.id) return { ok: false, error: "unexpected response" };
+    return { ok: true, id: json.id };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+export function registerFeedbackCommand(parent: Command): void {
+  parent
+    .command("feedback")
+    .description("Send feedback about the releases CLI")
+    .argument("[message]", "Feedback text (omit to type interactively or pipe via stdin)")
+    .option("--contact <value>", "How to reach you for follow-up (optional)")
+    .option("--type <type>", "bug | idea | other")
+    .option("--json", "Output as JSON")
+    .option("--dry-run", "Print the payload without sending")
+    .action(
+      async (
+        messageArg: string | undefined,
+        opts: { contact?: string; type?: string; json?: boolean; dryRun?: boolean },
+      ) => {
+        if (opts.type && !(FEEDBACK_TYPES as readonly string[]).includes(opts.type)) {
+          console.error(chalk.red(`--type must be one of: ${FEEDBACK_TYPES.join(", ")}`));
+          process.exit(1);
+        }
+
+        const raw = await resolveMessage(messageArg);
+        if (raw === null) {
+          console.error(chalk.dim("Cancelled — no feedback sent."));
+          process.exit(0);
+        }
+        const validated = validateMessage(raw);
+        if (!validated.ok) {
+          console.error(chalk.red(validated.error));
+          process.exit(1);
+        }
+
+        const contact = await resolveContact(opts.contact);
+        const payload = buildFeedbackPayload(
+          validated.message,
+          { type: opts.type, contact },
+          { telemetryEnabled: isTelemetryEnabled(), anonId: getOrCreateAnonId() },
+        );
+
+        if (opts.dryRun) {
+          if (opts.json) await writeJson({ dryRun: true, payload });
+          else console.log(chalk.dim("[dry-run] would POST:\n") + JSON.stringify(payload, null, 2));
+          return;
+        }
+
+        const result = await postFeedback(payload);
+        if (result.ok) {
+          if (opts.json) await writeJson({ ok: true, id: result.id });
+          else
+            console.log(
+              chalk.green("Thanks — feedback received ") + chalk.dim(`(id: ${result.id})`),
+            );
+          return;
+        }
+        if (opts.json) await writeJson({ ok: false, error: result.error });
+        else {
+          console.error(chalk.red(`Couldn't send feedback: ${result.error}`));
+          console.error(chalk.dim(`You can open an issue instead: ${ISSUES_URL}`));
+        }
+        process.exit(1);
+      },
+    );
+}
+
+interface FeedbackRow {
+  id: string;
+  createdAt: number;
+  message: string;
+  contact: string | null;
+  type: string;
+  status: string;
+}
+interface FeedbackListResponse {
+  items: FeedbackRow[];
+  nextCursor: string | null;
+}
+
+export function registerFeedbackAdminCommand(parent: Command): void {
+  const cmd = parent.command("feedback").description("Inspect submitted CLI feedback");
+
+  cmd
+    .command("list")
+    .description("List submitted feedback (newest first)")
+    .option("--status <status>", "Filter by status: new | triaged | closed")
+    .option("--type <type>", "Filter by type: bug | idea | other | general")
+    .option("--limit <n>", "Max rows (default 50)")
+    .option("--cursor <cursor>", "Pagination cursor from a previous page")
+    .option("--json", "Output as JSON")
+    .action(
+      async (opts: {
+        status?: string;
+        type?: string;
+        limit?: string;
+        cursor?: string;
+        json?: boolean;
+      }) => {
+        const qs = new URLSearchParams();
+        if (opts.status) qs.set("status", opts.status);
+        if (opts.type) qs.set("type", opts.type);
+        if (opts.limit) qs.set("limit", opts.limit);
+        if (opts.cursor) qs.set("cursor", opts.cursor);
+        const q = qs.toString();
+        const data = await apiFetch<FeedbackListResponse>(`/v1/admin/feedback${q ? `?${q}` : ""}`);
+
+        if (opts.json) {
+          await writeJson(data);
+          return;
+        }
+        if (!data.items.length) {
+          console.log(chalk.dim("No feedback yet."));
+          return;
+        }
+        for (const r of data.items) {
+          const when = new Date(r.createdAt).toISOString().slice(0, 16).replace("T", " ");
+          const head = `${chalk.bold(r.id)}  ${chalk.dim(when)}  ${chalk.cyan(r.type)}/${r.status}`;
+          const contact = r.contact ? chalk.dim(` <${r.contact}>`) : "";
+          console.log(`${head}${contact}`);
+          console.log(`  ${r.message.replace(/\s+/g, " ").slice(0, 200)}`);
+        }
+        if (data.nextCursor) {
+          console.log("");
+          console.log(chalk.dim(`More: releases admin feedback list --cursor ${data.nextCursor}`));
+        }
+      },
+    );
+}

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -35,6 +35,7 @@ import { registerEvaluateCommand } from "./commands/admin/evaluate.js";
 import { registerPlaybookCommand } from "./commands/admin/playbook.js";
 import { registerOverviewCommands } from "./commands/admin/overview.js";
 import { registerTelemetryCommand } from "./commands/telemetry.js";
+import { registerFeedbackCommand, registerFeedbackAdminCommand } from "./commands/feedback.js";
 import { registerServeCommand } from "./commands/serve.js";
 import { registerWhoamiCommand } from "./commands/whoami.js";
 import { registerWebhookCommand } from "./commands/webhook.js";
@@ -221,6 +222,7 @@ registerGetCommand(program);
 registerShowCommand(program);
 registerCollectionReadCommands(program);
 registerTelemetryCommand(program);
+registerFeedbackCommand(program);
 registerWhoamiCommand(program);
 registerAuthCommand(program);
 registerAgentContextCommand(program);
@@ -285,6 +287,7 @@ const mcpAdmin = admin.command("mcp").description("MCP server management");
 registerServeCommand(mcpAdmin);
 
 registerWebhookCommand(admin);
+registerFeedbackAdminCommand(admin);
 
 gateAdminSubtree(admin);
 

--- a/tests/unit/feedback.test.ts
+++ b/tests/unit/feedback.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "bun:test";
-import { validateMessage, buildFeedbackPayload } from "../../src/cli/commands/feedback.js";
+import {
+  validateMessage,
+  buildFeedbackPayload,
+  resolveTelemetry,
+} from "../../src/cli/commands/feedback.js";
 
 describe("validateMessage", () => {
   it("rejects messages shorter than 5 chars", () => {
@@ -55,5 +59,35 @@ describe("buildFeedbackPayload", () => {
       { telemetryEnabled: true, anonId: "anon-1" },
     );
     expect(p.type).toBe("general");
+  });
+});
+
+describe("resolveTelemetry", () => {
+  it("does not touch the anon id when telemetry is disabled", () => {
+    let called = false;
+    const r = resolveTelemetry({
+      isEnabled: () => false,
+      getAnonId: () => {
+        called = true;
+        return "anon-1";
+      },
+    });
+    expect(called).toBe(false);
+    expect(r.telemetryEnabled).toBe(false);
+    expect(r.anonId).toBe("");
+  });
+
+  it("resolves the anon id when telemetry is enabled", () => {
+    let called = false;
+    const r = resolveTelemetry({
+      isEnabled: () => true,
+      getAnonId: () => {
+        called = true;
+        return "anon-1";
+      },
+    });
+    expect(called).toBe(true);
+    expect(r.telemetryEnabled).toBe(true);
+    expect(r.anonId).toBe("anon-1");
   });
 });

--- a/tests/unit/feedback.test.ts
+++ b/tests/unit/feedback.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "bun:test";
+import { validateMessage, buildFeedbackPayload } from "../../src/cli/commands/feedback.js";
+
+describe("validateMessage", () => {
+  it("rejects messages shorter than 5 chars", () => {
+    const r = validateMessage("hi");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain("short");
+  });
+
+  it("rejects messages longer than 4000 chars", () => {
+    const r = validateMessage("x".repeat(4001));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain("long");
+  });
+
+  it("trims and accepts a valid message", () => {
+    expect(validateMessage("  good feedback here  ")).toEqual({
+      ok: true,
+      message: "good feedback here",
+    });
+  });
+});
+
+describe("buildFeedbackPayload", () => {
+  it("includes enrichment and the message + type + contact", () => {
+    const p = buildFeedbackPayload(
+      "hello world",
+      { type: "bug", contact: "me@x.com" },
+      { telemetryEnabled: true, anonId: "anon-1" },
+    );
+    expect(p.message).toBe("hello world");
+    expect(p.type).toBe("bug");
+    expect(p.contact).toBe("me@x.com");
+    expect(p.surface).toBe("cli");
+    expect(p.anonId).toBe("anon-1");
+    expect(typeof p.cliVersion).toBe("string");
+    expect(typeof p.os).toBe("string");
+  });
+
+  it("omits anonId when telemetry is disabled and defaults type to general", () => {
+    const p = buildFeedbackPayload(
+      "hello world",
+      {},
+      { telemetryEnabled: false, anonId: "anon-1" },
+    );
+    expect(p.anonId).toBeUndefined();
+    expect(p.type).toBe("general");
+  });
+
+  it("coerces an unknown type to general", () => {
+    const p = buildFeedbackPayload(
+      "hello world",
+      { type: "nonsense" },
+      { telemetryEnabled: true, anonId: "anon-1" },
+    );
+    expect(p.type).toBe("general");
+  });
+});


### PR DESCRIPTION
## What

Adds `releases feedback` — a one-line way for humans and agents to send feedback about the CLI — plus `releases admin feedback list` to review submissions.

Backend pair (the `/v1/feedback` endpoint, D1 table, and email-to-`zach@releases.sh` notification): **buildinternet/releases#1130**. Merge/deploy that first so the endpoint exists.

## Usage

```bash
# agent / script (non-interactive)
releases feedback "scoped search misses obvious hits" --type bug
echo "..." | releases feedback

# human (bare invocation in a TTY) — prompts for the message, then an optional contact
releases feedback

# preview the payload without sending
releases feedback "..." --dry-run --json

# operator read-back (admin-gated)
releases admin feedback list --status new --type bug
```

## Behavior

- **Text resolution** (first match wins): positional arg → piped stdin → interactive prompt (TTY only; blank cancels). Keeps it non-interactive for agents/CI while friendly for humans.
- **`--contact`** — optional, freeform (email/handle/Slack), not email-validated. Interactive flow also asks for it as a second optional line.
- **`--type`** — `bug | idea | other` (server defaults omitted to `general`).
- **Enrichment** — CLI version, OS/arch, runtime, client kind; `anonId` is attached **only when telemetry is enabled** (honors `DO_NOT_TRACK` / opt-out).
- **Send** — foreground `fetch` with a 10s timeout; on success prints `Thanks — feedback received (id: fb_…)`, on failure falls back to suggesting a GitHub issue. `--json` mirrors both outcomes. `--dry-run` prints the payload without sending.

## Changes

- `src/cli/commands/feedback.ts` — `registerFeedbackCommand` (submit) + `registerFeedbackAdminCommand` (admin list).
- `src/cli/program.ts` — register both (public submit; admin list under the gated `admin` subtree).
- `tests/unit/feedback.test.ts` — `validateMessage` bounds + `buildFeedbackPayload` enrichment / anonId opt-out.
- `.changeset/cli-feedback.md` — minor bump.

## Verification

- Full suite: 511 pass / 0 fail. `tsc --noEmit`: exit 0. `bun run lint`: 0 warnings/errors. `bun run format:check`: clean.
- Smoke: `feedback --help`, `feedback "…" --dry-run --json` (payload shape confirmed), `admin feedback list --help`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Submit CLI feedback interactively or via stdin, with optional contact, feedback type, message validation, and flags: --contact, --type, --json, --dry-run.
  * Admin feedback review: list and inspect submitted feedback with filtering, pagination, raw JSON or human-readable output, and a “More” hint when additional pages exist.

* **Tests**
  * Added unit tests covering message validation, payload building, and telemetry handling.

* **Documentation**
  * Changeset documenting the new CLI feedback capabilities and minor version bump.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/buildinternet/releases-cli/pull/216?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->