### PR TITLE
feat: admin feedback triage/archive/delete commands

### DIFF
--- a/.changeset/feedback-triage-commands.md
+++ b/.changeset/feedback-triage-commands.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": minor
+---
+
+Add the `releases admin feedback` triage write-path: `triage <id> --status <new|triaged|closed>`, `archive <id>` (with `--undo` to restore), and `delete <id>` (hard delete, gated behind an id typeback or `--yes`). `admin feedback list` gains `--include-archived` and now marks archived rows. Consumes the new `PATCH`/`DELETE /v1/feedback/:id` endpoints.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ releases feedback "love the tool" --contact you@example.com   # optional reply-t
 releases feedback "draft" --dry-run --json                    # preview the payload, send nothing
 ```
 
-With no message argument in an interactive terminal, `feedback` prompts for the text (and an optional contact); otherwise pass it inline or pipe via stdin. `--type` accepts `bug`, `idea`, or `other`. Maintainers with admin access review submissions via `releases admin feedback list` (filter by `--type` / `--status`, paginate with `--cursor`).
+With no message argument in an interactive terminal, `feedback` prompts for the text (and an optional contact); otherwise pass it inline or pipe via stdin. `--type` accepts `bug`, `idea`, or `other`. Maintainers with admin access review submissions via `releases admin feedback list` (filter by `--type` / `--status`, `--include-archived`, paginate with `--cursor`) and triage them: `releases admin feedback triage <id> --status closed`, `releases admin feedback archive <id>` (`--undo` to restore), and `releases admin feedback delete <id>` (permanent — type the id to confirm, or pass `--yes`).
 
 ### MCP
 

--- a/src/cli/commands/feedback.ts
+++ b/src/cli/commands/feedback.ts
@@ -8,6 +8,7 @@ import { VERSION } from "../version.js";
 import { isTelemetryEnabled, getOrCreateAnonId } from "../../lib/telemetry.js";
 import { apiFetch } from "../../api/client.js";
 import { stripAnsi } from "../../lib/sanitize.js";
+import { promptConfirm } from "../../lib/confirm.js";
 import { logger } from "@releases/lib/logger";
 
 const MIN_MESSAGE = 5;
@@ -205,6 +206,12 @@ export function registerFeedbackCommand(parent: Command): void {
     );
 }
 
+// Mirrors the API's FEEDBACK_STATUSES (packages/core schema). When
+// @buildinternet/releases-api-types ships the feedback shapes, these locals can
+// be replaced by its FeedbackItem / FeedbackStatus exports.
+const FEEDBACK_STATUSES = ["new", "triaged", "closed"] as const;
+const FEEDBACK_STATUSES_SET = new Set<string>(FEEDBACK_STATUSES);
+
 interface FeedbackRow {
   id: string;
   createdAt: number;
@@ -212,20 +219,39 @@ interface FeedbackRow {
   contact: string | null;
   type: string;
   status: string;
+  // Present once the API write-path (#1133) is deployed; optional so the
+  // command stays compatible with responses from an older API.
+  archived?: boolean;
 }
 interface FeedbackListResponse {
   items: FeedbackRow[];
   nextCursor: string | null;
 }
 
+/**
+ * Translate apiFetch's thrown error into a clean CLI failure. A 404 on a
+ * write becomes a short "not found"; anything else surfaces the API message
+ * rather than a stack trace. Always exits non-zero.
+ */
+function failFromApiError(err: unknown, id: string): never {
+  const msg = err instanceof Error ? err.message : String(err);
+  if (msg.includes("(404)")) {
+    logger.error(`No feedback found with id ${id}.`);
+  } else {
+    logger.error(msg);
+  }
+  process.exit(1);
+}
+
 export function registerFeedbackAdminCommand(parent: Command): void {
-  const cmd = parent.command("feedback").description("Inspect submitted CLI feedback");
+  const cmd = parent.command("feedback").description("Inspect and triage submitted CLI feedback");
 
   cmd
     .command("list")
     .description("List submitted feedback (newest first)")
     .option("--status <status>", "Filter by status: new | triaged | closed")
     .option("--type <type>", "Filter by type: bug | idea | other | general")
+    .option("--include-archived", "Include archived rows (hidden by default)")
     .option("--limit <n>", "Max rows (default 50)")
     .option("--cursor <cursor>", "Pagination cursor from a previous page")
     .option("--json", "Output as JSON")
@@ -233,6 +259,7 @@ export function registerFeedbackAdminCommand(parent: Command): void {
       async (opts: {
         status?: string;
         type?: string;
+        includeArchived?: boolean;
         limit?: string;
         cursor?: string;
         json?: boolean;
@@ -240,6 +267,7 @@ export function registerFeedbackAdminCommand(parent: Command): void {
         const qs = new URLSearchParams();
         if (opts.status) qs.set("status", opts.status);
         if (opts.type) qs.set("type", opts.type);
+        if (opts.includeArchived) qs.set("includeArchived", "true");
         if (opts.limit) qs.set("limit", opts.limit);
         if (opts.cursor) qs.set("cursor", opts.cursor);
         const data = await apiFetch<FeedbackListResponse>(
@@ -259,7 +287,8 @@ export function registerFeedbackAdminCommand(parent: Command): void {
           // stripAnsi here protects the operator's terminal from any
           // pre-existing or otherwise-ingested rows that carry escapes.
           const when = new Date(r.createdAt).toISOString().slice(0, 16).replace("T", " ");
-          const head = `${chalk.bold(r.id)}  ${chalk.dim(when)}  ${chalk.cyan(r.type)}/${r.status}`;
+          const archived = r.archived ? chalk.yellow(" [archived]") : "";
+          const head = `${chalk.bold(r.id)}  ${chalk.dim(when)}  ${chalk.cyan(r.type)}/${r.status}${archived}`;
           const contact = r.contact ? chalk.dim(` <${stripAnsi(r.contact)}>`) : "";
           logger.info(`${head}${contact}`);
           logger.info(`  ${stripAnsi(r.message).replace(/\s+/g, " ").slice(0, 200)}`);
@@ -269,4 +298,93 @@ export function registerFeedbackAdminCommand(parent: Command): void {
         }
       },
     );
+
+  cmd
+    .command("triage")
+    .description("Set the triage status of a feedback row")
+    .argument("<id>", "Feedback id (fb_…)")
+    .requiredOption("--status <status>", "new | triaged | closed")
+    .option("--json", "Output as JSON")
+    .action(async (id: string, opts: { status: string; json?: boolean }) => {
+      if (!FEEDBACK_STATUSES_SET.has(opts.status)) {
+        logger.error(`--status must be one of: ${FEEDBACK_STATUSES.join(", ")}`);
+        process.exit(1);
+      }
+      let updated: FeedbackRow;
+      try {
+        updated = await apiFetch<FeedbackRow>(`/v1/feedback/${encodeURIComponent(id)}`, {
+          method: "PATCH",
+          body: JSON.stringify({ status: opts.status }),
+        });
+      } catch (err) {
+        failFromApiError(err, id);
+      }
+      if (opts.json) {
+        await writeJson(updated);
+        return;
+      }
+      logger.info(chalk.green(`Set ${chalk.bold(updated.id)} → status ${updated.status}`));
+    });
+
+  cmd
+    .command("archive")
+    .description("Archive a feedback row (hide it from the default list); --undo to restore")
+    .argument("<id>", "Feedback id (fb_…)")
+    .option("--undo", "Restore an archived row instead of archiving it")
+    .option("--json", "Output as JSON")
+    .action(async (id: string, opts: { undo?: boolean; json?: boolean }) => {
+      const archived = !opts.undo;
+      let updated: FeedbackRow;
+      try {
+        updated = await apiFetch<FeedbackRow>(`/v1/feedback/${encodeURIComponent(id)}`, {
+          method: "PATCH",
+          body: JSON.stringify({ archived }),
+        });
+      } catch (err) {
+        failFromApiError(err, id);
+      }
+      if (opts.json) {
+        await writeJson(updated);
+        return;
+      }
+      logger.info(chalk.green(`${archived ? "Archived" : "Restored"} ${chalk.bold(updated.id)}`));
+    });
+
+  cmd
+    .command("delete")
+    .description("Permanently delete a feedback row (prefer `archive` for a reversible removal)")
+    .argument("<id>", "Feedback id (fb_…)")
+    .option("-y, --yes", "Skip the confirmation prompt (required in non-interactive contexts)")
+    .option("--json", "Output as JSON")
+    .action(async (id: string, opts: { yes?: boolean; json?: boolean }) => {
+      // Hard delete is irreversible — gate it behind a typeback of the id,
+      // bypassable with --yes. A non-TTY without --yes refuses rather than
+      // silently confirming (mirrors `org delete --hard`).
+      if (!opts.yes) {
+        const confirmed = await promptConfirm(
+          `Type the feedback id to permanently delete it (${id}): `,
+          id,
+        );
+        if (!confirmed) {
+          logger.error(
+            "Delete cancelled — id not confirmed. Pass --yes to skip the prompt in scripts.",
+          );
+          process.exit(1);
+        }
+      }
+      let result: { deleted: boolean; id: string };
+      try {
+        result = await apiFetch<{ deleted: boolean; id: string }>(
+          `/v1/feedback/${encodeURIComponent(id)}`,
+          { method: "DELETE" },
+        );
+      } catch (err) {
+        failFromApiError(err, id);
+      }
+      if (opts.json) {
+        await writeJson(result);
+        return;
+      }
+      logger.info(chalk.green(`Deleted ${chalk.bold(result.id)}`));
+    });
 }

--- a/tests/cli/feedback-admin.test.ts
+++ b/tests/cli/feedback-admin.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "bun:test";
+import { runCli } from "../utils.js";
+
+/**
+ * Integration coverage for the `releases admin feedback` triage write-path
+ * (triage / archive / delete). runCli spawns the CLI with piped stdio, so
+ * `process.stdin.isTTY` is false in the child. We assert the guard rails that
+ * fire BEFORE any network call — invalid input and the destructive-delete
+ * confirmation gate — plus that the new verbs and flags surface in --help.
+ *
+ * The promptConfirm typeback path itself is unit-tested in
+ * tests/unit/confirm.test.ts (readline can't be driven through piped stdin).
+ */
+describe("admin feedback triage write-path (CLI integration)", () => {
+  it("lists triage / archive / delete subcommands in help", () => {
+    const { stdout, exitCode } = runCli(["admin", "feedback", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("triage");
+    expect(stdout).toContain("archive");
+    expect(stdout).toContain("delete");
+  });
+
+  it("requires --status on triage", () => {
+    const { stderr, exitCode } = runCli(["admin", "feedback", "triage", "fb_x"]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr.toLowerCase()).toContain("status");
+  });
+
+  it("rejects an invalid triage status before any request", () => {
+    const { stderr, exitCode } = runCli([
+      "admin",
+      "feedback",
+      "triage",
+      "fb_x",
+      "--status",
+      "bogus",
+    ]);
+    expect(exitCode).not.toBe(0);
+    // The valid set is echoed back so the operator can self-correct.
+    expect(stderr).toContain("triaged");
+  });
+
+  it("refuses a hard delete without --yes when stdin is not a TTY", () => {
+    const { stderr, exitCode } = runCli(["admin", "feedback", "delete", "fb_x"]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("--yes");
+  });
+
+  it("exposes --undo on archive and --yes on delete", () => {
+    const archiveHelp = runCli(["admin", "feedback", "archive", "--help"]);
+    expect(archiveHelp.exitCode).toBe(0);
+    expect(archiveHelp.stdout).toContain("--undo");
+
+    const deleteHelp = runCli(["admin", "feedback", "delete", "--help"]);
+    expect(deleteHelp.exitCode).toBe(0);
+    expect(deleteHelp.stdout).toContain("--yes");
+  });
+});


### PR DESCRIPTION
## What

Adds the CLI consumer side of the feedback triage write-path. The backend landed in monorepo **#1140** (closes buildinternet/releases#1133); this wires up the commands maintainers actually use.

The admin surface was read-only (`admin feedback list`). Feedback rows were stuck at `status: new` with no way to triage or remove spam/test rows from the CLI.

## New commands

| Command | Effect |
|---|---|
| `releases admin feedback triage <id> --status <new\|triaged\|closed>` | `PATCH /v1/feedback/:id { status }` |
| `releases admin feedback archive <id>` | `PATCH /v1/feedback/:id { archived: true }` — hides it from the default list |
| `releases admin feedback archive <id> --undo` | restore (`{ archived: false }`) |
| `releases admin feedback delete <id>` | hard `DELETE /v1/feedback/:id` |

`admin feedback list` also gains `--include-archived` and marks archived rows in the output.

## Safety / ergonomics

- **`delete` is irreversible**, so it's gated behind typing the feedback id back (via `promptConfirm`), bypassable with `--yes`. A non-TTY without `--yes` refuses rather than auto-confirming — same model as `org delete --hard`. `archive` is the reversible default and needs no confirmation.
- All verbs inherit admin auth from the gated admin subtree.
- API errors map to clean CLI failures (`404` → "No feedback found with id …", otherwise the API message) instead of stack traces.
- All commands support `--json`.

## Notes

- Feedback row types are kept **local** for now — the published `@buildinternet/releases-api-types@0.22.0` doesn't yet carry the `FeedbackItem` shapes (added in #1140, lands on the next api-types publish). The local `FeedbackRow` can be swapped for the published `FeedbackItem` in a follow-up. `archived` is optional on the local type so the command still works against an API that predates the column.

## Tests

- `tests/cli/feedback-admin.test.ts` (new) — help lists the verbs; `triage` requires `--status`; invalid status rejected before any request; `delete` refuses without `--yes` in a non-TTY; `--undo`/`--yes` surface in help. Mirrors `tests/cli/org-delete.test.ts`.
- Full suite green: `560 pass, 0 fail`. `tsc` clean, oxlint 0 errors, prettier clean.
- Changeset: `@buildinternet/releases` minor.

Closes the CLI half of buildinternet/releases#1133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admin feedback management commands: triage status updates, archive/unarchive, and delete with confirmation prompts
  * New `--include-archived` flag to display archived feedback in admin listings

* **Documentation**
  * Expanded README with user feedback submission workflow and comprehensive admin feedback management command reference

* **Tests**
  * Added integration tests for admin feedback write-path commands

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/buildinternet/releases-cli/pull/225?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->