### PR TITLE
feat: clearer ownership + human dates in release reader output

### DIFF
--- a/.changeset/output-refinements-identity-dates.md
+++ b/.changeset/output-refinements-identity-dates.md
@@ -1,0 +1,9 @@
+---
+"@buildinternet/releases": patch
+---
+
+Refine the release reader output: clearer ownership, shorter labels, human dates.
+
+- `search` release hits now lead with the owning org as `Org/Source` (e.g. `Axiom/Changelog`) so it's clear who ships each result. The org prefix is skipped when the source name already starts with the org name (`Railway Changelog` stays as-is rather than becoming `Railway/Railway Changelog`). Feed views (`get` entity cards, scoped `tail`) are unchanged — the org is already established there.
+- `get` / `release get` print the publish date as `Jul 22, 2024` instead of the raw ISO timestamp. `--json` still emits ISO `publishedAt` for machine consumers.
+- Trimmed the AI-attribution labels on the `get` card to `AI summary` / `AI headline`, and dropped the redundant `Release` heading above the title.

--- a/.changeset/output-refinements-identity-dates.md
+++ b/.changeset/output-refinements-identity-dates.md
@@ -5,5 +5,6 @@
 Refine the release reader output: clearer ownership, shorter labels, human dates.
 
 - `search` release hits now lead with the owning org as `Org/Source` (e.g. `Axiom/Changelog`) so it's clear who ships each result. The org prefix is skipped when the source name already starts with the org name (`Railway Changelog` stays as-is rather than becoming `Railway/Railway Changelog`). Feed views (`get` entity cards, scoped `tail`) are unchanged — the org is already established there.
+- The release detail cards (`get <rel_…>` and `release get`) now show an `Org:` line so the owning company is named even when the source is generic (e.g. an "API Release Notes" source under Google).
 - `get` / `release get` print the publish date as `Jul 22, 2024` instead of the raw ISO timestamp. `--json` still emits ISO `publishedAt` for machine consumers.
 - Trimmed the AI-attribution labels on the `get` card to `AI summary` / `AI headline`, and dropped the redundant `Release` heading above the title.

--- a/src/cli/commands/get.ts
+++ b/src/cli/commands/get.ts
@@ -18,6 +18,7 @@ import { stripAnsi } from "../../lib/sanitize.js";
 import { logger } from "@releases/lib/logger";
 import { renderReleaseRows } from "../render/releases-table.js";
 import { slimReleaseDetail } from "../render/release-json.js";
+import { humanDate } from "../../lib/release-display.js";
 import { getEntityType, normalizeReleaseId, isLikelyBareId } from "@buildinternet/releases-core/id";
 import { countTokensSafe } from "@buildinternet/releases-core/tokens";
 import { writeJson } from "../../lib/output.js";
@@ -99,14 +100,13 @@ async function getRelease_(id: string, opts: GetEntityOpts) {
     );
     return;
   }
-  console.log(chalk.dim("Release"));
   console.log(chalk.bold(stripAnsi(rel.title)));
   console.log(`  ID:        ${rel.id}`);
   if (rel.version) console.log(`  Version:   ${stripAnsi(rel.version)}`);
   console.log(
     `  Source:    ${rel.sourceName ? stripAnsi(rel.sourceName) : chalk.dim("—")} (${rel.sourceSlug ?? chalk.dim("—")})`,
   );
-  if (rel.publishedAt) console.log(`  Published: ${rel.publishedAt}`);
+  if (rel.publishedAt) console.log(`  Published: ${humanDate(rel.publishedAt) || rel.publishedAt}`);
   if (rel.url) console.log(`  URL:       ${rel.url}`);
   if (rel.content) console.log(`  Content:   ${formatSize(rel.content)}`);
   if (rel.suppressed) {
@@ -124,11 +124,11 @@ async function getRelease_(id: string, opts: GetEntityOpts) {
   //      pivots to `release get`.
   if (rel.summary) {
     console.log("");
-    console.log(chalk.dim("Summary  · AI-generated, abbreviated"));
+    console.log(chalk.dim("AI summary"));
     console.log(stripAnsi(rel.summary));
   } else if (rel.titleGenerated || rel.titleShort) {
     console.log("");
-    console.log(chalk.dim("Headline  · AI-generated (no full summary on file yet)"));
+    console.log(chalk.dim("AI headline"));
     console.log(stripAnsi(rel.titleGenerated ?? rel.titleShort!));
   } else if (rel.content && rel.content.trim().length > 0) {
     const PREVIEW_CHARS = 280;

--- a/src/cli/commands/get.ts
+++ b/src/cli/commands/get.ts
@@ -100,9 +100,13 @@ async function getRelease_(id: string, opts: GetEntityOpts) {
     );
     return;
   }
+  // Owning org is on the release-detail wire (and the slim JSON) but not the
+  // narrow type — read it defensively so the card can name who ships the release.
+  const org = (rel as { org?: { slug: string; name: string } | null }).org;
   console.log(chalk.bold(stripAnsi(rel.title)));
   console.log(`  ID:        ${rel.id}`);
   if (rel.version) console.log(`  Version:   ${stripAnsi(rel.version)}`);
+  if (org) console.log(`  Org:       ${stripAnsi(org.name)} (${org.slug})`);
   console.log(
     `  Source:    ${rel.sourceName ? stripAnsi(rel.sourceName) : chalk.dim("—")} (${rel.sourceSlug ?? chalk.dim("—")})`,
   );

--- a/src/cli/commands/release.ts
+++ b/src/cli/commands/release.ts
@@ -45,8 +45,10 @@ async function releaseGetAction(rawId: string, opts: ReleaseGetOpts): Promise<vo
     return;
   }
 
+  const org = (rel as { org?: { slug: string; name: string } | null }).org;
   console.log(chalk.bold(stripAnsi(rel.title)));
   if (rel.version) console.log(`  Version:   ${stripAnsi(rel.version)}`);
+  if (org) console.log(`  Org:       ${stripAnsi(org.name)} (${org.slug})`);
   console.log(
     `  Source:    ${rel.sourceName ? stripAnsi(rel.sourceName) : chalk.dim("—")} (${rel.sourceSlug ?? chalk.dim("—")})`,
   );

--- a/src/cli/commands/release.ts
+++ b/src/cli/commands/release.ts
@@ -11,6 +11,7 @@ import {
   deleteReleasesForSource,
 } from "../../api/client.js";
 import { stripAnsi } from "../../lib/sanitize.js";
+import { humanDate } from "../../lib/release-display.js";
 import { normalizeReleaseId } from "@buildinternet/releases-core/id";
 import { writeJson, writeJsonLine } from "../../lib/output.js";
 import { warnDeprecatedAlias } from "../../lib/deprecated-alias.js";
@@ -49,7 +50,7 @@ async function releaseGetAction(rawId: string, opts: ReleaseGetOpts): Promise<vo
   console.log(
     `  Source:    ${rel.sourceName ? stripAnsi(rel.sourceName) : chalk.dim("—")} (${rel.sourceSlug ?? chalk.dim("—")})`,
   );
-  if (rel.publishedAt) console.log(`  Published: ${rel.publishedAt}`);
+  if (rel.publishedAt) console.log(`  Published: ${humanDate(rel.publishedAt) || rel.publishedAt}`);
   console.log(`  Fetched:   ${rel.fetchedAt}`);
   if (rel.suppressed)
     console.log(

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -9,7 +9,7 @@ import { writeJson } from "../../lib/output.js";
 import { parseTimeWindowFlag } from "../../lib/flags.js";
 import { renderReleaseRows } from "../render/releases-table.js";
 import { slimSearchHit } from "../render/release-json.js";
-import type { ReleaseRow } from "../../lib/release-display.js";
+import { humanDate, type ReleaseRow } from "../../lib/release-display.js";
 
 const SEARCH_MODES = ["lexical", "semantic", "hybrid"] as const;
 type SearchMode = (typeof SEARCH_MODES)[number];
@@ -35,17 +35,7 @@ function normalizeType(raw: string): SearchSection {
 const PREVIEW_LIMIT = 5;
 
 function formatShortDate(iso: string | null): string {
-  if (!iso) return "No date";
-  try {
-    return new Date(iso).toLocaleDateString("en-US", {
-      month: "short",
-      day: "numeric",
-      year: "numeric",
-      timeZone: "UTC",
-    });
-  } catch {
-    return iso;
-  }
+  return humanDate(iso) || "No date";
 }
 
 function renderLookup(lookup: LookupResultPayload, query: string): void {
@@ -346,6 +336,11 @@ Examples:
             publishedAt: r.publishedAt,
             sourceName: r.sourceName,
             sourceSlug: r.sourceSlug,
+            // Cross-vendor surface: carry the owning org so the identity column
+            // renders `Org/Source` ("who ships this"). Feed-mode callers leave
+            // this unset because the org is already established in context.
+            orgName: r.orgName ?? null,
+            orgSlug: r.orgSlug ?? null,
           }));
           console.log(renderReleaseRows(rows, { mode: "search" }));
           console.log();

--- a/src/lib/release-display.ts
+++ b/src/lib/release-display.ts
@@ -25,6 +25,21 @@ export function relativeDate(iso: string | null | undefined, now: number = Date.
   return `${Math.floor(d / YEAR)}y`;
 }
 
+/** Human-readable absolute date: `Jul 22, 2024`. Empty for null/unparseable.
+ *  Formatted in UTC (locale pinned to en-US) so it's deterministic and reflects
+ *  the calendar day of the stored ISO regardless of the runner's timezone. */
+export function humanDate(iso: string | null | undefined): string {
+  if (!iso) return "";
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return "";
+  return new Date(t).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
 /** Strip markdown to plain text, collapse whitespace, truncate to maxChars with an ellipsis. */
 export function cleanExcerpt(md: string | null | undefined, maxChars = 280): string {
   if (!md) return "";
@@ -54,13 +69,34 @@ export interface ReleaseRow {
   publishedAt: string | null;
   sourceName: string;
   sourceSlug: string;
+  /** Owning org's display name. When present, the identity column is rendered
+   *  as `Org/Source` so cross-vendor surfaces (search) make clear who ships the
+   *  release. Left unset by single-context feeds (entity cards, scoped `tail`)
+   *  where the org is already established in the surrounding output. */
+  orgName?: string | null;
+  orgSlug?: string | null;
 }
 
-/** Identity column: a package-qualified version (contains `@` or `/`) wins; else the source name. */
-export function releaseIdentity(row: Pick<ReleaseRow, "version" | "sourceName">): string {
+/**
+ * Identity column. A package-qualified version (contains `@` or `/`) wins —
+ * `next@15.0.0` is a more precise handle than any name. Otherwise the source
+ * name, prefixed with the owning org as `Org/Source` when `orgName` is supplied
+ * (the caller's opt-in for cross-vendor surfaces). The org prefix is skipped
+ * when the source name already starts with the org name, so a source literally
+ * named "Resend Changelog" under org "Resend" stays "Resend Changelog" rather
+ * than doubling up to "Resend/Resend Changelog".
+ */
+export function releaseIdentity(
+  row: Pick<ReleaseRow, "version" | "sourceName" | "orgName">,
+): string {
   const v = row.version?.trim();
   if (v && /[@/]/.test(v)) return v;
-  return row.sourceName;
+  const source = row.sourceName;
+  const org = row.orgName?.trim();
+  if (org && !source.toLowerCase().startsWith(org.toLowerCase())) {
+    return `${org}/${source}`;
+  }
+  return source;
 }
 
 /** Description column: summary → titleShort → titleGenerated → cleaned content excerpt → title. Always cleaned. */

--- a/tests/unit/release-display.test.ts
+++ b/tests/unit/release-display.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import {
   relativeDate,
+  humanDate,
   cleanExcerpt,
   releaseIdentity,
   releaseDescription,
@@ -21,6 +22,19 @@ describe("relativeDate", () => {
     expect(relativeDate(new Date(now - 21 * 86400 * 1000).toISOString(), now)).toBe("3w");
     expect(relativeDate(new Date(now - 90 * 86400 * 1000).toISOString(), now)).toBe("3mo");
     expect(relativeDate(new Date(now - 800 * 86400 * 1000).toISOString(), now)).toBe("2y");
+  });
+});
+
+describe("humanDate", () => {
+  it("returns empty string for null/undefined/unparseable", () => {
+    expect(humanDate(null)).toBe("");
+    expect(humanDate(undefined)).toBe("");
+    expect(humanDate("not-a-date")).toBe("");
+  });
+  it("formats as `Mon D, YYYY` in UTC", () => {
+    expect(humanDate("2024-07-22T00:00:00.000Z")).toBe("Jul 22, 2024");
+    // Midnight-UTC date renders the same calendar day regardless of runner TZ.
+    expect(humanDate("2026-01-01T00:00:00.000Z")).toBe("Jan 1, 2026");
   });
 });
 
@@ -57,6 +71,25 @@ describe("releaseIdentity", () => {
     );
     expect(releaseIdentity({ version: "v1.2.3", sourceName: "Render Blog" })).toBe("Render Blog");
     expect(releaseIdentity({ version: null, sourceName: "LangChain" })).toBe("LangChain");
+  });
+  it("prefixes the owning org as `Org/Source` when orgName is supplied", () => {
+    expect(releaseIdentity({ version: null, sourceName: "Changelog", orgName: "Axiom" })).toBe(
+      "Axiom/Changelog",
+    );
+  });
+  it("skips the org prefix when the source name already starts with the org name", () => {
+    expect(
+      releaseIdentity({ version: null, sourceName: "Resend Changelog", orgName: "Resend" }),
+    ).toBe("Resend Changelog");
+    // Case-insensitive match.
+    expect(releaseIdentity({ version: null, sourceName: "vercel blog", orgName: "Vercel" })).toBe(
+      "vercel blog",
+    );
+  });
+  it("keeps a package-qualified version even when orgName is present", () => {
+    expect(
+      releaseIdentity({ version: "next@15.0.0", sourceName: "Next.js", orgName: "Vercel" }),
+    ).toBe("next@15.0.0");
   });
 });
 

--- a/tests/unit/releases-rows.test.ts
+++ b/tests/unit/releases-rows.test.ts
@@ -117,6 +117,27 @@ describe("renderReleaseRows (search)", () => {
     expect(tty.split("\n")[0]).toContain("Multi line title");
   });
 
+  it("prefixes the identity with the owning org (Org/Source) when the hit carries one", () => {
+    const hit: ReleaseRow[] = [
+      {
+        id: "rel_o",
+        title: "Custom webhooks",
+        version: null,
+        summary: "Axiom introduces custom webhooks.",
+        publishedAt: null,
+        sourceName: "Changelog",
+        sourceSlug: "changelog",
+        orgName: "Axiom",
+        orgSlug: "axiom",
+      },
+    ];
+    const tty = stripAnsi(renderReleaseRows(hit, { mode: "search", isTTY: true, maxWidth: 100 }));
+    expect(tty.split("\n")[0].startsWith("Axiom/Changelog")).toBe(true);
+    // Same coordinate leads the machine TSV identity column.
+    const tsv = renderReleaseRows(hit, { mode: "search", isTTY: false });
+    expect(tsv.split("\t")[1]).toBe("Axiom/Changelog");
+  });
+
   it("non-TTY: one plain line per hit, no continuation", () => {
     const hit: ReleaseRow[] = [
       {


### PR DESCRIPTION
Follow-up polish on [#220](https://github.com/buildinternet/releases-cli/pull/220) (the search/latest output rework + slim `--json`), from a read-through of the actual CLI output.

## Changes

1. **Owning company in `search` results.** Release hits now lead with the org as `Org/Source` (e.g. `Axiom/Changelog`) so it's clear who ships each result — the homepage terminal demo's cross-vendor search was the motivating case. The prefix is skipped when the source name already starts with the org name, so `Railway Changelog` / `PlanetScale Changelog` stay as-is rather than doubling up to `Railway/Railway Changelog`. Scoped feed views (`get` entity cards, `tail`) are unchanged — the org is already established in their header, and search hits are the only rows that carry an owning org on the wire.
2. **`Org:` line on the release detail cards.** `get <rel_…>` and `release get` now name the owning company on its own line, read defensively off the release-detail payload (which already carries `org`). A generic source like "API Release Notes" under Google read as nobody in particular until the org was named.
3. **Human-readable publish date.** `get` and `release get` render the date as `May 4, 2026` instead of the raw ISO `2026-05-04T00:00:00.000Z`. `--json` still emits ISO `publishedAt` for machine consumers (sortable, unambiguous).
4. **Shorter AI-attribution labels.** `Summary  · AI-generated, abbreviated` → `AI summary`; the headline tier → `AI headline`.
5. **Dropped the redundant `Release` heading** above the bold title on the `get` card.

## Implementation

- New pure helper `humanDate()` in `src/lib/release-display.ts` (UTC, en-US, deterministic); `search`'s lookup-rail `formatShortDate` now delegates to it.
- `releaseIdentity()` gained optional `orgName`/`orgSlug` on `ReleaseRow`; it renders `Org/Source` only when `orgName` is supplied (search opts in; feed callers leave it unset) and dedups the org-name-prefix case.
- Label / heading / date / `Org:` edits in `get.ts` and `release.ts`.

## Verification

- `bun test` (557 pass), `tsc --noEmit` clean, `oxlint` clean, `prettier --check` clean.
- Smoke against prod (`api.releases.sh`):
  - `search webhooks --type releases` → `Axiom/Changelog` prefixed; `Railway Changelog` / `PlanetScale Changelog` / `LangChain Changelog` left unchanged by the dedup.
  - `get rel_vpnvlVinttqFUfgIlDlVZ` → `Org: Google (google)`, no `Release` heading, `Published: May 4, 2026`, `AI summary` label; `--json` `publishedAt` stays ISO.

Companion demo refresh in the monorepo (home-page `search` + `get` transcript) lands separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
