### PR TITLE
docs(cli): document create-appstore in the admin skill reference

### DIFF
--- a/.changeset/appstore-cli-ref-docs.md
+++ b/.changeset/appstore-cli-ref-docs.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": patch
+---
+
+Document the `source create-appstore` verb in the `releases-cli` admin skill reference: a dedicated "Create App Store source" section (identifier forms, `--platform`/`--storefront`, idempotency, the pre-create-product workflow) plus a note on the `create` command that App Store apps use it.

--- a/skills/releases-cli/references/admin.md
+++ b/skills/releases-cli/references/admin.md
@@ -40,7 +40,7 @@ releases admin source create "Linear" --url https://linear.app/changelog --dry-r
 
 `--dry-run` still runs the URL dedup and exclusion checks (so you'll see "already exists" or "blocked URL" outcomes), but skips the write — including the auto-create-org side effect when `--org <name>` doesn't resolve.
 
-By default, `create` runs automated pre-checks (provider detection, feed discovery, markdown probing). Override with `--type github|scrape|feed|agent`. Batch mode (`--batch`) skips evaluation by default for speed.
+By default, `create` runs automated pre-checks (provider detection, feed discovery, markdown probing). Override with `--type github|scrape|feed|agent`. Batch mode (`--batch`) skips evaluation by default for speed. App Store apps use the dedicated `source create-appstore` verb (below) — `create` rejects `--type appstore` and pasted `apps.apple.com` URLs with a pointer to it.
 
 Provide a feed URL explicitly when it isn't easily discoverable:
 
@@ -54,6 +54,27 @@ Evaluate without adding:
 ```bash
 releases admin discovery evaluate https://linear.app/changelog
 ```
+
+### Create App Store
+
+App Store apps have a dedicated verb because the create flow resolves the iTunes listing, mints the current version as the first release, and backfills the product's avatar with the app icon:
+
+```bash
+releases admin source create-appstore https://apps.apple.com/us/app/slack/id618783545 --org slack --product slack
+releases admin source create-appstore appstore:618783545 --platform ios --org slack
+releases admin source create-appstore 1496833156 --platform macos --dry-run
+```
+
+The identifier is an `apps.apple.com/.../id<trackId>` URL, a bare numeric track ID, or an `appstore:<trackId>` coordinate. `--platform` defaults to `ios` (`macos` = Mac App Store); `--storefront` defaults to `us`. The verb is idempotent on the track ID — re-running reports the existing source.
+
+With no `--product`, the endpoint names a _new_ product after the (often verbose) App Store title — e.g. "Shopify: Sell online/in person". To control the name, create the product first and reference it with `--product`:
+
+```bash
+releases admin product create "Shopify" --org shopify
+releases admin source create-appstore https://apps.apple.com/us/app/shopify/id719892358 --org shopify --product shopify
+```
+
+Add one app at a time — the listing is resolved on the fly, and concurrent creates for a brand-new org/product race on slug uniqueness.
 
 ### Update
 


### PR DESCRIPTION
Docs follow-up to #247 / #248 — documents the `source create-appstore` verb in the `releases-cli` skill's admin reference (the only CLI doc spot that enumerated `--type github|scrape|feed|agent` without mentioning App Store).

## What

- `skills/releases-cli/references/admin.md`: new **"Create App Store source"** section (identifier forms — URL / bare track ID / `appstore:<trackId>`; `--platform`/`--storefront`; track-ID idempotency; the pre-create-the-product workflow for clean names) and a note on `create` that App Store apps use the dedicated verb (and that `create` rejects `--type appstore` / pasted `apps.apple.com` URLs).
- `patch` changeset (the skill ships in the published package).

README and AGENTS.md were checked — neither enumerates source types or admin source commands, so nothing to change there. The monorepo's matching docs are in buildinternet/releases#1241.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
