### PR TITLE
feat(cli): add --max-content-chars to `overview inputs` to prevent silent stdout truncation

### DIFF
--- a/.changeset/overview-inputs-max-content-chars.md
+++ b/.changeset/overview-inputs-max-content-chars.md
@@ -1,0 +1,12 @@
+---
+"@buildinternet/releases": minor
+"@buildinternet/releases-darwin-arm64": minor
+"@buildinternet/releases-darwin-x64": minor
+"@buildinternet/releases-linux-arm64": minor
+"@buildinternet/releases-linux-x64": minor
+"@buildinternet/releases-windows-x64": minor
+"@buildinternet/releases-lib": minor
+"@buildinternet/releases-skills": minor
+---
+
+Add `--max-content-chars [n]` to `releases admin overview inputs`. In `--json` mode it clips each `selected[].content` to at most `n` characters client-side before printing (bare flag defaults to 1000), leaving every other field — `existingContent`, `media`, `totalAvailable`, and the `selected` length itself — untouched. High-volume orgs emit 500K+ chars of full release content here (sentry's largest single release is ~125K), which exceeds the ~30K Bash stdout cap a Claude Code sub-agent reads through and gets silently truncated, so the overview would be generated from only the first few releases. The clip is purely client-side — the CLI still receives the full payload over the wire — so it removes that footgun without the multi-step `jq` workaround. Omitting the flag preserves today's full-content output.

--- a/src/cli/commands/admin/overview.ts
+++ b/src/cli/commands/admin/overview.ts
@@ -28,6 +28,7 @@ import { orgNotFound } from "../../suggest.js";
 import { writeJson } from "../../../lib/output.js";
 import { trySaveBatchOverviewTrace } from "../../../lib/trace.js";
 import {
+  MAX_CONTENT_CHARS_DEFAULT,
   parseMaxContentCharsFlag,
   parseNonNegIntFlag,
   parsePositiveIntFlag,
@@ -747,7 +748,7 @@ old — orchestrator should poll-and-fetch first).`,
     )
     .option(
       "--max-content-chars [n]",
-      "With --json, clip each selected[].content to n chars before printing (bare: 1000)",
+      `With --json, clip each selected[].content to n chars before printing (bare: ${MAX_CONTENT_CHARS_DEFAULT})`,
     )
     .option("--json", "Output as JSON (recommended for agent consumption)")
     .addHelpText(
@@ -765,7 +766,7 @@ generator described in the \`regenerating-overviews\` skill, then upload the
 result with \`releases admin overview update\`.
 
 --max-content-chars clips each selected release body to n characters (bare flag
-defaults to 1000) before the JSON is printed, leaving every other field intact
+defaults to ${MAX_CONTENT_CHARS_DEFAULT}) before the JSON is printed, leaving every other field intact
 and never dropping a release. High-volume orgs (e.g. sentry, wordpress) emit
 500K+ chars of full release content here; when an agent runs this via Bash that
 exceeds the ~30K stdout cap and is silently truncated before the model sees it,

--- a/src/cli/commands/admin/overview.ts
+++ b/src/cli/commands/admin/overview.ts
@@ -19,6 +19,7 @@ import {
   triggerBatchOverview,
   getBatchOverviewStatus,
   type OverviewCitation,
+  type OverviewInputs,
   type OverviewManifestRow,
   type BatchOverviewTriggerBody,
   type BatchOverviewStatusResponse,
@@ -26,7 +27,12 @@ import {
 import { orgNotFound } from "../../suggest.js";
 import { writeJson } from "../../../lib/output.js";
 import { trySaveBatchOverviewTrace } from "../../../lib/trace.js";
-import { parseNonNegIntFlag, parsePositiveIntFlag, parseTagList } from "../../../lib/flags.js";
+import {
+  parseMaxContentCharsFlag,
+  parseNonNegIntFlag,
+  parsePositiveIntFlag,
+  parseTagList,
+} from "../../../lib/flags.js";
 import { logger } from "@releases/lib/logger";
 import { timeAgo } from "@buildinternet/releases-core/dates";
 import {
@@ -75,6 +81,8 @@ interface OverviewInputsOpts {
   window?: string;
   limit?: string;
   check?: boolean;
+  // `[n]` optional value: string when given, `true` when passed bare.
+  maxContentChars?: string | boolean;
 }
 
 interface OverviewPlanOpts {
@@ -208,6 +216,30 @@ async function overviewUpdateAction(
   }
 }
 
+/**
+ * Clip each `selected[].content` to at most `maxContentChars` characters,
+ * client-side, before the payload is printed. The CLI already received the full
+ * content over the wire — the wire isn't subject to the agent Bash-stdout cap;
+ * only stdout is — so this is purely about keeping the printed JSON under that
+ * cap for sub-agent callers. Never drops a release and leaves every other field
+ * (including `existingContent`, `media`, `totalAvailable`) untouched. Returns
+ * the input unchanged when `maxContentChars` is `undefined`.
+ */
+export function clipInputsContent(
+  inputs: OverviewInputs,
+  maxContentChars: number | undefined,
+): OverviewInputs {
+  if (maxContentChars === undefined) return inputs;
+  return {
+    ...inputs,
+    selected: inputs.selected.map((r) =>
+      r.content.length > maxContentChars
+        ? { ...r, content: r.content.slice(0, maxContentChars) }
+        : r,
+    ),
+  };
+}
+
 async function overviewInputsAction(
   orgIdentifier: string,
   opts: OverviewInputsOpts,
@@ -217,6 +249,7 @@ async function overviewInputsAction(
 
   const window = parsePositiveIntFlag("window", opts.window);
   const limit = parsePositiveIntFlag("limit", opts.limit);
+  const maxContentChars = parseMaxContentCharsFlag(opts.maxContentChars);
 
   if (opts.check) {
     const result = await getOverviewInputsCheck(org.slug, { window, limit });
@@ -241,7 +274,7 @@ async function overviewInputsAction(
   const inputs = await getOverviewInputs(org.slug, { window, limit });
 
   if (opts.json) {
-    await writeJson(inputs);
+    await writeJson(clipInputsContent(inputs, maxContentChars));
     return;
   }
 
@@ -712,6 +745,10 @@ old — orchestrator should poll-and-fetch first).`,
       "--check",
       "Pre-flight only — return {selected, totalAvailable, hasExistingContent, wouldRegenerate}",
     )
+    .option(
+      "--max-content-chars [n]",
+      "With --json, clip each selected[].content to n chars before printing (bare: 1000)",
+    )
     .option("--json", "Output as JSON (recommended for agent consumption)")
     .addHelpText(
       "after",
@@ -720,11 +757,21 @@ Examples:
   releases admin overview inputs vercel --json
   releases admin overview inputs vercel --check --json
   releases admin overview inputs vercel --window 30 --json
+  releases admin overview inputs sentry --json --max-content-chars 1000
 
 Use --check to decide whether to dispatch a regen sub-agent without paying for
 the full release-content + media payload. Otherwise feed the JSON to the
 generator described in the \`regenerating-overviews\` skill, then upload the
-result with \`releases admin overview update\`.`,
+result with \`releases admin overview update\`.
+
+--max-content-chars clips each selected release body to n characters (bare flag
+defaults to 1000) before the JSON is printed, leaving every other field intact
+and never dropping a release. High-volume orgs (e.g. sentry, wordpress) emit
+500K+ chars of full release content here; when an agent runs this via Bash that
+exceeds the ~30K stdout cap and is silently truncated before the model sees it,
+so the overview gets generated from only the first few releases. The clip
+happens client-side — the CLI still receives the full payload over the wire —
+so it removes that footgun without a multi-step jq workaround.`,
     )
     .action(overviewInputsAction);
 

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -19,6 +19,24 @@ export function parsePositiveIntFlag(label: string, raw: string | undefined): nu
   return n;
 }
 
+/** Bare-flag default for `--max-content-chars` — matches the per-release clip
+ * the `regenerating-overviews` generation step applies anyway, so nothing
+ * useful is lost for the overview use case. */
+export const MAX_CONTENT_CHARS_DEFAULT = 1000;
+
+/**
+ * Resolve the `--max-content-chars [n]` option for `overview inputs --json`.
+ * Commander hands us `undefined` when the flag is omitted, the boolean `true`
+ * when it's passed bare (→ {@link MAX_CONTENT_CHARS_DEFAULT}), or the raw string
+ * when given a value (→ parsed as a positive integer, exiting 2 on bad input).
+ * `false` can't occur for an optional-value option but is handled as omitted.
+ */
+export function parseMaxContentCharsFlag(raw: string | boolean | undefined): number | undefined {
+  if (raw === undefined || raw === false) return undefined;
+  if (raw === true) return MAX_CONTENT_CHARS_DEFAULT;
+  return parsePositiveIntFlag("max-content-chars", raw);
+}
+
 /**
  * Parse a non-negative-integer CLI flag value (0 is allowed). Returns
  * `undefined` if the option was not provided. Exits with code 2 on invalid

--- a/tests/cli/overview-subcommands.test.ts
+++ b/tests/cli/overview-subcommands.test.ts
@@ -52,6 +52,13 @@ describe("admin overview subcommand group", () => {
     expect(stdout).toContain("Pre-flight only");
   });
 
+  it("`overview inputs --help` documents --max-content-chars and the Bash-stdout-cap motivation", () => {
+    const { stdout, exitCode } = runCli(["admin", "overview", "inputs", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--max-content-chars");
+    expect(stdout).toContain("stdout cap");
+  });
+
   it("`overview update --help` requires --content-file", () => {
     const { stdout, exitCode } = runCli(["admin", "overview", "update", "--help"]);
     expect(exitCode).toBe(0);

--- a/tests/unit/flags.test.ts
+++ b/tests/unit/flags.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, spyOn } from "bun:test";
 import {
   parsePositiveIntFlag,
   parseNonNegIntFlag,
+  parseMaxContentCharsFlag,
+  MAX_CONTENT_CHARS_DEFAULT,
   coerceMetadataValue,
   parseMetadataSetFlag,
   parseTimeWindowFlag,
@@ -88,6 +90,36 @@ describe("parseNonNegIntFlag", () => {
   it("rejects a negative integer", () => {
     withExitTrap(() => {
       expect(() => parseNonNegIntFlag("offset", "-1")).toThrow("process.exit called");
+    });
+  });
+});
+
+describe("parseMaxContentCharsFlag", () => {
+  it("returns undefined when the flag is omitted", () => {
+    expect(parseMaxContentCharsFlag(undefined)).toBeUndefined();
+  });
+
+  it("treats false (optional-value not present, no bare) as omitted", () => {
+    expect(parseMaxContentCharsFlag(false)).toBeUndefined();
+  });
+
+  it("uses the bare default when passed without a value (true)", () => {
+    expect(parseMaxContentCharsFlag(true)).toBe(MAX_CONTENT_CHARS_DEFAULT);
+  });
+
+  it("parses an explicit positive integer string", () => {
+    expect(parseMaxContentCharsFlag("500")).toBe(500);
+  });
+
+  it("rejects zero", () => {
+    withExitTrap(() => {
+      expect(() => parseMaxContentCharsFlag("0")).toThrow("process.exit called");
+    });
+  });
+
+  it("rejects a decimal string", () => {
+    withExitTrap(() => {
+      expect(() => parseMaxContentCharsFlag("1.5")).toThrow("process.exit called");
     });
   });
 });

--- a/tests/unit/overview-clip-inputs.test.ts
+++ b/tests/unit/overview-clip-inputs.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "bun:test";
+import { clipInputsContent } from "../../src/cli/commands/admin/overview.js";
+import type { OverviewInputs, OverviewInputRelease } from "../../src/api/client.js";
+
+function release(overrides: Partial<OverviewInputRelease> = {}): OverviewInputRelease {
+  return {
+    id: "rel_1",
+    version: "1.0.0",
+    title: "Example release",
+    content: "x".repeat(5000),
+    publishedAt: "2026-05-25T00:00:00Z",
+    url: "https://example.com/r/1",
+    media: [],
+    ...overrides,
+  };
+}
+
+function inputs(selected: OverviewInputRelease[]): OverviewInputs {
+  return {
+    org: { id: "org_1", slug: "example", name: "Example", description: null },
+    sources: [],
+    existingContent: "Prior overview body that should never be clipped.",
+    selected,
+    totalAvailable: selected.length,
+    windowDays: 90,
+  };
+}
+
+describe("clipInputsContent", () => {
+  it("returns the input unchanged (same reference) when maxContentChars is undefined", () => {
+    const original = inputs([release()]);
+    expect(clipInputsContent(original, undefined)).toBe(original);
+  });
+
+  it("clips each selected[].content to at most n characters", () => {
+    const result = clipInputsContent(inputs([release(), release({ id: "rel_2" })]), 1000);
+    expect(result.selected).toHaveLength(2);
+    for (const r of result.selected) {
+      expect(r.content.length).toBe(1000);
+    }
+  });
+
+  it("leaves content shorter than n untouched", () => {
+    const short = release({ content: "tiny" });
+    const result = clipInputsContent(inputs([short]), 1000);
+    expect(result.selected[0]?.content).toBe("tiny");
+  });
+
+  it("never drops a release — selected length is preserved", () => {
+    const list = [release({ id: "a" }), release({ id: "b" }), release({ id: "c" })];
+    const result = clipInputsContent(inputs(list), 100);
+    expect(result.selected.map((r) => r.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("leaves every non-content field intact (url/title/version/publishedAt/media)", () => {
+    const r = release({ media: [{ url: "https://example.com/a.png", type: "image" }] as never });
+    const [out] = clipInputsContent(inputs([r]), 10).selected;
+    expect(out?.url).toBe(r.url);
+    expect(out?.title).toBe(r.title);
+    expect(out?.version).toBe(r.version);
+    expect(out?.publishedAt).toBe(r.publishedAt);
+    expect(out?.media).toEqual(r.media);
+  });
+
+  it("leaves existingContent (the prior overview) untouched", () => {
+    const original = inputs([release()]);
+    const result = clipInputsContent(original, 5);
+    expect(result.existingContent).toBe(original.existingContent);
+  });
+
+  it("does not mutate the input payload", () => {
+    const original = inputs([release()]);
+    clipInputsContent(original, 10);
+    expect(original.selected[0]?.content.length).toBe(5000);
+  });
+});


### PR DESCRIPTION
## What

Adds `--max-content-chars [n]` to `releases admin overview inputs`. In `--json` mode it clips each `selected[].content` to at most `n` characters **client-side, before printing** (bare flag defaults to `1000`). Omitting the flag preserves today's full-content output.

Closes #233.

## Why

`overview inputs <slug> --json` prints the full release body for every selected release. High-volume orgs are enormous here — sentry is ~602K chars with a single ~125K-char `getsentry/sentry` tag note; wordpress ~478K. When a Claude Code **sub-agent** runs this via Bash, the output blows past the agent's ~30K stdout cap and is **silently truncated** before the model sees it, so the overview gets generated from only the first few releases. This bit the 2026-05-25 regen sweep (sentry/wordpress came back with fewer citations until redone from a complete read).

The clip is purely client-side — the CLI still receives the full payload over the wire (the wire isn't subject to the Bash cap; only stdout is) — so it removes the footgun and makes the skill-level `jq` workaround optional.

## Scope

- Clips only `selected[].content`. `existingContent` (the prior overview, bounded) is left intact, as are `media`, `totalAvailable`, `url`/`title`/`version`/`publishedAt`.
- Never drops a release — `selected` length is unchanged.
- Applies in `--json` mode only; the human table output doesn't print bodies, so it's unaffected.
- `--help` documents the flag and the Bash-stdout-cap motivation.
- Bare flag (`--max-content-chars` with no value) defaults to `1000`, matching the per-release clip the `regenerating-overviews` generation step applies anyway.

## Prior art check

Confirmed this was never supported before: a full-history `-S` pickaxe for `max-content-chars` / `maxContentChars` / `clip` / `truncate` / `content-limit` finds nothing on `overview inputs`, and the monorepo `/v1/orgs/:slug/overview/inputs` endpoint has no server-side content cap. The familiar bit is the slim-`--json` + `--full` rework (#215/#220), which added content-trimming JSON projectors for `release`/`search`/`latest` only — it never reached `overview inputs`.

## Acceptance criteria

- [x] `overview inputs <slug> --json --max-content-chars <n>` clips every `selected[].content` to ≤ `n` with all other fields intact (verified live: sentry 124,998 → 1000, `totalAvailable`/`existingContent`/`media` preserved).
- [x] Omitting the flag preserves full-content output.
- [x] `selected` length unchanged (46 before and after on sentry).
- [x] `--help` documents the flag + the stdout-cap motivation.

## Tests

- `parseMaxContentCharsFlag` unit tests (omitted/bare-default/explicit/reject-zero/reject-decimal).
- `clipInputsContent` unit tests (no-op when undefined, clips to n, leaves short content, preserves length/media/other fields/existingContent, no mutation).
- `--help` assertion for `--max-content-chars` + the stdout-cap copy.
- Live smoke against sentry + wordpress; full suite 598 pass / 0 fail; tsc, oxlint, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--max-content-chars [n]` option to the `admin overview inputs` command for truncating content in JSON output (defaults to 1,000 characters when used without a value). Other fields remain unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/buildinternet/releases-cli/pull/234?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->