### PR TITLE
feat: --since/--until time-window filter on search and tail|latest

### DIFF
--- a/.changeset/cli-time-window-filter.md
+++ b/.changeset/cli-time-window-filter.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": minor
+---
+
+Add `--since` / `--until` time-window filters to `releases search` and `releases tail|latest`. Each accepts an ISO date (`2026-01-01`) or relative shorthand (`90d`, `4w`, `6m`, `2y`) and filters releases by publish date, composing with the existing filters. Enables capability-discovery queries like `releases search "slack integration" --since 90d`.

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -397,6 +397,9 @@ export async function unifiedSearch(
     domain?: string;
     mode?: "lexical" | "semantic" | "hybrid";
     kind?: Kind;
+    /** ISO date or relative shorthand (90d/4w/6m/2y); resolved server-side. */
+    since?: string;
+    until?: string;
   },
 ): Promise<UnifiedSearchResponse> {
   const params = new URLSearchParams({ q: query, limit: String(limit) });
@@ -404,6 +407,8 @@ export async function unifiedSearch(
   if (opts?.domain) params.set("domain", opts.domain);
   if (opts?.mode) params.set("mode", opts.mode);
   if (opts?.kind) params.set("kind", opts.kind);
+  if (opts?.since) params.set("since", opts.since);
+  if (opts?.until) params.set("until", opts.until);
   return apiFetch<UnifiedSearchResponse>(`/v1/search?${params}`);
 }
 
@@ -633,12 +638,17 @@ export async function getLatestReleases(opts: {
   org?: string;
   count: number;
   includeCoverage?: boolean;
+  /** ISO date or relative shorthand (90d/4w/6m/2y); resolved server-side. */
+  since?: string;
+  until?: string;
 }): Promise<LatestRelease[]> {
   const qs = new URLSearchParams();
   qs.set("count", String(opts.count));
   if (opts.source) qs.set("source", opts.source);
   if (opts.org) qs.set("org", opts.org);
   if (opts.includeCoverage) qs.set("include_coverage", "true");
+  if (opts.since) qs.set("since", opts.since);
+  if (opts.until) qs.set("until", opts.until);
 
   const data = await apiFetch<LatestReleasesResponse>(`/v1/releases/latest?${qs.toString()}`);
   if (!data) return [];

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -6,6 +6,7 @@ import { logger } from "@releases/lib/logger";
 import { isValidKind, KIND_VALUES, type Kind } from "@buildinternet/releases-core/kinds";
 import type { LookupResultPayload, UnifiedSearchResponse } from "../../api/types.js";
 import { writeJson } from "../../lib/output.js";
+import { parseTimeWindowFlag } from "../../lib/flags.js";
 
 const SEARCH_MODES = ["lexical", "semantic", "hybrid"] as const;
 type SearchMode = (typeof SEARCH_MODES)[number];
@@ -131,6 +132,14 @@ export function registerSearchCommand(program: Command) {
       "--kind <kind>",
       `Filter by taxonomy (${KIND_VALUES.join(", ")}). Release hits use COALESCE(source.kind, product.kind); catalog hits match the row's own kind only.`,
     )
+    .option(
+      "--since <when>",
+      "Only release hits published on/after this date. ISO (2026-01-01) or shorthand (90d, 4w, 6m, 2y).",
+    )
+    .option(
+      "--until <when>",
+      "Only release hits published on/before this date. Same formats as --since.",
+    )
     .option("--json", "Output as JSON")
     .addHelpText(
       "after",
@@ -138,6 +147,7 @@ export function registerSearchCommand(program: Command) {
 Examples:
   releases search "breaking change"               Full-text + semantic search
   releases search "breaking change" --kind sdk    Narrow to SDK sources
+  releases search "slack integration" --since 90d Only hits from the last 90 days
   releases search vercel --type orgs              Show only org matches
   releases search shopify/hydrogen                Coordinate lookup (GitHub)`,
     )
@@ -150,6 +160,8 @@ Examples:
           mode?: string;
           domain?: string;
           kind?: string;
+          since?: string;
+          until?: string;
           json?: boolean;
         },
       ) => {
@@ -181,10 +193,23 @@ Examples:
           process.exit(1);
         }
 
-        const searchOpts: { mode?: SearchMode; domain?: string; kind?: Kind } = {};
+        // Validate the window locally for a fast, clear error; the API resolves
+        // relative shorthand (90d/4w/6m/2y) server-side, so we forward verbatim.
+        const since = parseTimeWindowFlag("since", opts.since);
+        const until = parseTimeWindowFlag("until", opts.until);
+
+        const searchOpts: {
+          mode?: SearchMode;
+          domain?: string;
+          kind?: Kind;
+          since?: string;
+          until?: string;
+        } = {};
         if (mode) searchOpts.mode = mode;
         if (opts.domain) searchOpts.domain = opts.domain;
         if (kind) searchOpts.kind = kind;
+        if (since) searchOpts.since = since;
+        if (until) searchOpts.until = until;
         const response = await unifiedSearch(
           query,
           limit,

--- a/src/cli/commands/tail.ts
+++ b/src/cli/commands/tail.ts
@@ -7,6 +7,7 @@ import { stripAnsi } from "../../lib/sanitize.js";
 import { sleep } from "../../lib/sleep.js";
 import { renderLatestReleasesTable } from "../render/releases-table.js";
 import { writeJson, writeJsonLine } from "../../lib/output.js";
+import { parseTimeWindowFlag } from "../../lib/flags.js";
 
 function renderStreamLine(row: LatestRelease): string {
   const version = row.version ? chalk.yellow(stripAnsi(row.version)) : "";
@@ -46,6 +47,14 @@ export function registerTailCommand(program: Command) {
       "--include-coverage",
       "Include releases that are coverage of another (hidden by default)",
     )
+    .option(
+      "--since <when>",
+      "Only releases published on/after this date. ISO (2026-01-01) or shorthand (90d, 4w, 6m, 2y).",
+    )
+    .option(
+      "--until <when>",
+      "Only releases published on/before this date. Same formats as --since.",
+    )
     .option("-f, --follow", "Poll for new releases and stream them as they arrive")
     .option("--interval <seconds>", "Poll interval in seconds when following (min 5)", "60")
     .option("--json", "Output as JSON")
@@ -56,6 +65,7 @@ Examples:
   releases tail                         Latest releases across all sources
   releases tail my-source               Latest releases from one source
   releases tail --org acme --count 20   Latest 20 releases from an org
+  releases tail --since 30d             Releases from the last 30 days
   releases tail -f                      Follow new releases as they arrive (60s interval)
   releases tail -f --interval 30        Follow with a 30s poll interval
   releases tail --json                  Output as JSON
@@ -68,6 +78,8 @@ Examples:
           count: string;
           org?: string;
           includeCoverage?: boolean;
+          since?: string;
+          until?: string;
           follow?: boolean;
           interval: string;
           json?: boolean;
@@ -75,6 +87,9 @@ Examples:
       ) => {
         const count = parseInt(opts.count, 10);
         const intervalSeconds = Math.max(5, parseInt(opts.interval, 10) || 60);
+        // Validate locally; the API resolves relative shorthand server-side.
+        const since = parseTimeWindowFlag("since", opts.since);
+        const until = parseTimeWindowFlag("until", opts.until);
 
         if (sourceArg) {
           const source = await findSource(sourceArg);
@@ -93,6 +108,8 @@ Examples:
           org: orgSlug,
           count,
           includeCoverage: opts.includeCoverage,
+          since,
+          until,
         };
         const rows = await getLatestReleases(fetchOpts);
 
@@ -115,9 +132,11 @@ Examples:
 
         if (!opts.follow) return;
 
-        // Follow mode polls the same unfiltered request each tick so the response
-        // collapses onto the shared KV cache key — a server-side `since` filter
-        // would fork the cache and defeat the point. De-dupe via seen-id set.
+        // Follow mode re-issues the same request each tick and de-dupes via the
+        // seen-id set. The unfiltered default collapses onto the shared KV cache
+        // key; a `--since`/`--until` window forks off it, but the API marks
+        // windowed requests non-cacheable (BYPASS) so polling one is bounded —
+        // and a relative bound (e.g. `30d`) re-anchors to "now" on each tick.
         const seen = new Set<string>();
         rememberSeen(
           seen,

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -38,6 +38,36 @@ export function parseNonNegIntFlag(label: string, raw: string | undefined): numb
   return n;
 }
 
+/** Relative time-window shorthand accepted by the API: `<n><unit>` (d/w/m/y). */
+const TIME_WINDOW_RELATIVE_RE = /^(\d+)([dwmy])$/i;
+
+/**
+ * Validate a `--since`/`--until` flag value. The API resolves relative
+ * shorthand server-side, so the CLI only fast-fails on obviously-malformed
+ * input and forwards the trimmed value verbatim as a query param. Accepts an
+ * ISO date/datetime (`2026-01-01`) or relative shorthand (`90d`, `4w`, `6m`,
+ * `2y`). Returns `undefined` when the flag was omitted; exits with code 2 on a
+ * malformed value (matches the other flag parsers here). A bare number is
+ * rejected — it's neither a date nor shorthand, and would otherwise resolve to
+ * a surprising year server-side.
+ */
+export function parseTimeWindowFlag(label: string, raw: string | undefined): string | undefined {
+  if (raw === undefined) return undefined;
+  const trimmed = raw.trim();
+  const valid =
+    TIME_WINDOW_RELATIVE_RE.test(trimmed) ||
+    (trimmed.length > 0 && !/^\d+$/.test(trimmed) && !Number.isNaN(new Date(trimmed).getTime()));
+  if (!valid) {
+    console.error(
+      chalk.red(
+        `Invalid --${label}: "${raw}" — must be an ISO date (e.g. 2026-01-01) or relative shorthand (90d, 4w, 6m, 2y)`,
+      ),
+    );
+    process.exit(2);
+  }
+  return trimmed;
+}
+
 /** Parse a comma-separated `--tags foo,bar` flag into a trimmed, non-empty list. */
 export function parseTagList(raw: string | undefined): string[] {
   if (!raw) return [];

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -40,23 +40,31 @@ export function parseNonNegIntFlag(label: string, raw: string | undefined): numb
 
 /** Relative time-window shorthand accepted by the API: `<n><unit>` (d/w/m/y). */
 const TIME_WINDOW_RELATIVE_RE = /^(\d+)([dwmy])$/i;
+/**
+ * ISO accepted by the API's resolver: a date or a timezone-qualified datetime.
+ * Kept in lockstep with `ISO_DATE_RE` in @buildinternet/releases-core/dates so
+ * the CLI rejects the same shapes the server would (bare numbers, `2026/01/01`,
+ * and tz-less datetimes, which the server parses ambiguously as local time).
+ */
+const TIME_WINDOW_ISO_RE =
+  /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}(:?\d{2})?))?$/;
 
 /**
  * Validate a `--since`/`--until` flag value. The API resolves relative
  * shorthand server-side, so the CLI only fast-fails on obviously-malformed
  * input and forwards the trimmed value verbatim as a query param. Accepts an
- * ISO date/datetime (`2026-01-01`) or relative shorthand (`90d`, `4w`, `6m`,
- * `2y`). Returns `undefined` when the flag was omitted; exits with code 2 on a
- * malformed value (matches the other flag parsers here). A bare number is
- * rejected — it's neither a date nor shorthand, and would otherwise resolve to
- * a surprising year server-side.
+ * ISO date (`2026-01-01`), a timezone-qualified datetime (`…Z` / `…+05:00`),
+ * or relative shorthand (`90d`, `4w`, `6m`, `2y`). Returns `undefined` when the
+ * flag was omitted; exits with code 2 on a malformed value (matches the other
+ * flag parsers here). A bare number, `2026/01/01`, and a tz-less datetime are
+ * rejected so the local check matches the server contract.
  */
 export function parseTimeWindowFlag(label: string, raw: string | undefined): string | undefined {
   if (raw === undefined) return undefined;
   const trimmed = raw.trim();
   const valid =
     TIME_WINDOW_RELATIVE_RE.test(trimmed) ||
-    (trimmed.length > 0 && !/^\d+$/.test(trimmed) && !Number.isNaN(new Date(trimmed).getTime()));
+    (TIME_WINDOW_ISO_RE.test(trimmed) && !Number.isNaN(new Date(trimmed).getTime()));
   if (!valid) {
     console.error(
       chalk.red(

--- a/tests/unit/api-client.test.ts
+++ b/tests/unit/api-client.test.ts
@@ -287,3 +287,51 @@ describe("embed backfill routes", () => {
     expect(capturedUrl).toBe("https://test.example.com/v1/admin/embed/status");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Time-window (since/until) query-param passthrough
+// ---------------------------------------------------------------------------
+
+describe("since/until query params", () => {
+  let originalFetch: typeof globalThis.fetch;
+  let capturedUrl = "";
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    capturedUrl = "";
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  function captureWith(body: unknown) {
+    globalThis.fetch = (async (url: string) => {
+      capturedUrl = url;
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as any;
+  }
+
+  it("unifiedSearch forwards since and until", async () => {
+    captureWith({ orgs: [], catalog: [], releases: [], collections: [] });
+    await client.unifiedSearch("q", 10, { since: "90d", until: "2026-05-01" });
+    expect(capturedUrl).toContain("since=90d");
+    expect(capturedUrl).toContain("until=2026-05-01");
+  });
+
+  it("unifiedSearch omits since/until when not supplied", async () => {
+    captureWith({ orgs: [], catalog: [], releases: [], collections: [] });
+    await client.unifiedSearch("q", 10);
+    expect(capturedUrl).not.toContain("since=");
+    expect(capturedUrl).not.toContain("until=");
+  });
+
+  it("getLatestReleases forwards since and until", async () => {
+    captureWith({ releases: [] });
+    await client.getLatestReleases({ count: 10, since: "30d", until: "2026-05-01" });
+    expect(capturedUrl).toContain("since=30d");
+    expect(capturedUrl).toContain("until=2026-05-01");
+  });
+});

--- a/tests/unit/flags.test.ts
+++ b/tests/unit/flags.test.ts
@@ -269,4 +269,18 @@ describe("parseTimeWindowFlag", () => {
       expect(() => parseTimeWindowFlag("until", "not-a-date")).toThrow("process.exit called");
     });
   });
+
+  it("rejects a datetime without a timezone (server would parse it as local time)", () => {
+    withExitTrap(() => {
+      expect(() => parseTimeWindowFlag("since", "2026-01-01T12:30:00")).toThrow(
+        "process.exit called",
+      );
+    });
+  });
+
+  it("accepts a timezone offset", () => {
+    expect(parseTimeWindowFlag("since", "2026-01-01T12:30:00+05:00")).toBe(
+      "2026-01-01T12:30:00+05:00",
+    );
+  });
 });

--- a/tests/unit/flags.test.ts
+++ b/tests/unit/flags.test.ts
@@ -4,6 +4,7 @@ import {
   parseNonNegIntFlag,
   coerceMetadataValue,
   parseMetadataSetFlag,
+  parseTimeWindowFlag,
 } from "../../src/lib/flags.js";
 
 // Intercept process.exit so invalid-input tests don't kill the runner.
@@ -230,6 +231,42 @@ describe("parseMetadataSetFlag", () => {
   it("exits when the key contains '['", () => {
     withExitTrap(() => {
       expect(() => parseMetadataSetFlag("foo[0]=value")).toThrow("process.exit called");
+    });
+  });
+});
+
+describe("parseTimeWindowFlag", () => {
+  it("returns undefined when the flag is not supplied", () => {
+    expect(parseTimeWindowFlag("since", undefined)).toBeUndefined();
+  });
+
+  it("forwards an ISO date verbatim (trimmed)", () => {
+    expect(parseTimeWindowFlag("since", "2026-01-01")).toBe("2026-01-01");
+    expect(parseTimeWindowFlag("since", "  2026-01-01T12:30:00Z ")).toBe("2026-01-01T12:30:00Z");
+  });
+
+  it("forwards relative shorthand verbatim (resolved server-side)", () => {
+    expect(parseTimeWindowFlag("since", "90d")).toBe("90d");
+    expect(parseTimeWindowFlag("since", "4w")).toBe("4w");
+    expect(parseTimeWindowFlag("since", "6M")).toBe("6M");
+    expect(parseTimeWindowFlag("until", "2y")).toBe("2y");
+  });
+
+  it("rejects a bare number (ambiguous — neither date nor shorthand)", () => {
+    withExitTrap(() => {
+      expect(() => parseTimeWindowFlag("since", "90")).toThrow("process.exit called");
+    });
+  });
+
+  it("rejects an unknown unit", () => {
+    withExitTrap(() => {
+      expect(() => parseTimeWindowFlag("since", "90x")).toThrow("process.exit called");
+    });
+  });
+
+  it("rejects unparseable garbage", () => {
+    withExitTrap(() => {
+      expect(() => parseTimeWindowFlag("until", "not-a-date")).toThrow("process.exit called");
     });
   });
 });


### PR DESCRIPTION
Adds a `--since` / `--until` time-window filter to `releases search` and `releases tail|latest`, mirroring the API side (buildinternet/releases #1131, closes #1129).

## What

- `releases search <query> --since <when> [--until <when>]`
- `releases tail|latest --since <when> [--until <when>]`

Each accepts an **ISO date** (`2026-01-01`) or **relative shorthand** (`90d`, `4w`, `6m`, `2y`). The value is forwarded verbatim as a query param — the API resolves relative shorthand server-side and filters on `published_at`. Composes with the existing filters (`--type` / `--kind` / `--mode` / `--domain` on search; `--org` / `--count` on tail).

```
releases search "slack integration" --since 90d
releases tail --since 30d
```

## Details

- `parseTimeWindowFlag` in `src/lib/flags.ts` fast-fails malformed input (exit 2) with a clear message before the round-trip; a bare number is rejected to match the server's parser. Validation only — resolution stays server-side, so no `@buildinternet/releases-core` bump is needed.
- Follow mode (`tail -f`): a windowed request bypasses the shared KV cache by design (the API marks it non-cacheable), and a relative bound re-anchors to "now" each tick. Comment updated.

## Tests

`parseTimeWindowFlag` (ISO, shorthand, bare-number / unknown-unit / garbage rejection) and `since`/`until` query-param passthrough for `unifiedSearch` + `getLatestReleases`. Full suite (514 pass), `tsc`, lint, and prettier green. Changeset (`minor`) included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
