### PR TITLE
feat: add 'admin source stuck' report command

### DIFF
--- a/.changeset/stuck-sources-command.md
+++ b/.changeset/stuck-sources-command.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": minor
+---
+
+Add `releases admin source stuck` — lists sources that chronically fail to fetch (pause candidates) by reading the fetch-log error streak. Supports `--window`, `--min-attempts`, `--include-paused`, `--limit`, `--page`, and `--json`.

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -604,6 +604,65 @@ export async function getFetchLogs(opts: {
   }));
 }
 
+// ── Stuck sources ──
+
+export interface StuckSource {
+  sourceId: string;
+  sourceSlug: string;
+  name: string;
+  type: "github" | "scrape" | "feed" | "agent";
+  url: string;
+  kind: string | null;
+  orgSlug: string | null;
+  orgName: string | null;
+  fetchPriority: "normal" | "low" | "paused";
+  isPrimary: boolean;
+  isHidden: boolean;
+  recentAttempts: number;
+  recentErrors: number;
+  lastAttemptAt: string | null;
+  lastError: string | null;
+  lastErrorCategory: string | null;
+  /** null = the source has NEVER fetched successfully */
+  lastSuccessAt: string | null;
+  lastFetchedAt: string | null;
+  sourceCreatedAt: string | null;
+}
+
+export interface StuckSourcesResponse {
+  items: StuckSource[];
+  pagination: {
+    page: number;
+    pageSize: number;
+    returned: number;
+    totalItems?: number;
+    totalPages?: number;
+    hasMore: boolean;
+  };
+  meta: {
+    window: number;
+    minAttempts: number;
+    includePaused: boolean;
+  };
+}
+
+export async function getStuckSources(opts?: {
+  window?: number;
+  minAttempts?: number;
+  includePaused?: boolean;
+  limit?: number;
+  page?: number;
+}): Promise<StuckSourcesResponse> {
+  const params = new URLSearchParams();
+  if (opts?.window != null) params.set("window", String(opts.window));
+  if (opts?.minAttempts != null) params.set("minAttempts", String(opts.minAttempts));
+  if (opts?.includePaused) params.set("includePaused", "true");
+  if (opts?.limit != null) params.set("limit", String(opts.limit));
+  if (opts?.page != null) params.set("page", String(opts.page));
+  const qs = params.toString();
+  return apiFetch<StuckSourcesResponse>(`/v1/admin/sources/stuck${qs ? `?${qs}` : ""}`);
+}
+
 // ── Latest releases ──
 
 function toMediaItems(

--- a/src/cli/commands/stuck.ts
+++ b/src/cli/commands/stuck.ts
@@ -1,0 +1,117 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { renderTable } from "../render/table.js";
+import { getStuckSources } from "../../api/client.js";
+import { timeAgo } from "@buildinternet/releases-core/dates";
+import { stripAnsi } from "../../lib/sanitize.js";
+import { writeJson } from "../../lib/output.js";
+
+export function registerStuckCommand(program: Command) {
+  program
+    .command("stuck")
+    .description("List sources that chronically fail to fetch (pause candidates)")
+    .option("--window <n>", "Recent fetch attempts to examine per source", "5")
+    .option("--min-attempts <n>", "Minimum attempts required to appear", "3")
+    .option("--include-paused", "Include already-paused sources")
+    .option("--limit <n>", "Page size")
+    .option("--page <n>", "Page number")
+    .option("--json", "Output as JSON")
+    .addHelpText(
+      "after",
+      `
+Examples:
+  releases admin source stuck                        List chronically failing sources
+  releases admin source stuck --window 10            Examine last 10 attempts per source
+  releases admin source stuck --min-attempts 5       Require at least 5 attempts
+  releases admin source stuck --include-paused       Include already-paused sources
+  releases admin source stuck --limit 50
+  releases admin source stuck --json`,
+    )
+    .action(
+      async (opts: {
+        window?: string;
+        minAttempts?: string;
+        includePaused?: boolean;
+        limit?: string;
+        page?: string;
+        json?: boolean;
+      }) => {
+        const result = await getStuckSources({
+          // --window / --min-attempts always have commander defaults, so they're never undefined here.
+          window: parseInt(opts.window!, 10),
+          minAttempts: parseInt(opts.minAttempts!, 10),
+          includePaused: opts.includePaused,
+          limit: opts.limit ? parseInt(opts.limit, 10) : undefined,
+          page: opts.page ? parseInt(opts.page, 10) : undefined,
+        });
+
+        if (opts.json) {
+          await writeJson(result);
+          return;
+        }
+
+        const { items, pagination, meta } = result;
+        const summary = `${items.length === 0 ? "No" : items.length} stuck source(s) · window=${meta.window} minAttempts=${meta.minAttempts}`;
+
+        if (items.length === 0) {
+          console.log(summary);
+          return;
+        }
+
+        console.log(
+          renderTable({
+            head: [
+              { label: "Org" },
+              { label: "Source" },
+              { label: "Type", noTruncate: true },
+              { label: "Priority", noTruncate: true },
+              { label: "Errors", noTruncate: true, alignRight: true },
+              { label: "Last OK", noTruncate: true },
+              { label: "Last Error" },
+            ],
+            rows: items.map((item) => {
+              const orgLabel = item.orgSlug ?? chalk.dim("—");
+              const sourceLabel = item.isPrimary
+                ? `${item.sourceSlug} ${chalk.dim("*")}`
+                : item.sourceSlug;
+              let priorityLabel: string;
+              if (item.fetchPriority === "paused") priorityLabel = chalk.dim("paused");
+              else if (item.fetchPriority === "low") priorityLabel = chalk.yellow("low");
+              else priorityLabel = "normal";
+              const errorsLabel = chalk.red(`${item.recentErrors}/${item.recentAttempts}`);
+              const lastOkLabel = item.lastSuccessAt
+                ? (timeAgo(item.lastSuccessAt) ?? chalk.dim("—"))
+                : chalk.dim("never");
+              const lastErrorLabel = item.lastError
+                ? chalk.red(stripAnsi(item.lastError))
+                : chalk.dim("—");
+
+              return [
+                orgLabel,
+                sourceLabel,
+                item.type,
+                priorityLabel,
+                errorsLabel,
+                lastOkLabel,
+                lastErrorLabel,
+              ];
+            }),
+          }),
+        );
+
+        console.log(chalk.dim(`\n${summary}`));
+        console.log(
+          chalk.dim(`Pause one with: releases admin source update <id|org/slug> --priority paused`),
+        );
+
+        if (pagination.hasMore) {
+          const nextPage = pagination.page + 1;
+          console.log(
+            chalk.dim(
+              `More: releases admin source stuck --page ${nextPage}${opts.limit ? ` --limit ${opts.limit}` : ""}`,
+            ),
+          );
+        }
+      },
+    );
+}

--- a/src/cli/commands/stuck.ts
+++ b/src/cli/commands/stuck.ts
@@ -46,7 +46,8 @@ Examples:
         });
 
         if (opts.json) {
-          await writeJson(result);
+          // Match the CLI's ListResponse JSON contract (see list.ts): { items, pagination }.
+          await writeJson({ items: result.items, pagination: result.pagination });
           return;
         }
 

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -22,6 +22,7 @@ import { registerStatsCommand } from "./commands/stats.js";
 import { registerReleaseCommand } from "./commands/release.js";
 import { registerCheckCommand } from "./commands/check.js";
 import { registerFetchLogCommand } from "./commands/fetch-log.js";
+import { registerStuckCommand } from "./commands/stuck.js";
 import { registerOnboardCommand } from "./commands/onboard.js";
 import { registerIgnoreCommand } from "./commands/ignore.js";
 import { registerBlockCommand } from "./commands/block.js";
@@ -257,6 +258,7 @@ registerRemoveCommand(sourceAdmin);
 registerImportCommand(sourceAdmin);
 registerFetchCommand(sourceAdmin);
 registerFetchLogCommand(sourceAdmin);
+registerStuckCommand(sourceAdmin);
 registerCheckCommand(sourceAdmin);
 registerChangelogCommand(sourceAdmin);
 


### PR DESCRIPTION
## What

Adds `releases admin source stuck` — a read-only report listing sources that chronically fail to fetch, so an operator can review and pause them in one place.

A source is "stuck" when its last `--window` (default 5) non-`dry_run` fetch attempts were **all errors** with no successful fetch in between, and there are at least `--min-attempts` (default 3) of them. This reads the **fetch-log error streak** rather than `sources.consecutive_errors` — that column stays `0` for scrape/agent-path failures, so it can't be trusted to find these.

## Why

Firebase's `release-notes` scrape source had errored on every fetch for 9+ days (Google blocks Cloudflare Worker egress IPs) while `consecutive_errors` read `0`. It was found by eyeballing the dashboard. This command (and the matching dashboard tab) surface the next one without manual log-watching.

## Flags

`--window <n>` · `--min-attempts <n>` · `--include-paused` · `--limit <n>` · `--page <n>` · `--json`

Read-only — the pause action itself stays `releases admin source update <id|org/slug> --priority paused`.

## Backend

Depends on `GET /v1/admin/sources/stuck` (separate monorepo PR). The `StuckSource` wire type is defined locally here until the api-types package publishes it.

## Testing

- `bun run typecheck` — clean
- `bun run lint` — clean
- `bun test` — 555 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `releases admin source stuck` CLI command to identify sources experiencing chronic fetch failures
  * Command analyzes error patterns with configurable window and attempt thresholds
  * Supports pagination (`--limit`, `--page`) and source filtering options
  * Outputs results as human-readable table or JSON format via `--json` flag

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/buildinternet/releases-cli/pull/223?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->