### PR TITLE
feat(cli): add --featured / --no-featured to admin org update

### DIFF
--- a/.changeset/org-update-featured.md
+++ b/.changeset/org-update-featured.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": minor
+---
+
+`admin org update` now accepts `--featured` / `--no-featured`, so operators can curate the editorially-featured org list (the home-page rail, buildinternet/releases#1274/#1275) from the terminal instead of only via the web Admin menu or a raw API `PATCH`. The flag maps to `PATCH /v1/orgs/:slug { featured }`; aliased onto the deprecated `org edit` too. (#253)

--- a/src/cli/commands/org.ts
+++ b/src/cli/commands/org.ts
@@ -267,6 +267,7 @@ type OrgUpdateOpts = {
   category?: string | boolean;
   avatar?: string | boolean;
   paused?: boolean;
+  featured?: boolean;
   json?: boolean;
   dryRun?: boolean;
 };
@@ -295,6 +296,11 @@ async function orgUpdateAction(identifier: string, opts: OrgUpdateOpts): Promise
   else if (typeof opts.avatar === "string") updates.avatarUrl = opts.avatar;
 
   if (opts.paused !== undefined) updates.fetchPaused = opts.paused;
+
+  // Editorial home-page rail flag (buildinternet/releases#1274). The API field
+  // is `featured`; commander surfaces --featured/--no-featured as a single
+  // boolean (undefined when neither is passed).
+  if (opts.featured !== undefined) updates.featured = opts.featured;
 
   if (Object.keys(updates).length === 0) {
     logger.warn("No fields to update.");
@@ -631,6 +637,8 @@ Examples:
     .option("--no-avatar", "Clear avatar URL")
     .option("--paused", "Pause ingest for all of this org's sources (catalog stays visible)")
     .option("--no-paused", "Resume ingest for this org's sources")
+    .option("--featured", "Promote this org on the home-page featured rail")
+    .option("--no-featured", "Remove this org from the home-page featured rail")
     .option("--json", "Output as JSON")
     .option("--dry-run", "Show what would change without writing")
     .action(orgUpdateAction);
@@ -649,6 +657,8 @@ Examples:
     .option("--no-avatar", "Clear avatar URL")
     .option("--paused", "Pause ingest for all of this org's sources (catalog stays visible)")
     .option("--no-paused", "Resume ingest for this org's sources")
+    .option("--featured", "Promote this org on the home-page featured rail")
+    .option("--no-featured", "Remove this org from the home-page featured rail")
     .option("--json", "Output as JSON")
     .option("--dry-run", "Show what would change without writing")
     .action(warnDeprecatedAlias<[string, OrgUpdateOpts]>("edit", "update", orgUpdateAction));

--- a/tests/cli/org-update-featured.test.ts
+++ b/tests/cli/org-update-featured.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "bun:test";
+import { runCli } from "../utils.js";
+
+/**
+ * Surface coverage for `releases admin org update --featured` (issue #253).
+ *
+ * The body assembly (`updates.featured = opts.featured`) reaches the API's
+ * `PATCH /v1/orgs/:slug { featured }` write path, exercised by the monorepo
+ * tests that landed the `featured` flag (buildinternet/releases#1274/#1275).
+ * Here we only assert the flags are registered on both the canonical `update`
+ * and the deprecated `edit` alias, so muscle-memory callers don't fail silently.
+ */
+describe("admin org update --featured (CLI surface)", () => {
+  it("exposes --featured / --no-featured on `org update`", () => {
+    const { stdout, exitCode } = runCli(["admin", "org", "update", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--featured");
+    expect(stdout).toContain("--no-featured");
+  });
+
+  it("exposes --featured / --no-featured on the deprecated `org edit` alias", () => {
+    const { stdout, exitCode } = runCli(["admin", "org", "edit", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--featured");
+    expect(stdout).toContain("--no-featured");
+  });
+});


### PR DESCRIPTION
## Summary

Adds `--featured` / `--no-featured` to `releases admin org update`, so operators can curate the editorially-featured org list from the terminal instead of only via the web Admin menu or a raw API `PATCH`.

```
releases admin org update <org> --featured
releases admin org update <org> --no-featured
```

The monorepo added the `organizations.featured` editorial flag (buildinternet/releases#1274, #1275) — it powers the curated org rail on the releases.sh home page (the full A–Z list lives at `/catalog`). Featuring an org was reachable only via `PATCH /v1/orgs/:slug { featured }` or the dev-gated web Admin toggle; this fills the CLI gap.

## Implementation

Mirrors the existing `--paused` / `--no-paused` boolean pattern exactly:
- `featured?: boolean` added to `OrgUpdateOpts`; commander surfaces `--featured`/`--no-featured` as a single boolean (`undefined` when neither is passed).
- `orgUpdateAction` maps it to `updates.featured`, which `updateOrg` sends as `PATCH /v1/orgs/:slug { featured }`. `--dry-run` prints `featured → true/false` like any other field.
- Registered on both the canonical `org update` and the deprecated `org edit` alias.

`updateOrg` takes an untyped body, so no api-types pin bump is required for the write path (the `featured` field already exists in `@buildinternet/releases-api-types` as of the monorepo change and will be picked up on the next pin bump).

## Testing

- New surface test `tests/cli/org-update-featured.test.ts` (mirrors `org-update-paused.test.ts`): asserts both flags register on `update` and `edit`.
- `bun test` (new + paused surface tests pass), `tsc --noEmit`, `oxlint` (0 errors), `prettier --check` all clean.
- Smoke: `admin org update --help` lists `--featured` / `--no-featured` in the option block.
- Changeset added (`minor`, `@buildinternet/releases`).

Closes #253.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
