### PR TITLE
feat(cli): keyless `submit` command + admin recommendations review

### DIFF
--- a/.changeset/cli-submit-recommendation.md
+++ b/.changeset/cli-submit-recommendation.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": minor
+---
+
+Add a keyless `releases submit <url>` command to suggest a changelog or release-notes source for the registry — the terminal peer of the web submit form. Accepts an optional `--note` and `--contact`, normalizes a missing scheme to `https://`, and supports interactive/stdin input plus `--dry-run`. Maintainers review the queue via the new `releases admin recommendations list/triage/archive/delete` verbs, mirroring the existing `admin feedback` triage surface.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ releases get vercel                      # org, product, or source
 releases get org_abc123                  # typed IDs are accepted
 releases org overview vercel             # full AI-generated overview for an org
 releases stats
+releases submit https://acme.dev/changelog        # suggest a source for the registry
 releases feedback "great tool, here's an idea…"   # send feedback to the maintainers
 ```
 
@@ -102,6 +103,21 @@ releases feedback "draft" --dry-run --json                    # preview the payl
 ```
 
 With no message argument in an interactive terminal, `feedback` prompts for the text (and an optional contact); otherwise pass it inline or pipe via stdin. `--type` accepts `bug`, `idea`, or `other`. Maintainers with admin access review submissions via `releases admin feedback list` (filter by `--type` / `--status`, `--include-archived`, paginate with `--cursor`) and triage them: `releases admin feedback triage <id> --status closed`, `releases admin feedback archive <id>` (`--undo` to restore), and `releases admin feedback delete <id>` (permanent — type the id to confirm, or pass `--yes`).
+
+### Submit a source
+
+Suggest a changelog or release-notes URL for the registry — the same review queue the [web submit form](https://releases.sh/submit) feeds. No API key or account required:
+
+```bash
+releases submit https://acme.dev/changelog                       # one-shot
+releases submit acme.dev/changelog                               # scheme optional — https:// is assumed
+releases submit                                                  # prompt for the URL (interactive)
+echo "https://acme.dev/releases" | releases submit               # pipe from stdin
+releases submit https://acme.dev/changelog --note "GitHub: acme/acme" --contact you@example.com
+releases submit https://acme.dev/changelog --dry-run --json      # preview the payload, send nothing
+```
+
+Index pages, changelogs, GitHub releases, and feed URLs are all ideal. `--note` carries extra context (product name, GitHub repo, feed quirks) and `--contact` is an optional email to notify once it's reviewed. With no URL argument in an interactive terminal, `submit` prompts for it (and the optional note/contact); otherwise pass it inline or pipe via stdin. Maintainers with admin access review the queue via `releases admin recommendations list` (filter by `--status` / `--type`, `--include-archived`, paginate with `--cursor`) and triage them: `releases admin recommendations triage <id> --status closed`, `releases admin recommendations archive <id>` (`--undo` to restore), and `releases admin recommendations delete <id>` (permanent — type the id to confirm, or pass `--yes`).
 
 ### MCP
 

--- a/skills/releases-cli/SKILL.md
+++ b/skills/releases-cli/SKILL.md
@@ -50,6 +50,10 @@ Two commands built for agents specifically:
 
 `releases get <source> --json` reports `hasChangelogFile` and the `changelogUrl` keyless, so you can tell whether a source maintains a checked-in CHANGELOG.md. To read the **sliced content** keyless, use the MCP's `get_catalog_entry` (with `changelog_tokens` / `nextOffset`) or fetch the `changelogUrl` directly — the CLI's `releases admin source changelog` wrapper is key-gated and won't run without auth.
 
+### Submitting a source (keyless)
+
+`releases submit <url>` suggests a changelog or release-notes URL for the registry — the same review queue the [web submit form](https://releases.sh/submit) feeds, no key required. Scheme is optional (`https://` assumed); `--note` adds context and `--contact` an optional reply email. With no argument in a TTY it prompts; it also reads a piped URL from stdin. Its sibling `releases feedback "<message>"` sends product feedback the same keyless way. Maintainers triage submissions under the key-gated `releases admin recommendations …` (see the admin reference).
+
 ## Common Mistakes
 
 - `releases list` lists sources (alias `releases sources`). Do NOT write `releases sources list` — it reads `list` as a source slug and fails with "Source not found: list".

--- a/skills/releases-cli/references/admin.md
+++ b/skills/releases-cli/references/admin.md
@@ -211,3 +211,19 @@ releases admin mcp serve
 ```
 
 Useful for clients that only support stdio transport. For native remote MCP support (Claude Code, Codex), connect directly to `https://mcp.releases.sh/mcp` instead.
+
+## Recommendations
+
+Review and triage the source URLs that users submit keyless via `releases submit` (and the [web submit form](https://releases.sh/submit)). The submit side needs no key; only the review verbs below do.
+
+```bash
+releases admin recommendations list                          # newest first
+releases admin recommendations list --status new --type source
+releases admin recommendations list --include-archived --cursor <cursor>
+releases admin recommendations triage <id> --status closed   # new | triaged | closed
+releases admin recommendations archive <id>                  # hide from default list
+releases admin recommendations archive <id> --undo           # restore
+releases admin recommendations delete <id>                   # permanent — type the id to confirm, or --yes
+```
+
+`list` is cursor-paginated (`--limit`, follow `--cursor` from the previous page) and hides archived rows unless `--include-archived` is passed. Prefer `archive` over `delete` for a reversible removal. Recommendation ids are `rec_…`. Mirrors the `releases admin feedback …` triage surface.

--- a/skills/releases-cli/references/reader.md
+++ b/skills/releases-cli/references/reader.md
@@ -132,6 +132,21 @@ releases lookup domain vercel.com
 releases lookup domain https://tailwindcss.com/blog
 ```
 
+## Submit a source
+
+Suggest a changelog or release-notes URL for the registry (keyless — no account or key). This feeds the same review queue as the [web submit form](https://releases.sh/submit); maintainers triage it under the key-gated `releases admin recommendations …`.
+
+```bash
+releases submit https://acme.dev/changelog                  # one-shot
+releases submit acme.dev/changelog                          # scheme optional — https:// is assumed
+releases submit                                             # prompt for the URL (interactive)
+echo "https://acme.dev/releases" | releases submit          # pipe from stdin
+releases submit https://acme.dev/changelog --note "GitHub: acme/acme" --contact you@example.com
+releases submit https://acme.dev/changelog --dry-run --json # preview the payload, send nothing
+```
+
+`--note` carries extra context (product name, GitHub repo, feed quirks); `--contact` is an optional email to notify once it's reviewed. With no URL argument in an interactive terminal, `submit` prompts for the URL (and the optional note/contact); otherwise pass it inline or pipe via stdin. Index pages, changelogs, GitHub releases, and feed URLs are all ideal.
+
 ## Agent self-discovery
 
 ```bash

--- a/src/cli/commands/recommend.ts
+++ b/src/cli/commands/recommend.ts
@@ -1,0 +1,401 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { createInterface } from "node:readline/promises";
+import { getApiUrl } from "../../lib/mode.js";
+import { writeJson } from "../../lib/output.js";
+import { RELEASES_CLI_UA } from "../../lib/user-agent.js";
+import { apiFetch } from "../../api/client.js";
+import { stripAnsi } from "../../lib/sanitize.js";
+import { promptConfirm } from "../../lib/confirm.js";
+import { logger } from "@releases/lib/logger";
+
+const MAX_URL = 2048;
+const MAX_NOTE = 4000;
+const MAX_CONTACT = 200;
+const POST_TIMEOUT_MS = 10_000;
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export type ValidateUrlResult = { ok: true; url: string } | { ok: false; error: string };
+
+/**
+ * Validate and normalize a submitted URL. Mirrors the API's
+ * normalizeSubmittedUrl (workers/api/src/routes/recommendations.ts): a missing
+ * scheme defaults to https, and only http(s) is accepted. Returning the
+ * normalized form gives the operator queue a consistent value to dedupe on.
+ */
+export function validateUrl(raw: string): ValidateUrlResult {
+  const trimmed = raw.trim();
+  if (!trimmed) return { ok: false, error: "Enter a release notes URL." };
+  if (trimmed.length > MAX_URL) {
+    return { ok: false, error: `URL is too long (max ${MAX_URL} chars).` };
+  }
+  const withScheme = /^[a-z][a-z0-9+.-]*:/i.test(trimmed) ? trimmed : `https://${trimmed}`;
+  let url: URL;
+  try {
+    url = new URL(withScheme);
+  } catch {
+    return { ok: false, error: "That doesn't look like a valid URL." };
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    return { ok: false, error: "URL must start with http:// or https://." };
+  }
+  if (!url.hostname) return { ok: false, error: "That doesn't look like a valid URL." };
+  return { ok: true, url: url.toString() };
+}
+
+export interface RecommendationPayload {
+  type: "source";
+  url: string;
+  note?: string;
+  contactEmail?: string;
+  surface: "cli";
+}
+
+export function buildRecommendationPayload(
+  url: string,
+  opts: { note?: string; contact?: string },
+): RecommendationPayload {
+  const note = opts.note?.trim();
+  const contactEmail = opts.contact?.trim();
+  return {
+    type: "source",
+    url,
+    note: note || undefined,
+    contactEmail: contactEmail || undefined,
+    surface: "cli",
+  };
+}
+
+async function resolveUrl(arg: string | undefined): Promise<string | null> {
+  if (arg && arg.trim()) return arg;
+  if (!process.stdin.isTTY) {
+    const piped = (await Bun.stdin.text()).trim();
+    return piped.length ? piped : null;
+  }
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  try {
+    const answer = await rl.question(
+      chalk.bold("Release notes URL? ") + chalk.dim("(blank to cancel)\n> "),
+    );
+    return answer.trim().length ? answer : null;
+  } finally {
+    rl.close();
+  }
+}
+
+/**
+ * Resolve an optional field: use the provided flag value if present, otherwise
+ * prompt in an interactive terminal, otherwise skip. Returns undefined when
+ * nothing is supplied. Non-TTY callers never block on input.
+ */
+async function resolveOptional(
+  label: string,
+  provided: string | undefined,
+): Promise<string | undefined> {
+  if (provided !== undefined) return provided.trim() || undefined;
+  if (!process.stdin.isTTY) return undefined;
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  try {
+    const answer = await rl.question(chalk.dim(`${label} (optional, blank to skip)\n> `));
+    return answer.trim().length ? answer.trim() : undefined;
+  } finally {
+    rl.close();
+  }
+}
+
+export function submitErrorMessage(error: string | undefined, status: number): string {
+  switch (error) {
+    case "url_required":
+      return "That URL was rejected — provide a valid http(s) URL.";
+    case "invalid_email":
+      return "The contact email looks invalid — fix it or omit --contact.";
+    case "rate_limited":
+      return "Too many submissions. Please try again in a minute.";
+    case "recommendations_disabled":
+      return "Submissions are temporarily disabled. Please try again later.";
+    case "payload_too_large":
+      return "That submission is too large.";
+    default:
+      return `server returned ${status}`;
+  }
+}
+
+async function postRecommendation(
+  payload: RecommendationPayload,
+): Promise<{ ok: true; id: string } | { ok: false; error: string }> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), POST_TIMEOUT_MS);
+  try {
+    const res = await fetch(`${getApiUrl()}/v1/recommendations`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "User-Agent": RELEASES_CLI_UA },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+    const json = (await res.json().catch(() => null)) as {
+      ok?: boolean;
+      id?: string;
+      error?: string;
+    } | null;
+    if (!res.ok) return { ok: false, error: submitErrorMessage(json?.error, res.status) };
+    if (!json?.ok || !json.id) return { ok: false, error: "unexpected response" };
+    return { ok: true, id: json.id };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export function registerSubmitCommand(parent: Command): void {
+  parent
+    .command("submit")
+    .description("Suggest a changelog or release-notes URL for the registry")
+    .argument("[url]", "Release notes URL (omit to type interactively or pipe via stdin)")
+    .option("--note <text>", "Extra context: product name, GitHub repo, or feed quirks")
+    .option("--contact <email>", "Email to notify once it's reviewed (optional)")
+    .option("--json", "Output as JSON")
+    .option("--dry-run", "Print the payload without sending")
+    .action(
+      async (
+        urlArg: string | undefined,
+        opts: { note?: string; contact?: string; json?: boolean; dryRun?: boolean },
+      ) => {
+        const raw = await resolveUrl(urlArg);
+        if (raw === null) {
+          logger.info(chalk.dim("Cancelled — nothing submitted."));
+          process.exit(0);
+        }
+        const validated = validateUrl(raw);
+        if (!validated.ok) {
+          logger.error(validated.error);
+          process.exit(1);
+        }
+
+        const note = await resolveOptional("Additional info", opts.note);
+        if (note && note.length > MAX_NOTE) {
+          logger.error(`Note is too long (max ${MAX_NOTE} chars).`);
+          process.exit(1);
+        }
+        const contact = await resolveOptional("Contact email", opts.contact);
+        if (contact && (contact.length > MAX_CONTACT || !EMAIL_PATTERN.test(contact))) {
+          logger.error("That contact email looks invalid — fix it or omit --contact.");
+          process.exit(1);
+        }
+
+        const payload = buildRecommendationPayload(validated.url, { note, contact });
+
+        if (opts.dryRun) {
+          if (opts.json) await writeJson({ dryRun: true, payload });
+          else logger.info(chalk.dim("[dry-run] would POST:\n") + JSON.stringify(payload, null, 2));
+          return;
+        }
+
+        const result = await postRecommendation(payload);
+        if (result.ok) {
+          if (opts.json) await writeJson({ ok: true, id: result.id });
+          else
+            logger.info(
+              chalk.green("Thanks — your suggestion is in the review queue ") +
+                chalk.dim(`(id: ${result.id})`),
+            );
+          return;
+        }
+        if (opts.json) await writeJson({ ok: false, error: result.error });
+        else logger.error(`Couldn't submit the URL: ${result.error}`);
+        process.exit(1);
+      },
+    );
+}
+
+// Mirrors the API's RECOMMENDATION_STATUSES / RECOMMENDATION_TYPES (packages/core
+// schema). When @buildinternet/releases-api-types ships the recommendation
+// shapes, these locals can be replaced by its exports.
+const RECOMMENDATION_STATUSES = ["new", "triaged", "closed"] as const;
+const RECOMMENDATION_STATUSES_SET = new Set<string>(RECOMMENDATION_STATUSES);
+
+interface RecommendationRow {
+  id: string;
+  createdAt: number;
+  type: string;
+  url: string;
+  note: string | null;
+  contactEmail: string | null;
+  status: string;
+  archived?: boolean;
+  surface?: string;
+}
+interface RecommendationListResponse {
+  items: RecommendationRow[];
+  nextCursor: string | null;
+}
+
+/**
+ * Translate apiFetch's thrown error into a clean CLI failure. A 404 on a write
+ * becomes a short "not found"; anything else surfaces the API message rather
+ * than a stack trace. Always exits non-zero.
+ */
+function failFromApiError(err: unknown, id: string): never {
+  const msg = err instanceof Error ? err.message : String(err);
+  if (msg.includes("(404)")) {
+    logger.error(`No recommendation found with id ${id}.`);
+  } else {
+    logger.error(msg);
+  }
+  process.exit(1);
+}
+
+export function registerRecommendationAdminCommand(parent: Command): void {
+  const cmd = parent
+    .command("recommendations")
+    .description("Inspect and triage submitted source recommendations");
+
+  cmd
+    .command("list")
+    .description("List submitted recommendations (newest first)")
+    .option("--status <status>", "Filter by status: new | triaged | closed")
+    .option("--type <type>", "Filter by type: source")
+    .option("--include-archived", "Include archived rows (hidden by default)")
+    .option("--limit <n>", "Max rows (default 50)")
+    .option("--cursor <cursor>", "Pagination cursor from a previous page")
+    .option("--json", "Output as JSON")
+    .action(
+      async (opts: {
+        status?: string;
+        type?: string;
+        includeArchived?: boolean;
+        limit?: string;
+        cursor?: string;
+        json?: boolean;
+      }) => {
+        const qs = new URLSearchParams();
+        if (opts.status) qs.set("status", opts.status);
+        if (opts.type) qs.set("type", opts.type);
+        if (opts.includeArchived) qs.set("includeArchived", "true");
+        if (opts.limit) qs.set("limit", opts.limit);
+        if (opts.cursor) qs.set("cursor", opts.cursor);
+        const data = await apiFetch<RecommendationListResponse>(
+          `/v1/admin/recommendations${qs.size ? `?${qs}` : ""}`,
+        );
+
+        if (opts.json) {
+          await writeJson(data);
+          return;
+        }
+        if (!data.items.length) {
+          logger.info(chalk.dim("No recommendations yet."));
+          return;
+        }
+        for (const r of data.items) {
+          const when = new Date(r.createdAt).toISOString().slice(0, 16).replace("T", " ");
+          const archived = r.archived ? chalk.yellow(" [archived]") : "";
+          const head = `${chalk.bold(r.id)}  ${chalk.dim(when)}  ${chalk.cyan(r.type)}/${r.status}${archived}`;
+          const contact = r.contactEmail ? chalk.dim(` <${stripAnsi(r.contactEmail)}>`) : "";
+          logger.info(`${head}${contact}`);
+          // Defense-in-depth: the API strips control chars at ingest; stripAnsi
+          // here protects the operator's terminal from any pre-existing rows.
+          logger.info(`  ${chalk.underline(stripAnsi(r.url))}`);
+          if (r.note) {
+            logger.info(`  ${chalk.dim(stripAnsi(r.note).replace(/\s+/g, " ").slice(0, 200))}`);
+          }
+        }
+        if (data.nextCursor) {
+          logger.info(
+            chalk.dim(`More: releases admin recommendations list --cursor ${data.nextCursor}`),
+          );
+        }
+      },
+    );
+
+  cmd
+    .command("triage")
+    .description("Set the triage status of a recommendation")
+    .argument("<id>", "Recommendation id (rec_…)")
+    .requiredOption("--status <status>", "new | triaged | closed")
+    .option("--json", "Output as JSON")
+    .action(async (id: string, opts: { status: string; json?: boolean }) => {
+      if (!RECOMMENDATION_STATUSES_SET.has(opts.status)) {
+        logger.error(`--status must be one of: ${RECOMMENDATION_STATUSES.join(", ")}`);
+        process.exit(1);
+      }
+      let updated: RecommendationRow;
+      try {
+        updated = await apiFetch<RecommendationRow>(
+          `/v1/recommendations/${encodeURIComponent(id)}`,
+          {
+            method: "PATCH",
+            body: JSON.stringify({ status: opts.status }),
+          },
+        );
+      } catch (err) {
+        failFromApiError(err, id);
+      }
+      if (opts.json) {
+        await writeJson(updated);
+        return;
+      }
+      logger.info(chalk.green(`Set ${chalk.bold(updated.id)} → status ${updated.status}`));
+    });
+
+  cmd
+    .command("archive")
+    .description("Archive a recommendation (hide it from the default list); --undo to restore")
+    .argument("<id>", "Recommendation id (rec_…)")
+    .option("--undo", "Restore an archived row instead of archiving it")
+    .option("--json", "Output as JSON")
+    .action(async (id: string, opts: { undo?: boolean; json?: boolean }) => {
+      const archived = !opts.undo;
+      let updated: RecommendationRow;
+      try {
+        updated = await apiFetch<RecommendationRow>(
+          `/v1/recommendations/${encodeURIComponent(id)}`,
+          {
+            method: "PATCH",
+            body: JSON.stringify({ archived }),
+          },
+        );
+      } catch (err) {
+        failFromApiError(err, id);
+      }
+      if (opts.json) {
+        await writeJson(updated);
+        return;
+      }
+      logger.info(chalk.green(`${archived ? "Archived" : "Restored"} ${chalk.bold(updated.id)}`));
+    });
+
+  cmd
+    .command("delete")
+    .description("Permanently delete a recommendation (prefer `archive` for a reversible removal)")
+    .argument("<id>", "Recommendation id (rec_…)")
+    .option("-y, --yes", "Skip the confirmation prompt (required in non-interactive contexts)")
+    .option("--json", "Output as JSON")
+    .action(async (id: string, opts: { yes?: boolean; json?: boolean }) => {
+      if (!opts.yes) {
+        const confirmed = await promptConfirm(
+          `Type the recommendation id to permanently delete it (${id}): `,
+          id,
+        );
+        if (!confirmed) {
+          logger.error(
+            "Delete cancelled — id not confirmed. Pass --yes to skip the prompt in scripts.",
+          );
+          process.exit(1);
+        }
+      }
+      let result: { deleted: boolean; id: string };
+      try {
+        result = await apiFetch<{ deleted: boolean; id: string }>(
+          `/v1/recommendations/${encodeURIComponent(id)}`,
+          { method: "DELETE" },
+        );
+      } catch (err) {
+        failFromApiError(err, id);
+      }
+      if (opts.json) {
+        await writeJson(result);
+        return;
+      }
+      logger.info(chalk.green(`Deleted ${chalk.bold(result.id)}`));
+    });
+}

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -38,6 +38,7 @@ import { registerOverviewCommands } from "./commands/admin/overview.js";
 import { registerWorkCommands } from "./commands/admin/work.js";
 import { registerTelemetryCommand } from "./commands/telemetry.js";
 import { registerFeedbackCommand, registerFeedbackAdminCommand } from "./commands/feedback.js";
+import { registerSubmitCommand, registerRecommendationAdminCommand } from "./commands/recommend.js";
 import { registerServeCommand } from "./commands/serve.js";
 import { registerWhoamiCommand } from "./commands/whoami.js";
 import { registerWebhookCommand } from "./commands/webhook.js";
@@ -225,6 +226,7 @@ registerShowCommand(program);
 registerCollectionReadCommands(program);
 registerTelemetryCommand(program);
 registerFeedbackCommand(program);
+registerSubmitCommand(program);
 registerWhoamiCommand(program);
 registerAuthCommand(program);
 registerAgentContextCommand(program);
@@ -292,6 +294,7 @@ registerServeCommand(mcpAdmin);
 
 registerWebhookCommand(admin);
 registerFeedbackAdminCommand(admin);
+registerRecommendationAdminCommand(admin);
 
 gateAdminSubtree(admin);
 

--- a/tests/cli/recommend.test.ts
+++ b/tests/cli/recommend.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "bun:test";
+import { runCli } from "../utils.js";
+
+/**
+ * Integration coverage for the public `releases submit` command and the
+ * `releases admin recommendations` review write-path. runCli spawns the CLI
+ * with piped stdio, so `process.stdin.isTTY` is false in the child. We assert
+ * the guard rails that fire BEFORE any network call — `--dry-run`, invalid
+ * input, the required-status check, and the destructive-delete confirmation
+ * gate — plus that the verbs and flags surface in --help.
+ */
+describe("submit (public CLI integration)", () => {
+  it("documents the command and its flags in help", () => {
+    const { stdout, exitCode } = runCli(["submit", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--note");
+    expect(stdout).toContain("--contact");
+    expect(stdout).toContain("--dry-run");
+  });
+
+  it("previews the payload with --dry-run --json and sends nothing", () => {
+    const { stdout, exitCode } = runCli([
+      "submit",
+      "https://example.com/releases",
+      "--note",
+      "GitHub: acme/acme",
+      "--dry-run",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout) as {
+      dryRun: boolean;
+      payload: { url: string; type: string; surface: string; note?: string };
+    };
+    expect(parsed.dryRun).toBe(true);
+    expect(parsed.payload.url).toBe("https://example.com/releases");
+    expect(parsed.payload.type).toBe("source");
+    expect(parsed.payload.surface).toBe("cli");
+    expect(parsed.payload.note).toBe("GitHub: acme/acme");
+  });
+
+  it("rejects an invalid url before any request", () => {
+    const { stderr, exitCode } = runCli(["submit", "ftp://example.com/releases"]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr.toLowerCase()).toContain("url");
+  });
+
+  it("rejects an invalid --contact email before any request", () => {
+    const { stderr, exitCode } = runCli([
+      "submit",
+      "https://example.com/releases",
+      "--contact",
+      "notanemail",
+    ]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr.toLowerCase()).toContain("email");
+  });
+
+  it("rejects a --note longer than the cap before any request", () => {
+    const { stderr, exitCode } = runCli([
+      "submit",
+      "https://example.com/releases",
+      "--note",
+      "x".repeat(4001),
+    ]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr.toLowerCase()).toContain("too long");
+  });
+
+  it("reads the URL from stdin when no argument is given", () => {
+    const { stdout, exitCode } = runCli(["submit", "--dry-run", "--json"], {
+      input: "https://example.com/piped\n",
+    });
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout) as { payload: { url: string } };
+    expect(parsed.payload.url).toBe("https://example.com/piped");
+  });
+});
+
+describe("admin recommendations review write-path (CLI integration)", () => {
+  it("lists list / triage / archive / delete subcommands in help", () => {
+    const { stdout, exitCode } = runCli(["admin", "recommendations", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("list");
+    expect(stdout).toContain("triage");
+    expect(stdout).toContain("archive");
+    expect(stdout).toContain("delete");
+  });
+
+  it("requires --status on triage", () => {
+    const { stderr, exitCode } = runCli(["admin", "recommendations", "triage", "rec_x"]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr.toLowerCase()).toContain("status");
+  });
+
+  it("rejects an invalid triage status before any request", () => {
+    const { stderr, exitCode } = runCli([
+      "admin",
+      "recommendations",
+      "triage",
+      "rec_x",
+      "--status",
+      "bogus",
+    ]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("triaged");
+  });
+
+  it("refuses a hard delete without --yes when stdin is not a TTY", () => {
+    const { stderr, exitCode } = runCli(["admin", "recommendations", "delete", "rec_x"]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("--yes");
+  });
+
+  it("exposes --undo on archive and --yes on delete", () => {
+    const archiveHelp = runCli(["admin", "recommendations", "archive", "--help"]);
+    expect(archiveHelp.exitCode).toBe(0);
+    expect(archiveHelp.stdout).toContain("--undo");
+
+    const deleteHelp = runCli(["admin", "recommendations", "delete", "--help"]);
+    expect(deleteHelp.exitCode).toBe(0);
+    expect(deleteHelp.stdout).toContain("--yes");
+  });
+});

--- a/tests/unit/recommend.test.ts
+++ b/tests/unit/recommend.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "bun:test";
+import {
+  validateUrl,
+  buildRecommendationPayload,
+  submitErrorMessage,
+} from "../../src/cli/commands/recommend.js";
+
+describe("validateUrl", () => {
+  it("rejects an empty url", () => {
+    const r = validateUrl("   ");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.toLowerCase()).toContain("url");
+  });
+
+  it("rejects a non-http(s) scheme", () => {
+    const r = validateUrl("ftp://example.com/releases");
+    expect(r.ok).toBe(false);
+  });
+
+  it("rejects a string that is not a url", () => {
+    expect(validateUrl("not a url at all").ok).toBe(false);
+  });
+
+  it("accepts a full https url", () => {
+    expect(validateUrl("https://example.com/releases")).toEqual({
+      ok: true,
+      url: "https://example.com/releases",
+    });
+  });
+
+  it("adds https:// when the scheme is omitted", () => {
+    const r = validateUrl("example.com/changelog");
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.url).toBe("https://example.com/changelog");
+  });
+
+  it("rejects a url longer than 2048 chars", () => {
+    const r = validateUrl("https://example.com/" + "a".repeat(2100));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.toLowerCase()).toContain("long");
+  });
+});
+
+describe("buildRecommendationPayload", () => {
+  it("builds a source recommendation with the cli surface", () => {
+    const p = buildRecommendationPayload("https://example.com/releases", {});
+    expect(p.type).toBe("source");
+    expect(p.url).toBe("https://example.com/releases");
+    expect(p.surface).toBe("cli");
+    expect(p.note).toBeUndefined();
+    expect(p.contactEmail).toBeUndefined();
+  });
+
+  it("includes trimmed note and contact when provided", () => {
+    const p = buildRecommendationPayload("https://example.com/releases", {
+      note: "  GitHub: acme/acme  ",
+      contact: "  me@x.com  ",
+    });
+    expect(p.note).toBe("GitHub: acme/acme");
+    expect(p.contactEmail).toBe("me@x.com");
+  });
+
+  it("omits blank note and contact rather than sending empty strings", () => {
+    const p = buildRecommendationPayload("https://example.com/releases", {
+      note: "   ",
+      contact: "",
+    });
+    expect(p.note).toBeUndefined();
+    expect(p.contactEmail).toBeUndefined();
+  });
+});
+
+describe("submitErrorMessage", () => {
+  it("maps each known API error code to an operator-friendly message", () => {
+    expect(submitErrorMessage("url_required", 400)).toContain("URL");
+    expect(submitErrorMessage("invalid_email", 400).toLowerCase()).toContain("email");
+    expect(submitErrorMessage("rate_limited", 429).toLowerCase()).toContain("too many");
+    expect(submitErrorMessage("recommendations_disabled", 503).toLowerCase()).toContain("disabled");
+    expect(submitErrorMessage("payload_too_large", 413).toLowerCase()).toContain("too large");
+  });
+
+  it("falls back to the raw status for an unknown code", () => {
+    expect(submitErrorMessage("something_new", 500)).toBe("server returned 500");
+    expect(submitErrorMessage(undefined, 502)).toBe("server returned 502");
+  });
+});

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -6,7 +6,7 @@ const CLI_PATH = join(import.meta.dirname, "..", "src", "index.ts");
 
 export function runCli(
   args: string[],
-  options?: { env?: Record<string, string>; timeout?: number },
+  options?: { env?: Record<string, string>; timeout?: number; input?: string },
 ): { stdout: string; stderr: string; exitCode: number } {
   // OSS CLI is remote-only — a real-looking URL must be set so the CLI starts.
   // Commands that don't hit the API (e.g. `categories`) succeed without it.
@@ -21,6 +21,7 @@ export function runCli(
     stdio: ["pipe", "pipe", "pipe"],
     env: safeEnv,
     timeout: options?.timeout ?? 30_000,
+    input: options?.input,
   });
   return {
     stdout: stripAnsi(result.stdout ?? ""),


### PR DESCRIPTION
## Summary

Adds CLI support for submitting recommended sources to the registry — the terminal peer of the web submit form — plus an operator review surface. Modeled on the existing `feedback` command.

- **`releases submit <url>`** — public, **keyless** (no API key). POSTs to the open `/v1/recommendations` endpoint with `type: source`, `surface: cli`. Scheme is optional (`acme.dev/changelog` → `https://…`); supports `--note`, `--contact`, interactive prompts, stdin, `--json`, and `--dry-run`.
- **`releases admin recommendations list | triage | archive | delete`** — key-gated review verbs (cursor-paginated list with `--status`/`--type`/`--include-archived`; triage to `new|triaged|closed`; archive with `--undo`; delete with typeback confirmation or `--yes`), mirroring `admin feedback`.

Submit type stays `source` only (the API enum is `["source"]`), so there is no `--type` flag on submit.

## Changes

- New command module `src/cli/commands/recommend.ts`; wired into `src/cli/program.ts` (public block + admin subtree).
- Tests: `tests/unit/recommend.test.ts` (URL validation/normalization, payload shape, error-code mapping) and `tests/cli/recommend.test.ts` (help, `--dry-run`, invalid-url/email/note guards, stdin path). `runCli` gained an optional `input` for stdin tests.
- Docs: README "Submit a source" section; `releases-cli` skill (`SKILL.md`, `references/reader.md` keyless, `references/admin.md` review verbs).
- Changeset: `minor` on `@buildinternet/releases`.

## Test plan

- [x] `bun test` — 626 pass / 0 fail (22 in the new suites)
- [x] `npx tsc --noEmit` — clean
- [x] `bun run lint` (oxlint) — 0 warnings / 0 errors
- [x] `bun run format:check` — clean
- [x] `releases agent-context` lists all 6 new command paths
- [x] Manual `--dry-run` smoke: scheme normalization + payload shape verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)
