### PR TITLE
feat(cli): list products across all orgs when org is omitted (#259)

### DIFF
--- a/.changeset/product-list-all-orgs.md
+++ b/.changeset/product-list-all-orgs.md
@@ -1,0 +1,7 @@
+---
+"@buildinternet/releases": minor
+---
+
+`admin product list` now lists products across all orgs when the org argument is omitted.
+
+The org argument is optional: `releases admin product list` (no org) enumerates products across every org, honoring `--kind`, `--json`, and the new `--limit`/`--page` pagination flags. The cross-org table gains an **Org** column so a bare product slug stays attributable; org-scoped listing keeps its original columns. This closes the CLI↔MCP gap that blocked a cross-org `kind=sdk` audit — previously expressible only via the remote MCP `list_catalog` tool (buildinternet/releases-cli#259). Backed by the existing org-agnostic `GET /v1/products` endpoint; no API change required.

--- a/skills/releases-cli/references/admin.md
+++ b/skills/releases-cli/references/admin.md
@@ -223,6 +223,8 @@ releases admin product create "Next.js" --org vercel --url https://nextjs.org
 releases admin product create "Stripe Node" --org stripe --kind sdk
 releases admin product list vercel
 releases admin product list openai --kind sdk           # filter by taxonomy
+releases admin product list                             # every product, all orgs (adds an Org column)
+releases admin product list --kind sdk --json           # cross-org kind audit (CLI↔MCP list_catalog parity)
 releases admin product update nextjs --description "React framework for production"
 releases admin product update stripe-node --kind sdk    # classify
 releases admin product update stripe-node --no-kind     # clear

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -36,7 +36,7 @@ import type {
   OrgDependentsResponse,
   AppStoreMaterializeResponse,
 } from "./types.js";
-import type { ListResponse } from "@buildinternet/releases-core/cli-contracts";
+import { computePagination, type ListResponse } from "@buildinternet/releases-core/cli-contracts";
 import type {
   DomainLookupResponse,
   OverviewCitation,
@@ -1112,21 +1112,66 @@ export async function findProduct(identifier: string): Promise<Product | null> {
   return apiFetch<Product | null>(target.pathSegment);
 }
 
+export type ProductWithSourceCount = Product & { sourceCount: number };
+
+/**
+ * List products via `GET /v1/products`. Omit `orgId` to enumerate products
+ * across every org — the org-agnostic form backing `releases admin product
+ * list` with no org argument (releases-cli#259). Returns the paginated
+ * envelope so callers can surface `pagination.hasMore`; `getProductsByOrg`
+ * unwraps it for the single-org callers that only want the rows.
+ *
+ * `/v1/products` returns a paginated envelope; the legacy bare-array shape is
+ * tolerated too in case an old worker is ever in the path. Without the unwrap,
+ * downstream `for/find/filter/map` would silently iterate an object and yield
+ * nothing — which is what made `releases org get` skip the Products section.
+ */
+export async function listProducts(opts?: {
+  orgId?: string;
+  kind?: Kind;
+  limit?: number;
+  page?: number;
+}): Promise<ListResponse<ProductWithSourceCount>> {
+  const params = new URLSearchParams();
+  if (opts?.orgId) params.set("orgId", opts.orgId);
+  if (opts?.kind) params.set("kind", opts.kind);
+  if (opts?.limit != null) params.set("limit", String(opts.limit));
+  if (opts?.page != null) params.set("page", String(opts.page));
+  const qs = params.toString();
+  const raw = await apiFetch<ProductWithSourceCount[] | ListResponse<ProductWithSourceCount>>(
+    `/v1/products${qs ? `?${qs}` : ""}`,
+  );
+  if (!raw) {
+    return {
+      items: [],
+      pagination: computePagination({
+        page: opts?.page ?? 1,
+        pageSize: opts?.limit ?? 0,
+        returned: 0,
+        totalItems: 0,
+      }),
+    };
+  }
+  if (Array.isArray(raw)) {
+    return {
+      items: raw,
+      pagination: computePagination({
+        page: 1,
+        pageSize: raw.length,
+        returned: raw.length,
+        totalItems: raw.length,
+      }),
+    };
+  }
+  return raw;
+}
+
 export async function getProductsByOrg(
   orgId: string,
   opts?: { kind?: Kind },
-): Promise<Array<Product & { sourceCount: number }>> {
-  // /v1/products returns a paginated envelope; tolerate the legacy bare-array
-  // shape too in case an old worker is ever in the path. Without the unwrap,
-  // every downstream `for/find/filter/map` over the result was silently
-  // iterating an object and yielding nothing — which is what made
-  // `releases org get` skip the Products section even when the org had them.
-  type Row = Product & { sourceCount: number };
-  const params = new URLSearchParams({ orgId });
-  if (opts?.kind) params.set("kind", opts.kind);
-  const raw = await apiFetch<Row[] | ListResponse<Row>>(`/v1/products?${params}`);
-  if (!raw) return [];
-  return Array.isArray(raw) ? raw : raw.items;
+): Promise<ProductWithSourceCount[]> {
+  const { items } = await listProducts({ orgId, kind: opts?.kind });
+  return items;
 }
 
 export async function updateProduct(

--- a/src/cli/commands/product.ts
+++ b/src/cli/commands/product.ts
@@ -1,10 +1,11 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { renderTable } from "../render/table.js";
+import { renderTable, type ColumnSpec } from "../render/table.js";
 import {
   findOrg,
   findProduct,
-  getProductsByOrg,
+  listProducts,
+  listOrgs,
   createProduct,
   updateProduct,
   deleteProduct,
@@ -24,7 +25,12 @@ import { isValidCategory, CATEGORIES } from "@buildinternet/releases-core/catego
 import { isValidKind, KIND_VALUES, type Kind } from "@buildinternet/releases-core/kinds";
 import { logger } from "@releases/lib/logger";
 import { writeJson } from "../../lib/output.js";
-import { computePagination, type ListResponse } from "@buildinternet/releases-core/cli-contracts";
+import {
+  computePagination,
+  DEFAULT_PAGE_SIZE,
+  formatTruncationWarning,
+  type ListResponse,
+} from "@buildinternet/releases-core/cli-contracts";
 import { warnDeprecatedAlias } from "../../lib/deprecated-alias.js";
 import { parseTagList } from "../../lib/flags.js";
 
@@ -251,63 +257,134 @@ export function registerProductCommand(program: Command) {
 
   product
     .command("list")
-    .description("List products for an organization")
-    .argument("[org]", "Organization (org_…, slug, domain, name, or handle)")
+    .description("List products for an organization, or across all orgs when no org is given")
+    .argument(
+      "[org]",
+      "Organization (org_…, slug, domain, name, or handle). Omit to list products across every org.",
+    )
     .option("--json", "Output as JSON")
     .option(
       "--kind <kind>",
       `Filter by product taxonomy (${KIND_VALUES.join(", ")}). Matches the product's own kind only.`,
     )
-    .action(async (orgIdentifier: string | undefined, opts: { json?: boolean; kind?: string }) => {
-      if (!orgIdentifier) {
-        console.error(chalk.red("Please specify an organization"));
-        process.exit(1);
-      }
+    .option("--limit <n>", `Limit the number of results (default ${DEFAULT_PAGE_SIZE})`)
+    .option("--page <n>", "Page number for paginated results")
+    .addHelpText(
+      "after",
+      `
+Examples:
+  releases admin product list vercel          Products under one org
+  releases admin product list --kind sdk      Every SDK product across all orgs
+  releases admin product list --json          All products as JSON (for audits)`,
+    )
+    .action(
+      async (
+        orgIdentifier: string | undefined,
+        opts: { json?: boolean; kind?: string; limit?: string; page?: string },
+      ) => {
+        if (opts.kind !== undefined && !isValidKind(opts.kind)) {
+          logger.error(`Invalid kind "${opts.kind}". Must be one of: ${KIND_VALUES.join(", ")}`);
+          process.exit(1);
+        }
+        const kind = opts.kind as Kind | undefined;
 
-      if (opts.kind !== undefined && !isValidKind(opts.kind)) {
-        logger.error(`Invalid kind "${opts.kind}". Must be one of: ${KIND_VALUES.join(", ")}`);
-        process.exit(1);
-      }
-      const kind = opts.kind as Kind | undefined;
+        const parsedLimit = opts.limit === undefined ? undefined : Number(opts.limit);
+        if (parsedLimit !== undefined && (!Number.isInteger(parsedLimit) || parsedLimit <= 0)) {
+          logger.error("--limit must be a positive integer");
+          process.exit(1);
+        }
+        const explicitLimit = parsedLimit !== undefined;
+        const pageSize = explicitLimit ? parsedLimit : DEFAULT_PAGE_SIZE;
 
-      const org = await findOrg(orgIdentifier);
-      if (!org) {
-        console.error(chalk.red(`Organization not found: ${orgIdentifier}`));
-        process.exit(1);
-      }
+        const parsedPage = opts.page === undefined ? 1 : Number(opts.page);
+        if (!Number.isInteger(parsedPage) || parsedPage <= 0) {
+          logger.error("--page must be a positive integer");
+          process.exit(1);
+        }
+        const page = parsedPage;
 
-      const productList = await getProductsByOrg(org.id, { kind });
+        // org omitted → enumerate products across every org (releases-cli#259).
+        let org: Awaited<ReturnType<typeof findOrg>> | undefined;
+        if (orgIdentifier) {
+          org = await findOrg(orgIdentifier);
+          if (!org) {
+            console.error(chalk.red(`Organization not found: ${orgIdentifier}`));
+            process.exit(1);
+          }
+        }
 
-      if (productList.length === 0) {
-        if (opts.json) await writeJson([]);
-        else console.log(chalk.yellow(`No products found for organization: ${org.name}`));
-        return;
-      }
+        const { items: productList, pagination } = await listProducts({
+          orgId: org?.id,
+          kind,
+          limit: explicitLimit ? pageSize : undefined,
+          page: page > 1 ? page : undefined,
+        });
 
-      if (opts.json) {
-        await writeJson(productList);
-        return;
-      }
+        if (productList.length === 0) {
+          if (opts.json) await writeJson([]);
+          else if (org)
+            console.log(chalk.yellow(`No products found for organization: ${org.name}`));
+          else console.log(chalk.yellow("No products found."));
+          return;
+        }
 
-      console.log(
-        renderTable({
-          head: [
-            { label: "Name" },
-            { label: "Slug", noTruncate: true },
-            { label: "URL" },
-            { label: "Avatar" },
-            { label: "Sources", noTruncate: true, alignRight: true },
-          ],
-          rows: productList.map((p) => [
-            p.name,
-            p.slug,
-            p.url ?? chalk.dim("—"),
-            p.avatarUrl ?? chalk.dim("—"),
-            String(p.sourceCount),
-          ]),
-        }),
-      );
-    });
+        const warnIfTruncated = () => {
+          if (!explicitLimit && pagination.hasMore) {
+            logger.warn(
+              formatTruncationWarning({
+                returned: productList.length,
+                pageSize,
+                commandExample: "releases admin product list --limit <n> --page <p>",
+              }),
+            );
+          }
+        };
+
+        if (opts.json) {
+          await writeJson(productList);
+          warnIfTruncated();
+          return;
+        }
+
+        // Cross-org listing needs an Org column so a bare product slug is
+        // attributable; resolve ids → names once (orgs with products but no
+        // releases included). Org-scoped listing keeps the original columns.
+        const crossOrg = !org;
+        const orgNameById = new Map<string, string>();
+        if (crossOrg) {
+          const orgs = await listOrgs({ limit: 500, includeEmpty: true });
+          for (const o of orgs.items) orgNameById.set(o.id, o.name);
+        }
+
+        const head: ColumnSpec[] = [{ label: "Name" }];
+        if (crossOrg) head.push({ label: "Org" });
+        head.push(
+          { label: "Slug", noTruncate: true },
+          { label: "URL" },
+          { label: "Avatar" },
+          { label: "Sources", noTruncate: true, alignRight: true },
+        );
+
+        console.log(
+          renderTable({
+            head,
+            rows: productList.map((p) => {
+              const row = [p.name];
+              if (crossOrg) row.push(orgNameById.get(p.orgId) ?? p.orgId);
+              row.push(
+                p.slug,
+                p.url ?? chalk.dim("—"),
+                p.avatarUrl ?? chalk.dim("—"),
+                String(p.sourceCount),
+              );
+              return row;
+            }),
+          }),
+        );
+
+        warnIfTruncated();
+      },
+    );
 
   // ── product create (canonical) / product add (deprecated) ──
   product

--- a/tests/cli/product-list-all-orgs.test.ts
+++ b/tests/cli/product-list-all-orgs.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "bun:test";
+import { runCli } from "../utils.js";
+
+/**
+ * `releases admin product list` with no org argument enumerates products
+ * across every org (releases-cli#259) — closing the CLI↔MCP `list_catalog`
+ * gap that blocked a cross-org `kind=sdk` audit. The org argument is now
+ * optional; pagination flags (`--limit`/`--page`) are validated locally.
+ *
+ * Behavioral assertions stop at the network boundary: the suite runs against a
+ * fake API URL, so the no-org path is verified by the *absence* of the old
+ * "Please specify an organization" guard, not by inspecting a live response.
+ */
+describe("admin product list — org optional (#259)", () => {
+  it("--help documents the optional org argument and pagination flags", () => {
+    const { stdout, exitCode } = runCli(["admin", "product", "list", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("across all orgs");
+    // commander wraps the argument description across lines, so assert on a
+    // fragment that survives the wrap rather than the full sentence.
+    expect(stdout).toContain("across every org");
+    expect(stdout).toContain("--limit <n>");
+    expect(stdout).toContain("--page <n>");
+  });
+
+  it("no longer rejects a missing org argument", () => {
+    // Without an org it now proceeds to the API (which fails against the fake
+    // URL). The contract under test is that the old local guard is gone.
+    const { stderr } = runCli(["admin", "product", "list"]);
+    expect(stderr).not.toContain("Please specify an organization");
+  });
+
+  it("rejects an unknown --kind before any API call", () => {
+    const { stderr, exitCode } = runCli(["admin", "product", "list", "--kind", "nope"]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain('Invalid kind "nope"');
+  });
+
+  it("rejects a non-positive --limit before any API call", () => {
+    const { stderr, exitCode } = runCli(["admin", "product", "list", "--limit", "0"]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("--limit must be a positive integer");
+  });
+
+  it("rejects a non-positive --page before any API call", () => {
+    const { stderr, exitCode } = runCli(["admin", "product", "list", "--page", "-1"]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("--page must be a positive integer");
+  });
+});

--- a/tests/unit/api-client.test.ts
+++ b/tests/unit/api-client.test.ts
@@ -232,6 +232,110 @@ describe("listSourcesWithOrg", () => {
 });
 
 // ---------------------------------------------------------------------------
+// listProducts — org-agnostic product listing backing `releases admin product
+// list` with no org argument (releases-cli#259). Omitting orgId enumerates
+// products across every org; getProductsByOrg unwraps the envelope for the
+// single-org callers.
+// ---------------------------------------------------------------------------
+
+const productEnvelope = (items: unknown[], hasMore = false) => ({
+  items,
+  pagination: {
+    page: 1,
+    pageSize: items.length,
+    returned: items.length,
+    totalItems: items.length,
+    totalPages: 1,
+    hasMore,
+  },
+});
+
+describe("listProducts", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("omits orgId from the query string when no org is given", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = (async (url: string) => {
+      capturedUrl = url;
+      return new Response(JSON.stringify(productEnvelope([])), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as any;
+
+    await client.listProducts();
+    expect(capturedUrl).toContain("/v1/products");
+    expect(capturedUrl).not.toContain("orgId");
+  });
+
+  it("passes orgId, kind, limit, and page as query params", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = (async (url: string) => {
+      capturedUrl = url;
+      return new Response(JSON.stringify(productEnvelope([])), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as any;
+
+    await client.listProducts({ orgId: "org_abc", kind: "sdk", limit: 25, page: 3 });
+    expect(capturedUrl).toContain("orgId=org_abc");
+    expect(capturedUrl).toContain("kind=sdk");
+    expect(capturedUrl).toContain("limit=25");
+    expect(capturedUrl).toContain("page=3");
+  });
+
+  it("returns the paginated envelope from the worker", async () => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify(productEnvelope([{ id: "prod_1", orgId: "org_x" }], true)), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })) as any;
+
+    const res = await client.listProducts({ kind: "sdk" });
+    expect(res.items).toHaveLength(1);
+    expect(res.pagination.hasMore).toBe(true);
+  });
+
+  it("wraps the legacy bare-array shape in an envelope", async () => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify([{ id: "prod_1", orgId: "org_x" }]), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })) as any;
+
+    const res = await client.listProducts();
+    expect(res.items).toHaveLength(1);
+    expect(res.pagination.returned).toBe(1);
+  });
+
+  it("getProductsByOrg unwraps the envelope to a bare array", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = (async (url: string) => {
+      capturedUrl = url;
+      return new Response(JSON.stringify(productEnvelope([{ id: "prod_1", orgId: "org_x" }])), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as any;
+
+    const rows = await client.getProductsByOrg("org_x", { kind: "sdk" });
+    expect(Array.isArray(rows)).toBe(true);
+    expect(rows).toHaveLength(1);
+    expect(capturedUrl).toContain("orgId=org_x");
+    expect(capturedUrl).toContain("kind=sdk");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Embed backfill routes — paths moved from /v1/admin/embed/* to /v1/workflows/embed-*
 // (monorepo #494); status endpoint stayed on /v1/admin/embed/status.
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #259 — the CLI had no way to list products (or run a cross-org `kind=sdk` audit) across all orgs; that was only expressible via the remote MCP `list_catalog` tool.

This implements **Option 1** from the issue: the org argument on `releases admin product list` is now optional.

- **`releases admin product list`** (no org) enumerates products across **every** org, honoring `--kind`, `--json`, and new `--limit`/`--page` pagination flags.
- Backed by the **existing** org-agnostic `GET /v1/products` endpoint — **no API/worker change required**.
- The cross-org table gains an **Org** column so a bare product slug stays attributable; the resolved-name map is fetched once (`listOrgs`, `includeEmpty`) and only on the human-table path.
- **Org-scoped listing is unchanged** — same 5 columns, same bare-array `--json` shape (backward compatible).
- Surfaces a truncation warning when results hit the page boundary, matching `releases list`.

Combined with the existing `releases list --kind sdk` (sources), the registry-wide `kind` audit is now fully expressible from the CLI.

## Implementation

- `src/api/client.ts`: new `listProducts({ orgId?, kind?, limit?, page? })` returning the paginated envelope; `getProductsByOrg` now delegates to it (unwraps `.items`) so existing callers (`org get`, `org.ts`, MCP server) are untouched.
- `src/cli/commands/product.ts`: org arg optional, kind/limit/page validated pre-network, conditional Org column.
- Docs: `skills/releases-cli/references/admin.md` examples.

## Repro (now works)

```
releases admin product list --kind sdk --json    # was: "Please specify an organization"
```

## Verification

- `bun test` — 707 pass, 0 fail (5 new CLI behavior tests + 5 new `listProducts` client unit tests).
- `tsc --noEmit`, `oxlint`, `prettier --check` — all clean.
- Smoke-tested against prod: cross-org `--kind sdk` returns 14 SDK products spanning multiple orgs; org-scoped `vercel` listing unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The `releases admin product list` command now supports cross-organization product listing when the org argument is omitted, with pagination flags (`--limit`, `--page`) and an Org column displaying product attribution.

* **Documentation**
  * Added examples demonstrating cross-org product listing and kind-based filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->