### PR TITLE
feat(cli): add --discovery flag to admin org update and admin source update

### DIFF
--- a/.changeset/discovery-flag.md
+++ b/.changeset/discovery-flag.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": minor
+---
+
+`admin org update` and `admin source update` now accept `--discovery <status>` to promote or demote discovery status (`curated | agent | on_demand`).

--- a/src/cli/commands/org.ts
+++ b/src/cli/commands/org.ts
@@ -26,6 +26,7 @@ import { logger } from "@releases/lib/logger";
 import { orgNotFound } from "../suggest.js";
 import { toSlug } from "@buildinternet/releases-core/slug";
 import { isValidCategory, CATEGORIES } from "@buildinternet/releases-core/categories";
+import { SOURCE_DISCOVERY } from "@buildinternet/releases-core/source-enums";
 import { timeAgo } from "@buildinternet/releases-core/dates";
 import { writeJson } from "../../lib/output.js";
 import {
@@ -268,11 +269,25 @@ type OrgUpdateOpts = {
   avatar?: string | boolean;
   paused?: boolean;
   featured?: boolean;
+  discovery?: string;
   json?: boolean;
   dryRun?: boolean;
 };
 
 async function orgUpdateAction(identifier: string, opts: OrgUpdateOpts): Promise<void> {
+  // Validate enumerated options before any network call so errors surface fast.
+  if (typeof opts.category === "string" && !isValidCategory(opts.category)) {
+    logger.error(`Invalid category: "${opts.category}". Valid: ${CATEGORIES.join(", ")}`);
+    process.exit(1);
+  }
+  if (
+    opts.discovery !== undefined &&
+    !(SOURCE_DISCOVERY as readonly string[]).includes(opts.discovery)
+  ) {
+    logger.error(`Invalid discovery "${opts.discovery}". Valid: ${SOURCE_DISCOVERY.join(", ")}`);
+    process.exit(1);
+  }
+
   const found = await findOrg(identifier);
   if (!found) return orgNotFound(identifier);
 
@@ -285,10 +300,6 @@ async function orgUpdateAction(identifier: string, opts: OrgUpdateOpts): Promise
   if (opts.category === false) {
     updates.category = null;
   } else if (typeof opts.category === "string") {
-    if (!isValidCategory(opts.category)) {
-      logger.error(`Invalid category: "${opts.category}". Valid: ${CATEGORIES.join(", ")}`);
-      process.exit(1);
-    }
     updates.category = opts.category;
   }
 
@@ -301,6 +312,8 @@ async function orgUpdateAction(identifier: string, opts: OrgUpdateOpts): Promise
   // is `featured`; commander surfaces --featured/--no-featured as a single
   // boolean (undefined when neither is passed).
   if (opts.featured !== undefined) updates.featured = opts.featured;
+
+  if (opts.discovery !== undefined) updates.discovery = opts.discovery;
 
   if (Object.keys(updates).length === 0) {
     logger.warn("No fields to update.");
@@ -639,6 +652,10 @@ Examples:
     .option("--no-paused", "Resume ingest for this org's sources")
     .option("--featured", "Promote this org on the home-page featured rail")
     .option("--no-featured", "Remove this org from the home-page featured rail")
+    .option(
+      "--discovery <status>",
+      `Promote/demote discovery status (${SOURCE_DISCOVERY.join(" | ")})`,
+    )
     .option("--json", "Output as JSON")
     .option("--dry-run", "Show what would change without writing")
     .action(orgUpdateAction);
@@ -659,6 +676,10 @@ Examples:
     .option("--no-paused", "Resume ingest for this org's sources")
     .option("--featured", "Promote this org on the home-page featured rail")
     .option("--no-featured", "Remove this org from the home-page featured rail")
+    .option(
+      "--discovery <status>",
+      `Promote/demote discovery status (${SOURCE_DISCOVERY.join(" | ")})`,
+    )
     .option("--json", "Output as JSON")
     .option("--dry-run", "Show what would change without writing")
     .action(warnDeprecatedAlias<[string, OrgUpdateOpts]>("edit", "update", orgUpdateAction));

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -11,7 +11,7 @@ import {
 import { sourceNotFound } from "../suggest.js";
 import { toSlug } from "@buildinternet/releases-core/slug";
 import { isValidKind, KIND_VALUES, type Kind } from "@buildinternet/releases-core/kinds";
-import { SOURCE_TYPES } from "@buildinternet/releases-core/source-enums";
+import { SOURCE_TYPES, SOURCE_DISCOVERY } from "@buildinternet/releases-core/source-enums";
 import { logger } from "@releases/lib/logger";
 import { writeJson } from "../../lib/output.js";
 import { readContentArg } from "../../lib/input.js";
@@ -47,6 +47,7 @@ export type UpdateSourceOpts = {
   enable?: boolean;
   changelogPaths?: string | boolean;
   kind?: string | boolean;
+  discovery?: string;
   dryRun?: boolean;
   metadataSet?: string[];
   metadataUnset?: string[];
@@ -86,6 +87,17 @@ export async function updateSourceAction(
   identifier: string,
   opts: UpdateSourceOpts,
 ): Promise<void> {
+  // Validate enumerated options before any network call so errors surface fast.
+  if (
+    opts.discovery !== undefined &&
+    !(SOURCE_DISCOVERY as readonly string[]).includes(opts.discovery)
+  ) {
+    logger.error(
+      `Invalid discovery "${opts.discovery}". Must be one of: ${SOURCE_DISCOVERY.join(", ")}`,
+    );
+    process.exit(1);
+  }
+
   // `--no-parse-instructions` produces `false` (boolean); `--parse-instructions-file`
   // provides the content string. An empty file clears (matches the empty-string case).
   const parseInstructions: string | false | undefined =
@@ -222,6 +234,11 @@ export async function updateSourceAction(
     }
     updates.kind = opts.kind satisfies Kind;
     changes.push(`kind → ${opts.kind}`);
+  }
+
+  if (opts.discovery !== undefined) {
+    updates.discovery = opts.discovery;
+    changes.push(`discovery → ${opts.discovery}`);
   }
 
   const metaUpdates: Record<string, unknown> = {};
@@ -424,6 +441,10 @@ export function attachUpdateOptions(cmd: Command): Command {
       `Set source taxonomy (${KIND_VALUES.join(", ")}). Resolves through the parent product on content-oriented surfaces (releases feed, search release hits) and matches directly on metadata surfaces (lists, catalog).`,
     )
     .option("--no-kind", "Clear the source's kind (falls back to inheriting from parent product)")
+    .option(
+      "--discovery <status>",
+      `Promote/demote discovery status (${SOURCE_DISCOVERY.join(" | ")})`,
+    )
     .option(
       "--changelog-paths <paths>",
       "Comma-separated list of CHANGELOG paths (relative to repo root) for monorepo sources, e.g. 'packages/core/CHANGELOG.md,packages/cli/CHANGELOG.md'",

--- a/tests/cli/org-update-discovery.test.ts
+++ b/tests/cli/org-update-discovery.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "bun:test";
+import { runCli } from "../utils.js";
+
+/**
+ * Surface coverage for `releases admin org update --discovery` (buildinternet/releases#1317).
+ *
+ * Operators can promote/demote discovery status (curated | agent | on_demand).
+ * The body assembly (`updates.discovery = opts.discovery`) flows through the
+ * existing `updateOrg(found.slug, updates)` call; server persistence ships in
+ * the companion monorepo PR. Until then, the server silently ignores the field.
+ *
+ * Local validation (rejection of unknown values) is asserted here because it
+ * fires before any network call. Help-output tests confirm the option is
+ * registered on both the canonical `update` and the deprecated `edit` alias.
+ */
+describe("admin org update --discovery (CLI surface)", () => {
+  it("exposes --discovery on `org update`", () => {
+    const { stdout, exitCode } = runCli(["admin", "org", "update", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--discovery <status>");
+  });
+
+  it("exposes --discovery on the deprecated `org edit` alias", () => {
+    const { stdout, exitCode } = runCli(["admin", "org", "edit", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--discovery <status>");
+  });
+
+  it("help text mentions valid values", () => {
+    const { stdout, exitCode } = runCli(["admin", "org", "update", "--help"]);
+    expect(exitCode).toBe(0);
+    // commander may wrap the description; assert substrings
+    expect(stdout).toContain("curated");
+    expect(stdout).toContain("on_demand");
+  });
+});
+
+describe("admin org update --discovery validation", () => {
+  it("rejects an unknown discovery value before any API call", () => {
+    const { stderr, exitCode } = runCli([
+      "admin",
+      "org",
+      "update",
+      "some-org",
+      "--discovery",
+      "bogus",
+    ]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain('"bogus"');
+    // Confirm valid values are listed in the error
+    expect(stderr).toContain("curated");
+    expect(stderr).toContain("on_demand");
+  });
+
+  it("accepts 'curated' as a valid discovery value (no local validation error)", () => {
+    // The command will fail at the network/findOrg step with a fake URL, but
+    // the local validator must not reject it.
+    const { stderr } = runCli([
+      "admin",
+      "org",
+      "update",
+      "nonexistent-org-xyz",
+      "--discovery",
+      "curated",
+    ]);
+    expect(stderr).not.toContain("Invalid discovery");
+    expect(stderr).not.toContain('"curated"');
+  });
+
+  it("accepts 'agent' as a valid discovery value (no local validation error)", () => {
+    const { stderr } = runCli([
+      "admin",
+      "org",
+      "update",
+      "nonexistent-org-xyz",
+      "--discovery",
+      "agent",
+    ]);
+    expect(stderr).not.toContain("Invalid discovery");
+  });
+
+  it("accepts 'on_demand' as a valid discovery value (no local validation error)", () => {
+    const { stderr } = runCli([
+      "admin",
+      "org",
+      "update",
+      "nonexistent-org-xyz",
+      "--discovery",
+      "on_demand",
+    ]);
+    expect(stderr).not.toContain("Invalid discovery");
+  });
+});

--- a/tests/cli/source-update-discovery.test.ts
+++ b/tests/cli/source-update-discovery.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "bun:test";
+import { runCli } from "../utils.js";
+
+/**
+ * Surface coverage for `releases admin source update --discovery` (buildinternet/releases#1317).
+ *
+ * Operators can promote/demote discovery status (curated | agent | on_demand)
+ * on individual sources. The body assembly (`updates.discovery = opts.discovery`)
+ * flows through the existing `updateSource(source, updates)` call; server
+ * persistence ships in the companion monorepo PR.
+ *
+ * Local validation (rejection of unknown values) is asserted here because it
+ * fires before any network call. Help-output tests confirm the option is
+ * registered on the canonical `update` command.
+ */
+describe("admin source update --discovery (CLI surface)", () => {
+  it("exposes --discovery on `source update`", () => {
+    const { stdout, exitCode } = runCli(["admin", "source", "update", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--discovery <status>");
+  });
+
+  it("help text mentions valid values", () => {
+    const { stdout, exitCode } = runCli(["admin", "source", "update", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("curated");
+    expect(stdout).toContain("on_demand");
+  });
+});
+
+describe("admin source update --discovery validation", () => {
+  it("rejects an unknown discovery value before any API call", () => {
+    const { stderr, exitCode } = runCli([
+      "admin",
+      "source",
+      "update",
+      "some-source",
+      "--discovery",
+      "bogus",
+    ]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain('"bogus"');
+    // Confirm valid values are listed in the error
+    expect(stderr).toContain("curated");
+    expect(stderr).toContain("on_demand");
+  });
+
+  it("accepts 'curated' as a valid discovery value (no local validation error)", () => {
+    // The command will fail at the network/findSource step with a fake URL, but
+    // the local validator must not reject it.
+    const { stderr } = runCli([
+      "admin",
+      "source",
+      "update",
+      "nonexistent-source-xyz",
+      "--discovery",
+      "curated",
+    ]);
+    expect(stderr).not.toContain("Invalid discovery");
+    expect(stderr).not.toContain('"curated"');
+  });
+
+  it("accepts 'agent' as a valid discovery value (no local validation error)", () => {
+    const { stderr } = runCli([
+      "admin",
+      "source",
+      "update",
+      "nonexistent-source-xyz",
+      "--discovery",
+      "agent",
+    ]);
+    expect(stderr).not.toContain("Invalid discovery");
+  });
+
+  it("accepts 'on_demand' as a valid discovery value (no local validation error)", () => {
+    const { stderr } = runCli([
+      "admin",
+      "source",
+      "update",
+      "nonexistent-source-xyz",
+      "--discovery",
+      "on_demand",
+    ]);
+    expect(stderr).not.toContain("Invalid discovery");
+  });
+});


### PR DESCRIPTION
## Summary

Adds `--discovery <status>` to two admin commands, allowing operators to promote or demote discovery status (`curated | agent | on_demand`) on both orgs and individual sources:

- `releases admin org update <identifier> --discovery curated`
- `releases admin source update <identifier> --discovery on_demand`

Addresses Bug/feature of buildinternet/releases#1317 (cross-repo reference — the companion monorepo PR adds server-side persistence). Until that PR is deployed the server silently drops the field (zod strips unknown keys), so this PR is safe to merge in any order.

## Details

- Valid values are derived from `SOURCE_DISCOVERY` in `@buildinternet/releases-core/source-enums`, the same constant already used by the API wire types (`SourceDiscoverySchema`).
- Validation fires **before** any network call in both action functions, so a typo produces an immediate, clear error without a round-trip.
- The `discovery` field flows through the existing `updateOrg(slug, updates)` and `updateSource(source, updates)` PATCH calls with no changes to the API client.
- No `@buildinternet/releases-api-types` bump required — both client functions accept `Record<string, unknown>` bodies.
- A minor-bump changeset is included (`.changeset/discovery-flag.md`, targeting `@buildinternet/releases`).

## Test plan

- [x] `bun test` — 724 pass, 0 fail (includes 13 new tests in `tests/cli/org-update-discovery.test.ts` and `tests/cli/source-update-discovery.test.ts`)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — 0 warnings, 0 errors
- [ ] Manual smoke: `releases admin org update <slug> --discovery curated --dry-run` (once companion monorepo PR is deployed, verify the field persists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
