### PR TITLE
ci: restrict Claude Code workflow to write-access users

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,11 +12,33 @@ on:
 
 jobs:
   claude:
+    # Gate on author_association so only people with write access can summon
+    # the agent. Without this, any commenter — including a first-time external
+    # contributor on their own PR — could trigger a run and burn the Anthropic
+    # OAuth credential exposed to this job. OWNER/MEMBER/COLLABORATOR are the
+    # write-access tiers GitHub reports; CONTRIBUTOR/FIRST_TIME_CONTRIBUTOR/NONE
+    # are filtered out. The association field differs per event type.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (
+        github.event_name == 'issue_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+      ) ||
+      (
+        github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+      ) ||
+      (
+        github.event_name == 'pull_request_review' &&
+        contains(github.event.review.body, '@claude') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)
+      ) ||
+      (
+        github.event_name == 'issues' &&
+        (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association)
+      )
     runs-on: ubuntu-latest
     # Agent runs are open-ended; cap them so a wedged session can't sit on a
     # runner for the 6h default.


### PR DESCRIPTION
## What

Gate the `Claude Code` workflow (`.github/workflows/claude.yml`) on `author_association` so only repo members with write access (`OWNER` / `MEMBER` / `COLLABORATOR`) can trigger an agent run.

## Why

The job's `if:` only checked that a comment / issue / review body contains `@claude` — it never checked **who** sent it. Because `issue_comment`, `pull_request_review*`, and `issues` events run in the base-repo context with repo secrets, **any commenter — including a first-time external contributor on their own PR — could summon the agent** and consume the `CLAUDE_CODE_OAUTH_TOKEN` (Anthropic credits) exposed to the job.

Blast radius is already bounded by the job's read-only `permissions:` (it can't push or merge), but the credential exposure and letting untrusted users spend Anthropic budget are worth closing.

## What changed

Each branch of the existing `@claude` trigger now also requires the actor to be `OWNER`, `MEMBER`, or `COLLABORATOR`, using the association field that matches each event type:

- `issue_comment` / `pull_request_review_comment` → `github.event.comment.author_association`
- `pull_request_review` → `github.event.review.author_association`
- `issues` → `github.event.issue.author_association`

`CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, and `NONE` are filtered out.

## Safety / injection check

The untrusted fields (`*.body`, `issue.title`) are read only inside the `if:` **expression context** via `contains()` — never interpolated into a `run:` shell command — so this introduces no command-injection surface. `author_association` is a GitHub-controlled enum, not free text. The change strictly narrows the trigger surface.

## Notes

- **No changeset** — workflow-only change with no published-package impact (CI has no changeset gate).
- The monorepo `buildinternet/releases` `.github/workflows/claude.yml` is byte-identical and has the same gap; worth the same fix in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
