### PR TITLE
feat(overview): surface citations on overview get (#228)

### DIFF
--- a/.changeset/overview-get-citations.md
+++ b/.changeset/overview-get-citations.md
@@ -1,5 +1,12 @@
 ---
 "@buildinternet/releases": patch
+"@buildinternet/releases-darwin-arm64": patch
+"@buildinternet/releases-darwin-x64": patch
+"@buildinternet/releases-linux-arm64": patch
+"@buildinternet/releases-linux-x64": patch
+"@buildinternet/releases-windows-x64": patch
+"@buildinternet/releases-lib": patch
+"@buildinternet/releases-skills": patch
 ---
 
 `releases admin overview get` now surfaces inline citations. The table line includes a citation count alongside the release count, and `--json` adds `citationCount` plus the full `citations` array. The org overview GET already returns citations ordered by character position — this exposes them so a post-write `overview get` can verify what `overview update` reported (which echoes `citations: N`) without a re-write.

--- a/.changeset/overview-get-citations.md
+++ b/.changeset/overview-get-citations.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": patch
+---
+
+`releases admin overview get` now surfaces inline citations. The table line includes a citation count alongside the release count, and `--json` adds `citationCount` plus the full `citations` array. The org overview GET already returns citations ordered by character position — this exposes them so a post-write `overview get` can verify what `overview update` reported (which echoes `citations: N`) without a re-write.

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1237,11 +1237,18 @@ export async function getMonthlySummary(
 
 const SCOPE_RESOURCE = { org: "orgs", product: "products" } as const;
 
+/**
+ * Knowledge page plus the inline citations the read endpoint returns. The org
+ * GET (`/v1/orgs/:slug/overview`) attaches `citations` ordered by character
+ * position; the product GET does not, so the field is optional.
+ */
+export type OverviewWithCitations = KnowledgePage & { citations?: OverviewCitation[] };
+
 export async function getOverview(
   scope: keyof typeof SCOPE_RESOURCE,
   identifier: string,
-): Promise<KnowledgePage | null> {
-  return apiFetch<KnowledgePage | null>(
+): Promise<OverviewWithCitations | null> {
+  return apiFetch<OverviewWithCitations | null>(
     `/v1/${SCOPE_RESOURCE[scope]}/${encodeURIComponent(identifier)}/overview`,
   );
 }

--- a/src/cli/commands/admin/overview.ts
+++ b/src/cli/commands/admin/overview.ts
@@ -111,6 +111,12 @@ async function overviewGetAction(orgIdentifier: string, opts: OverviewGetOpts): 
     return;
   }
 
+  // Citations are attached by the org overview GET, ordered by character
+  // position (#228). Surface a count so a post-write `overview get` can verify
+  // what `overview update` reported (it echoes `citations: N`); --json carries
+  // the full array for round-trip/audit without a re-write.
+  const citations = overview.citations ?? [];
+
   if (opts.json) {
     await writeJson({
       org: org.slug,
@@ -119,6 +125,8 @@ async function overviewGetAction(orgIdentifier: string, opts: OverviewGetOpts): 
       generatedAt: overview.generatedAt,
       updatedAt: overview.updatedAt,
       lastContributingReleaseAt: overview.lastContributingReleaseAt,
+      citationCount: citations.length,
+      citations,
     });
     return;
   }
@@ -126,7 +134,9 @@ async function overviewGetAction(orgIdentifier: string, opts: OverviewGetOpts): 
   const ageLabel = overview.generatedAt ? (timeAgo(overview.generatedAt) ?? "?") : "?";
   console.log(chalk.bold(`${org.name} — overview`));
   console.log(
-    chalk.dim(`  generated ${ageLabel} · ${overview.releaseCount} releases contributing`),
+    chalk.dim(
+      `  generated ${ageLabel} · ${overview.releaseCount} releases contributing · ${citations.length} citations`,
+    ),
   );
   console.log();
   console.log(overview.content);

--- a/tests/unit/overview-get-citations.test.ts
+++ b/tests/unit/overview-get-citations.test.ts
@@ -24,10 +24,10 @@ afterAll(() => {
   else process.env.RELEASES_API_KEY = prevEnv.key;
 });
 
-function mockGet(response: unknown) {
+function mockGet(response: unknown, status = 200) {
   globalThis.fetch = (async () =>
     new Response(JSON.stringify(response), {
-      status: 200,
+      status,
       headers: { "Content-Type": "application/json" },
     })) as typeof fetch;
 }
@@ -110,11 +110,22 @@ describe("getOverview citations (#228)", () => {
     expect(payload).toHaveProperty("citationCount");
   });
 
-  it("returns null when no overview exists yet", async () => {
+  it("returns null when no overview exists yet (endpoint returns 200 + null)", async () => {
+    // The overview GET handler returns `c.json(null)` (HTTP 200, null body) when
+    // the org or page is missing — it does not 404 — so this is the real shape.
     mockGet(null);
 
     const { getOverview } = await import("../../src/api/client.js");
     const overview = await getOverview("org", "railway");
+
+    expect(overview).toBeNull();
+  });
+
+  it("returns null on a 404 too (generic apiFetch GET-404 → null path)", async () => {
+    mockGet({ message: "Not found" }, 404);
+
+    const { getOverview } = await import("../../src/api/client.js");
+    const overview = await getOverview("org", "nope");
 
     expect(overview).toBeNull();
   });

--- a/tests/unit/overview-get-citations.test.ts
+++ b/tests/unit/overview-get-citations.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Unit tests for `overview get` surfacing inline citations (#228).
+ *
+ * The org overview GET returns the knowledge page plus a `citations` array
+ * ordered by character position. `getOverview` must carry it through so
+ * `overview get` can report a count that matches what `overview update`
+ * echoed. We mock `globalThis.fetch` (same approach as search-lookup) and
+ * assert the parsed shape, then simulate the JSON payload the action builds.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
+import type { OverviewCitation } from "../../src/api/client.js";
+
+const prevEnv: { url?: string; key?: string } = {};
+beforeAll(() => {
+  prevEnv.url = process.env.RELEASES_API_URL;
+  prevEnv.key = process.env.RELEASES_API_KEY;
+  process.env.RELEASES_API_URL = "https://test.example.com";
+  process.env.RELEASES_API_KEY = "test-key";
+});
+afterAll(() => {
+  if (prevEnv.url === undefined) delete process.env.RELEASES_API_URL;
+  else process.env.RELEASES_API_URL = prevEnv.url;
+  if (prevEnv.key === undefined) delete process.env.RELEASES_API_KEY;
+  else process.env.RELEASES_API_KEY = prevEnv.key;
+});
+
+function mockGet(response: unknown) {
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify(response), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    })) as typeof fetch;
+}
+
+const BASE_PAGE = {
+  scope: "org",
+  orgSlug: "railway",
+  content: "Railway shipped a bunch.",
+  releaseCount: 42,
+  generatedAt: "2026-05-25T00:00:00Z",
+  updatedAt: "2026-05-25T00:00:00Z",
+  lastContributingReleaseAt: "2026-05-24T00:00:00Z",
+};
+
+const CITATIONS: OverviewCitation[] = [
+  {
+    startIndex: 0,
+    endIndex: 7,
+    sourceUrl: "https://railway.app/changelog/a",
+    title: "A",
+    citedText: "Railway",
+  },
+  {
+    startIndex: 8,
+    endIndex: 15,
+    sourceUrl: "https://railway.app/changelog/b",
+    title: "B",
+    citedText: "shipped",
+  },
+];
+
+describe("getOverview citations (#228)", () => {
+  let originalFetch: typeof globalThis.fetch;
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("carries the citations array through from the org overview GET", async () => {
+    mockGet({ ...BASE_PAGE, citations: CITATIONS });
+
+    const { getOverview } = await import("../../src/api/client.js");
+    const overview = await getOverview("org", "railway");
+
+    expect(overview).not.toBeNull();
+    expect(overview?.citations).toHaveLength(2);
+    expect(overview?.citations?.[0]?.sourceUrl).toBe("https://railway.app/changelog/a");
+  });
+
+  it("treats a citationless page as zero citations (count derivation is safe)", async () => {
+    mockGet({ ...BASE_PAGE }); // no `citations` field — pages pre-#846
+
+    const { getOverview } = await import("../../src/api/client.js");
+    const overview = await getOverview("org", "railway");
+
+    const citations = overview?.citations ?? [];
+    expect(citations).toHaveLength(0);
+  });
+
+  it("builds the --json payload shape with citationCount matching the array", async () => {
+    mockGet({ ...BASE_PAGE, citations: CITATIONS });
+
+    const { getOverview } = await import("../../src/api/client.js");
+    const overview = await getOverview("org", "railway");
+    const citations = overview?.citations ?? [];
+
+    // Mirror what overviewGetAction's --json path emits.
+    const payload = {
+      org: "railway",
+      content: overview?.content,
+      releaseCount: overview?.releaseCount,
+      citationCount: citations.length,
+      citations,
+    };
+
+    expect(payload.citationCount).toBe(2);
+    expect(payload.citations).toHaveLength(2);
+    expect(payload).toHaveProperty("citationCount");
+  });
+
+  it("returns null when no overview exists yet", async () => {
+    mockGet(null);
+
+    const { getOverview } = await import("../../src/api/client.js");
+    const overview = await getOverview("org", "railway");
+
+    expect(overview).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Surface inline citations on `releases admin overview get`.

Closes #228.

## Why

After `releases admin overview update <slug>`, the natural way to verify the write is `overview get <slug>`. But its payload was `org, content, releaseCount, generatedAt, updatedAt, lastContributingReleaseAt` — no citations. During the 2026-05-25 regen sweep a spot-check via `overview get` showed citations absent, which read as "the write dropped every link." It hadn't — `overview update` had echoed the correct counts; the verification command just didn't expose them.

## How

The org overview GET (`/v1/orgs/:slug/overview`) **already** returns a `citations` array ordered by character position (`OverviewPageItemSchema` carries it), so this is CLI-only:

- `getOverview` return type now carries the optional citations array (`OverviewWithCitations = KnowledgePage & { citations?: OverviewCitation[] }`).
- Table: the summary line gains a citation count next to the release count.
- `--json`: adds `citationCount` and the full `citations` array, so an audit / round-trip is possible without a re-write.

## Tests

`tests/unit/overview-get-citations.test.ts` (mocks `fetch`, same pattern as `search-lookup.test.ts`):
- citations array carried through from the GET;
- a citationless page (pre-#846) derives a count of 0 safely;
- the `--json` payload shape has `citationCount` matching the array;
- `null` overview still returns `null`.

## Validation

- `bun test` — 564 pass / 0 fail ✓
- `bun run lint` — 0 errors ✓
- `bun run format:check` ✓
- `tsc --noEmit` ✓
- Changeset added (`@buildinternet/releases`, patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The admin `overview get` command now displays citation counts alongside release information in the status output
  * JSON export includes both citation count and full citations array for overview data

* **Tests**
  * Added test suite validating citation propagation and handling in overview retrieval

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/buildinternet/releases-cli/pull/231?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->