### PR TITLE
feat(cli): product cross-source release feed via `latest --product`

### DIFF
--- a/.changeset/product-release-feed.md
+++ b/.changeset/product-release-feed.md
@@ -1,0 +1,7 @@
+---
+"@buildinternet/releases": minor
+---
+
+Add `releases latest --product <org/slug>` (alias `releases tail --product`) to show one product's cross-source release feed, backed by `GET /v1/orgs/:slug/releases?product=`. Accepts an `org/slug` coordinate, a `prod_…` id, or a bare product slug; composes with `--count`, `--since`/`--until`, `--include-coverage`, `--json`/`--full`, and `--follow`. It can't combine with a `[source]` argument or `--org`.
+
+The local MCP server's `get_latest_releases` tool now filters by product correctly too — previously its `product` argument was misrouted as a source filter, silently returning the wrong results.

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -676,23 +676,44 @@ function toMediaItems(
   }));
 }
 
-type LatestReleasesResponse = {
-  releases: Array<{
-    id: string;
-    version: string | null;
-    type: string;
-    title: string;
-    summary: string | null;
-    titleGenerated?: string | null;
-    titleShort?: string | null;
-    contentChars?: number | null;
-    contentTokens?: number | null;
-    publishedAt: string | null;
-    url: string | null;
-    media: Array<{ type: string; url: string; alt?: string; r2Url?: string }>;
-    source: { slug: string; name: string; type: string };
-  }>;
+// Common release-row wire shape shared by `/v1/releases/latest` and the
+// org feed (`/v1/orgs/:slug/releases`). The org feed carries a few extra
+// fields (prerelease, coverageCount, source.appStore) the CLI ignores, so
+// declaring the narrower shape here is fine — `toLatestRelease` only reads
+// what both endpoints return.
+type LatestReleaseWire = {
+  id: string;
+  version: string | null;
+  title: string;
+  summary: string | null;
+  titleGenerated?: string | null;
+  titleShort?: string | null;
+  contentChars?: number | null;
+  contentTokens?: number | null;
+  publishedAt: string | null;
+  media: Array<{ type: string; url: string; alt?: string; r2Url?: string }>;
+  source: { slug: string; name: string; type: string };
 };
+
+// `titleGenerated`/`titleShort`/`contentChars`/`contentTokens` are carried so
+// the shared renderer's description fallback chain and the slim JSON size hints
+// have data without an extra round-trip. #215.
+function toLatestRelease(r: LatestReleaseWire): LatestRelease {
+  return {
+    id: r.id,
+    title: r.title,
+    version: r.version,
+    publishedAt: r.publishedAt,
+    sourceName: r.source.name,
+    sourceSlug: r.source.slug,
+    summary: r.summary ?? null,
+    titleGenerated: r.titleGenerated ?? null,
+    titleShort: r.titleShort ?? null,
+    contentChars: r.contentChars ?? null,
+    contentTokens: r.contentTokens ?? null,
+    media: toMediaItems(r.media),
+  };
+}
 
 export async function getLatestReleases(opts: {
   /** Source identifier (src_… or slug). */
@@ -713,24 +734,80 @@ export async function getLatestReleases(opts: {
   if (opts.since) qs.set("since", opts.since);
   if (opts.until) qs.set("until", opts.until);
 
-  const data = await apiFetch<LatestReleasesResponse>(`/v1/releases/latest?${qs.toString()}`);
+  const data = await apiFetch<{ releases: LatestReleaseWire[] }>(
+    `/v1/releases/latest?${qs.toString()}`,
+  );
   if (!data) return [];
-  return data.releases.map((r) => ({
-    id: r.id,
-    title: r.title,
-    version: r.version,
-    publishedAt: r.publishedAt,
-    sourceName: r.source.name,
-    sourceSlug: r.source.slug,
-    summary: r.summary ?? null,
-    // Carried so the shared renderer's description fallback chain and the slim
-    // JSON size hints have data without an extra round-trip. #215.
-    titleGenerated: r.titleGenerated ?? null,
-    titleShort: r.titleShort ?? null,
-    contentChars: r.contentChars ?? null,
-    contentTokens: r.contentTokens ?? null,
-    media: toMediaItems(r.media),
-  }));
+  return data.releases.map(toLatestRelease);
+}
+
+/**
+ * Resolve a product identifier to the `{ orgRef, product }` pair the org
+ * release feed needs (`GET /v1/orgs/:orgRef/releases?product=…`). Mirrors the
+ * identifier shapes `resolveProductTarget` accepts:
+ *   - `prod_…` ids: fetch the product to recover its org (the feed is
+ *     org-scoped; the org path segment accepts `org_…` ids).
+ *   - `org/slug` coordinates: split locally, no round-trip. Existence is
+ *     validated by the feed call (a bad coord 404s → `getProductReleases`
+ *     returns `null`).
+ *   - bare slugs: bounce through `/v1/lookups/product-by-slug` for the
+ *     canonical org.
+ * Returns `null` when a `prod_…`/bare slug doesn't resolve to a product.
+ */
+export async function resolveProductFeedTarget(
+  identifier: string,
+): Promise<{ orgRef: string; product: string } | null> {
+  if (identifier.startsWith("prod_")) {
+    const product = await findProduct(identifier);
+    if (!product) return null;
+    return { orgRef: product.orgId, product: identifier };
+  }
+  const slash = identifier.indexOf("/");
+  if (slash > 0 && slash < identifier.length - 1) {
+    return { orgRef: identifier.slice(0, slash), product: identifier.slice(slash + 1) };
+  }
+  const resolved = await apiFetch<{
+    productId: string;
+    productSlug: string;
+    orgSlug: string;
+  } | null>(`/v1/lookups/product-by-slug?slug=${encodeURIComponent(identifier)}`);
+  if (!resolved) return null;
+  return { orgRef: resolved.orgSlug, product: resolved.productSlug };
+}
+
+/**
+ * One product's cross-source release feed via `GET /v1/orgs/:orgRef/releases?
+ * product=…`. Cursor-paginated; the server's cursor is opaque to the CLI.
+ * Returns `null` when the org or product is unknown (the endpoint 404s), which
+ * `apiFetch` maps to `null` for GETs — distinct from a valid-but-empty product
+ * (`{ releases: [], … }`).
+ */
+export async function getProductReleases(opts: {
+  orgRef: string;
+  product: string;
+  count: number;
+  cursor?: string | null;
+  includeCoverage?: boolean;
+  since?: string;
+  until?: string;
+}): Promise<{ releases: LatestRelease[]; nextCursor: string | null } | null> {
+  const qs = new URLSearchParams();
+  qs.set("product", opts.product);
+  qs.set("limit", String(opts.count));
+  if (opts.cursor) qs.set("cursor", opts.cursor);
+  if (opts.includeCoverage) qs.set("include_coverage", "true");
+  if (opts.since) qs.set("since", opts.since);
+  if (opts.until) qs.set("until", opts.until);
+
+  const data = await apiFetch<{
+    releases: LatestReleaseWire[];
+    pagination?: { nextCursor: string | null };
+  } | null>(`/v1/orgs/${encodeURIComponent(opts.orgRef)}/releases?${qs.toString()}`);
+  if (!data) return null;
+  return {
+    releases: data.releases.map(toLatestRelease),
+    nextCursor: data.pagination?.nextCursor ?? null,
+  };
 }
 
 // ── Known releases for incremental parsing ──

--- a/src/cli/commands/tail.ts
+++ b/src/cli/commands/tail.ts
@@ -1,8 +1,14 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { findOrg, findSource, getLatestReleases } from "../../api/client.js";
+import {
+  findOrg,
+  findSource,
+  getLatestReleases,
+  getProductReleases,
+  resolveProductFeedTarget,
+} from "../../api/client.js";
 import type { LatestRelease } from "../../api/types.js";
-import { orgNotFound, sourceNotFound } from "../suggest.js";
+import { orgNotFound, productNotFound, sourceNotFound } from "../suggest.js";
 import { stripAnsi } from "../../lib/sanitize.js";
 import { sleep } from "../../lib/sleep.js";
 import { renderReleaseRows } from "../render/releases-table.js";
@@ -46,6 +52,10 @@ export function registerTailCommand(program: Command) {
       "Filter to an organization (org_…, slug, domain, name, or handle)",
     )
     .option(
+      "--product <identifier>",
+      "Show one product's cross-source feed (org/slug, prod_… id, or product slug). Not combinable with [source] or --org.",
+    )
+    .option(
       "--include-coverage",
       "Include releases that are coverage of another (hidden by default)",
     )
@@ -68,6 +78,7 @@ Examples:
   releases tail                         Latest releases across all sources
   releases tail my-source               Latest releases from one source
   releases tail --org acme --count 20   Latest 20 releases from an org
+  releases tail --product vercel/turborepo   One product's cross-source feed
   releases tail --since 30d             Releases from the last 30 days
   releases tail -f                      Follow new releases as they arrive (60s interval)
   releases tail -f --interval 30        Follow with a 30s poll interval
@@ -80,6 +91,7 @@ Examples:
         opts: {
           count: string;
           org?: string;
+          product?: string;
           includeCoverage?: boolean;
           since?: string;
           until?: string;
@@ -96,6 +108,14 @@ Examples:
         const since = parseTimeWindowFlag("since", opts.since);
         const until = parseTimeWindowFlag("until", opts.until);
 
+        // --product switches to the product's cross-source feed
+        // (GET /v1/orgs/:org/releases?product=…) — a different endpoint from the
+        // global latest feed, so it can't combine with a [source] or --org filter.
+        if (opts.product && (sourceArg || opts.org)) {
+          logger.error("--product can't be combined with a [source] argument or --org.");
+          process.exit(1);
+        }
+
         if (sourceArg) {
           const source = await findSource(sourceArg);
           if (!source) return sourceNotFound(sourceArg);
@@ -108,6 +128,14 @@ Examples:
           orgSlug = org.slug;
         }
 
+        let productTarget: { orgRef: string; product: string } | null = null;
+        if (opts.product) {
+          productTarget = await resolveProductFeedTarget(opts.product);
+          // org/slug coords aren't pre-validated here; a bad coord surfaces as a
+          // null feed in fetchPage. prod_/bare-slug forms validate in the resolver.
+          if (!productTarget) return productNotFound(opts.product);
+        }
+
         const fetchOpts = {
           source: sourceArg,
           org: orgSlug,
@@ -116,7 +144,24 @@ Examples:
           since,
           until,
         };
-        const rows = await getLatestReleases(fetchOpts);
+
+        // One page of the active feed (global latest, or the product feed when
+        // --product is set). Follow mode re-invokes this each tick.
+        const fetchPage = async (): Promise<LatestRelease[]> => {
+          if (!productTarget) return getLatestReleases(fetchOpts);
+          const res = await getProductReleases({
+            orgRef: productTarget.orgRef,
+            product: productTarget.product,
+            count,
+            includeCoverage: opts.includeCoverage,
+            since,
+            until,
+          });
+          if (!res) return productNotFound(opts.product!);
+          return res.releases;
+        };
+
+        const rows = await fetchPage();
 
         if (opts.json) {
           await writeJson(rows.map((row) => slimLatest(row, opts.full === true)));
@@ -154,7 +199,7 @@ Examples:
           // eslint-disable-next-line no-await-in-loop
           await sleep(intervalSeconds * 1000);
           // eslint-disable-next-line no-await-in-loop
-          const fresh = await getLatestReleases(fetchOpts);
+          const fresh = await fetchPage();
           const novel = fresh.filter((r) => !seen.has(r.id));
           if (novel.length === 0) continue;
 

--- a/src/cli/suggest.ts
+++ b/src/cli/suggest.ts
@@ -24,3 +24,9 @@ export async function sourceNotFound(identifier: string): Promise<never> {
   }
   process.exit(1);
 }
+
+export function productNotFound(identifier: string): never {
+  console.error(chalk.red(`Product not found: ${identifier}`));
+  console.error(chalk.dim('Use an "org/slug" coordinate, a prod_… id, or a product slug.'));
+  process.exit(1);
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -7,6 +7,8 @@ import {
   findOrg,
   listOrgs,
   getLatestReleases,
+  getProductReleases,
+  resolveProductFeedTarget,
   unifiedSearch,
   sourceChangelog,
   getAliases,
@@ -16,6 +18,7 @@ import {
   findProduct,
   listSourcesWithOrg,
 } from "../api/client.js";
+import type { LatestRelease } from "../api/types.js";
 import { logger } from "@releases/lib/logger";
 import { recordEvent } from "../lib/telemetry.js";
 import { VERSION } from "../cli/version.js";
@@ -120,7 +123,12 @@ server.registerTool(
   {
     description: "Get the most recent releases, optionally filtered by product or organization",
     inputSchema: {
-      product: z.string().optional().describe("Filter to a specific product slug"),
+      product: z
+        .string()
+        .optional()
+        .describe(
+          "Show one product's cross-source feed. Accepts an org/slug coordinate, a prod_… id, or a product slug.",
+        ),
       organization: z
         .string()
         .optional()
@@ -137,11 +145,22 @@ server.registerTool(
   async ({ product, organization, count }) => {
     const maxCount = count ?? 10;
 
-    let releases = await getLatestReleases({
-      source: product,
-      org: organization,
-      count: maxCount,
-    });
+    // product takes precedence — it routes to the product's cross-source feed
+    // (GET /v1/orgs/:org/releases?product=…) rather than the global latest feed.
+    let releases: LatestRelease[];
+    if (product) {
+      const target = await resolveProductFeedTarget(product);
+      const res = target
+        ? await getProductReleases({
+            orgRef: target.orgRef,
+            product: target.product,
+            count: maxCount,
+          })
+        : null;
+      releases = res?.releases ?? [];
+    } else {
+      releases = await getLatestReleases({ org: organization, count: maxCount });
+    }
 
     // type filter: LatestRelease doesn't carry a type field — the remote MCP worker
     // handles this natively. Silently ignored when proxying.

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -157,7 +157,13 @@ server.registerTool(
             count: maxCount,
           })
         : null;
-      releases = res?.releases ?? [];
+      // A null target (unresolvable id/slug) or null feed (unknown org/product
+      // 404) is a bad identifier — distinct from a valid product with zero
+      // releases — so say so rather than returning a misleading empty result.
+      if (!target || !res) {
+        return textResult(`No product found matching "${product}".`);
+      }
+      releases = res.releases;
     } else {
       releases = await getLatestReleases({ org: organization, count: maxCount });
     }

--- a/tests/unit/api-client.test.ts
+++ b/tests/unit/api-client.test.ts
@@ -335,3 +335,142 @@ describe("since/until query params", () => {
     expect(capturedUrl).toContain("until=2026-05-01");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Product cross-source feed
+// ---------------------------------------------------------------------------
+
+describe("getProductReleases", () => {
+  let originalFetch: typeof globalThis.fetch;
+  let capturedUrl = "";
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    capturedUrl = "";
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  function captureWith(status: number, body: unknown) {
+    globalThis.fetch = (async (url: string) => {
+      capturedUrl = url;
+      return new Response(JSON.stringify(body), {
+        status,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as any;
+  }
+
+  it("hits the org feed with product + limit and maps the rows + cursor", async () => {
+    captureWith(200, {
+      releases: [
+        {
+          id: "rel_1",
+          version: "1.2.0",
+          title: "Shipped X",
+          summary: "Did the thing",
+          titleGenerated: "X is here",
+          titleShort: "X",
+          contentChars: 42,
+          contentTokens: 12,
+          publishedAt: "2026-05-20T00:00:00.000Z",
+          url: "https://example.com/x",
+          media: [],
+          // extra fields the org feed carries but the CLI ignores:
+          type: "feature",
+          prerelease: false,
+          coverageCount: 0,
+          source: { slug: "turborepo", name: "Turborepo", type: "github" },
+        },
+      ],
+      pagination: { nextCursor: "CURSOR_2", limit: 20 },
+    });
+
+    const res = await client.getProductReleases({
+      orgRef: "vercel",
+      product: "turborepo",
+      count: 20,
+    });
+
+    expect(capturedUrl).toContain("/v1/orgs/vercel/releases?");
+    expect(capturedUrl).toContain("product=turborepo");
+    expect(capturedUrl).toContain("limit=20");
+    expect(res).not.toBeNull();
+    expect(res!.nextCursor).toBe("CURSOR_2");
+    expect(res!.releases).toHaveLength(1);
+    const row = res!.releases[0];
+    expect(row.id).toBe("rel_1");
+    expect(row.sourceName).toBe("Turborepo");
+    expect(row.sourceSlug).toBe("turborepo");
+    expect(row.titleShort).toBe("X");
+    expect(row.contentTokens).toBe(12);
+  });
+
+  it("forwards cursor, since, and until when supplied", async () => {
+    captureWith(200, { releases: [], pagination: { nextCursor: null, limit: 20 } });
+    await client.getProductReleases({
+      orgRef: "vercel",
+      product: "turborepo",
+      count: 20,
+      cursor: "CURSOR_1",
+      since: "30d",
+      until: "2026-05-01",
+    });
+    expect(capturedUrl).toContain("cursor=CURSOR_1");
+    expect(capturedUrl).toContain("since=30d");
+    expect(capturedUrl).toContain("until=2026-05-01");
+  });
+
+  it("returns null when the org/product 404s", async () => {
+    captureWith(404, { error: "not_found" });
+    const res = await client.getProductReleases({
+      orgRef: "vercel",
+      product: "nope",
+      count: 20,
+    });
+    expect(res).toBeNull();
+  });
+});
+
+describe("resolveProductFeedTarget", () => {
+  let originalFetch: typeof globalThis.fetch;
+  let capturedUrl = "";
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    capturedUrl = "";
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("splits an org/slug coordinate locally without a round-trip", async () => {
+    globalThis.fetch = (async (url: string) => {
+      capturedUrl = url;
+      return new Response("{}", { status: 200 });
+    }) as any;
+    const target = await client.resolveProductFeedTarget("vercel/turborepo");
+    expect(target).toEqual({ orgRef: "vercel", product: "turborepo" });
+    expect(capturedUrl).toBe(""); // no network call for the coordinate form
+  });
+
+  it("bounces a bare slug through the product-by-slug lookup", async () => {
+    globalThis.fetch = (async (url: string) => {
+      capturedUrl = url;
+      return new Response(
+        JSON.stringify({ productId: "prod_x", productSlug: "turborepo", orgSlug: "vercel" }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }) as any;
+    const target = await client.resolveProductFeedTarget("turborepo");
+    expect(capturedUrl).toContain("/v1/lookups/product-by-slug?slug=turborepo");
+    expect(target).toEqual({ orgRef: "vercel", product: "turborepo" });
+  });
+
+  it("returns null when a bare slug doesn't resolve", async () => {
+    globalThis.fetch = (async () => new Response("null", { status: 404 })) as any;
+    const target = await client.resolveProductFeedTarget("ghost");
+    expect(target).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `releases latest --product <org/slug>` (alias `releases tail --product`) — the missing read surface for a product's cross-source release feed. Backed by the live `GET /v1/orgs/:slug/releases?product=` endpoint (cursor-paginated, the same feed the web product page and `.atom`/`.json` adapters use). No api-types change needed.
- Accepts an `org/slug` coordinate, a `prod_…` id, or a bare product slug (bounced through `/v1/lookups/product-by-slug`). Composes with `--count`, `--since`/`--until`, `--include-coverage`, `--json`/`--full`, and `--follow`; rejects combining with a `[source]` arg or `--org`.
- Fixes the local MCP server's `get_latest_releases` tool — its `product` input was misrouted as a *source* filter (`getLatestReleases({ source: product })`), silently returning wrong results. It now routes through the product feed, matching remote MCP #1209.
- Refactors the shared latest-release row mapping into `toLatestRelease` so the latest and product feeds map identically.

Closes #243.

## Test plan

- [x] `bun test` — 632 pass (incl. 6 new tests for `getProductReleases` URL/param/mapping/404 + `resolveProductFeedTarget` org/slug, bare-slug-lookup, and miss cases)
- [x] `bun run typecheck` (tsc) clean · `bun run lint` (oxlint) 0/0
- [x] Live smoke vs prod (`RELEASES_API_URL=https://api.releases.sh`):
  - `latest --product vercel/turborepo` → renders the feed (table + slim `--json` with size hints)
  - bare slug `--product turborepo` → resolves via lookup → renders
  - `--product prod_AYklyECIj-XY2rdp8m6bq` → resolves via product detail → renders
  - `--product vercel/nope-xyz-404` → "Product not found" + hint, exit 1
  - `--product … --org vercel` → rejected with a clear error
- MCP `get_latest_releases` exercises the same `resolveProductFeedTarget` + `getProductReleases` path (unit-tested + smoked via the CLI command); not driven over a stdio MCP roundtrip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
