### PR TITLE
feat(cli): add `admin source create-video` verb + reject YouTube URLs in generic create

### DIFF
--- a/.changeset/cli-source-create-video.md
+++ b/.changeset/cli-source-create-video.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": minor
+---
+
+Add `admin source create-video <channel-or-playlist-url> --org <slug>` to materialize a `video` source from a YouTube channel/playlist (`POST /v1/sources/video`), surfacing the resolved provider/channel and backfilled release count. The generic `source create` now rejects `--type video` and pasted `youtube.com`/`youtu.be` URLs with a pointer to the dedicated verb — mirroring the App Store guard — so a YouTube URL can no longer be silently mis-created as an empty-bodied feed source.

--- a/skills/managing-sources/SKILL.md
+++ b/skills/managing-sources/SKILL.md
@@ -16,6 +16,7 @@ Operations can be performed via CLI commands or typed MCP/agent tools. Use which
 | List sources | `releases list [slug] --json [--org <org>] [--query <text>] [--has-feed] [--category <c>] [--compact] [--limit <n>] [--page <n>]` | `list_catalog` (filter `kind: "source"` to exclude products); `list_sources` is a deprecated alias |
 | Add source | `releases admin source create <name> --url <url> [--type <type>] [--org <org>] [--feed-url <url>] [--primary]` | `manage_source` action "add" with name, url, type, organization, feed_url, **is_primary** (type auto-detected if omitted; only pass is_primary=true when the source is the org's primary changelog — see "Primary Sources") |
 | Add App Store source | `releases admin source create-appstore <url-or-id> [--platform ios\|macos] [--org <slug>] [--product <slug>] [--storefront <code>]` | _(no typed tool yet — CLI only)_ |
+| Add video source | `releases admin source create-video <channel-or-playlist-url> --org <slug> [--product <slug>]` | _(no typed tool yet — CLI only)_ |
 | Edit source | `releases admin source update <identifier> [--primary] [--priority <p>]` | `manage_source` action "edit" with identifier, is_primary, fetch_priority, name, url, type (use only when changing an already-added source; prefer setting flags on "add") |
 | Remove source | `releases admin source delete <slug> [--ignore --reason <reason>]` | `manage_source` action "remove" with identifier |
 | Fetch releases | `releases admin source fetch <slug> [--dry-run] [--max <n>]` | `manage_source` action "fetch" with identifier |
@@ -48,7 +49,7 @@ Use `--json` (CLI) for structured output. Typed tools always return JSON.
 
 ## Adding Sources
 
-Required: **name** and **url**. Optional: **type** (github, scrape, feed, agent — auto-detected from URL if omitted), **organization** (org ID or slug to associate with), **feed_url** (direct feed URL if known). App Store apps (`appstore` type) are **not** created this way — use `create-appstore` (below); `source create` rejects `--type appstore` and pasted `apps.apple.com` URLs with a pointer to it.
+Required: **name** and **url**. Optional: **type** (github, scrape, feed, agent — auto-detected from URL if omitted), **organization** (org ID or slug to associate with), **feed_url** (direct feed URL if known). App Store apps (`appstore` type) are **not** created this way — use `create-appstore` (below); `source create` rejects `--type appstore` and pasted `apps.apple.com` URLs with a pointer to it. YouTube channels/playlists (`video` type) are likewise **not** created this way — use `create-video` (below); `source create` rejects `--type video` and pasted `youtube.com`/`youtu.be` URLs.
 
 On slug collision the API auto-suffixes (`changelog` → `changelog-2`, `-3`, …) and the created row in the response tells you the resolved slug — no rename-and-retry needed.
 
@@ -70,6 +71,19 @@ releases admin source create-appstore <url-or-id> [--platform ios|macos] [--org 
 
 - **Keep writes serial.** The endpoint resolves the listing on the fly; concurrent creates for a brand-new org/product race on the org/product slug uniqueness constraint. Add one app at a time.
 - The command is idempotent on the app's track ID — re-running reports the existing source instead of creating a duplicate.
+
+### Video sources
+
+YouTube channels and playlists need a dedicated command because the create flow resolves the channel/playlist to its Atom feed, mints a `video` source, and backfills current videos as releases (description-only, summarizer-cleaned, marketing-filtered):
+
+```
+releases admin source create-video <channel-or-playlist-url> --org <slug> [--product <slug>]
+```
+
+- `<channel-or-playlist-url>` is a YouTube channel (`youtube.com/@handle`, `/channel/<id>`) or playlist (`/playlist?list=<id>`) URL.
+- **`--org` is required and must already exist** — unlike `create-appstore`, no org is derived from the channel. Pass a slug or a typed `org_…` id. `--product <slug>` optionally attaches the source to an existing product.
+- The command is idempotent on the resolved feed URL — re-running reports the existing source.
+- **Never use generic `source create` for a YouTube URL.** It builds a `feed` source whose parser drops `media:group/media:description`, leaving a source with titles and dates but **empty release bodies** — a silent failure that needs deleting and re-creating to fix. `create` rejects YouTube URLs with a pointer to `create-video`.
 
 ### Naming sources and products
 

--- a/skills/releases-cli/references/admin.md
+++ b/skills/releases-cli/references/admin.md
@@ -40,7 +40,7 @@ releases admin source create "Linear" --url https://linear.app/changelog --dry-r
 
 `--dry-run` still runs the URL dedup and exclusion checks (so you'll see "already exists" or "blocked URL" outcomes), but skips the write — including the auto-create-org side effect when `--org <name>` doesn't resolve.
 
-By default, `create` runs automated pre-checks (provider detection, feed discovery, markdown probing). Override with `--type github|scrape|feed|agent`. Batch mode (`--batch`) skips evaluation by default for speed. App Store apps use the dedicated `source create-appstore` verb (below) — `create` rejects `--type appstore` and pasted `apps.apple.com` URLs with a pointer to it.
+By default, `create` runs automated pre-checks (provider detection, feed discovery, markdown probing). Override with `--type github|scrape|feed|agent`. Batch mode (`--batch`) skips evaluation by default for speed. App Store apps use the dedicated `source create-appstore` verb (below) — `create` rejects `--type appstore` and pasted `apps.apple.com` URLs with a pointer to it. YouTube channels/playlists use `source create-video` (below) — `create` likewise rejects `--type video` and pasted `youtube.com`/`youtu.be` URLs.
 
 Provide a feed URL explicitly when it isn't easily discoverable:
 
@@ -86,6 +86,20 @@ releases admin source create-appstore https://apps.apple.com/us/app/shopify/id71
 ```
 
 Add one app at a time — the listing is resolved on the fly, and concurrent creates for a brand-new org/product race on slug uniqueness.
+
+### Create Video
+
+YouTube channels and playlists have a dedicated verb because the create flow resolves the channel/playlist to its Atom feed, mints a `video` source, and backfills current videos as releases (description-only, summarizer-cleaned, marketing-filtered):
+
+```bash
+releases admin source create-video https://www.youtube.com/@AnthropicAI --org anthropic
+releases admin source create-video https://www.youtube.com/playlist?list=PLf2m23nhTg1P --org anthropic --product claude
+releases admin source create-video https://www.youtube.com/@AnthropicAI --org anthropic --dry-run
+```
+
+`--org` is **required** and must already exist — unlike `create-appstore`, no org is derived from the channel. Pass a slug or a typed `org_…` id. `--product <slug>` (optional) attaches the source to an existing product. The verb is idempotent on the resolved feed URL — re-running reports the existing source.
+
+Do not point generic `source create` at a YouTube URL. It builds a `feed` source whose parser drops `media:group/media:description`, producing a source with titles and dates but **empty release bodies** — a silent failure. `create` rejects `--type video` and pasted `youtube.com`/`youtu.be` URLs with a pointer to this verb.
 
 ### Update
 

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -35,6 +35,7 @@ import type {
   MediaItem,
   OrgDependentsResponse,
   AppStoreMaterializeResponse,
+  VideoMaterializeResponse,
 } from "./types.js";
 import { computePagination, type ListResponse } from "@buildinternet/releases-core/cli-contracts";
 import type {
@@ -1006,6 +1007,33 @@ export async function createAppStoreSource(params: {
     Object.entries(params).filter(([, v]) => v !== null && v !== undefined),
   );
   return apiFetch<AppStoreMaterializeResponse>("/v1/sources/appstore", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+/**
+ * Materialize a video source via `POST /v1/sources/video`. Resolves a YouTube
+ * channel/playlist URL into its Atom feed, mints a `video` source under the
+ * given org, and backfills current videos as releases (description-only,
+ * summarizer-cleaned, marketing-filtered). `orgSlug` or `orgId` is required —
+ * unlike the App Store path, no org is derived from the feed, so the org must
+ * already exist. Idempotent on the resolved feed URL: `status: "indexed"` is a
+ * new source (HTTP 201), `"existing"` an idempotent hit (HTTP 200). Writes
+ * should stay serial — concurrent POSTs for a brand-new org race on
+ * `UNIQUE(org_id, slug)`.
+ */
+export async function createVideoSource(params: {
+  url: string;
+  orgSlug?: string;
+  orgId?: string;
+  productId?: string;
+}): Promise<VideoMaterializeResponse> {
+  // Strip undefined/null so optional fields don't reach the API as explicit nulls.
+  const body = Object.fromEntries(
+    Object.entries(params).filter(([, v]) => v !== null && v !== undefined),
+  );
+  return apiFetch<VideoMaterializeResponse>("/v1/sources/video", {
     method: "POST",
     body: JSON.stringify(body),
   });

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -6,3 +6,35 @@
  * bump the pin in `package.json` when adopting new response shapes.
  */
 export * from "@buildinternet/releases-api-types";
+
+/**
+ * Response from `POST /v1/sources/video` — materializes a YouTube
+ * channel/playlist into a curated Org → Source → backfilled Releases.
+ *
+ * Structurally identical to `AppStoreMaterializeResponse`: a bare inserted (or
+ * idempotently looked-up) source row plus a `releaseCount`. Defined locally
+ * rather than re-exported because `@buildinternet/releases-api-types` does not
+ * yet ship a video schema — the `/v1/sources/video` route is hidden from the
+ * production OpenAPI surface. Replace with the published type once api-types
+ * exports one.
+ *
+ * `status: "indexed"` is a brand-new source (HTTP 201); `"existing"` is the
+ * idempotent hit on a prior materialize of the same resolved feed URL
+ * (HTTP 200). The resolved provider/channel live inside `source.metadata`
+ * (a JSON string) under `video: { provider, channel }`.
+ */
+export interface VideoMaterializeResponse {
+  status: "indexed" | "existing";
+  source: {
+    id: string;
+    slug: string;
+    name: string;
+    type: string;
+    url: string;
+    orgId: string | null;
+    productId: string | null;
+    metadata: string | null;
+    [key: string]: unknown;
+  };
+  releaseCount: number;
+}

--- a/src/cli/commands/add.ts
+++ b/src/cli/commands/add.ts
@@ -19,7 +19,7 @@ export function registerAddCommand(program: Command) {
     .argument("[name]", "Display name for the source")
     .option(
       "--type <type>",
-      "Source type: github, scrape, feed, or agent (auto-detected from URL if omitted)",
+      "Source type: github, scrape, feed, or agent (auto-detected from URL if omitted). App Store apps use `source create-appstore`; YouTube channels/playlists use `source create-video`.",
     )
     .option("--url <url>", "URL of the source")
     .option("--slug <slug>", "Custom slug (auto-derived from name if omitted)")

--- a/src/cli/commands/create-video.ts
+++ b/src/cli/commands/create-video.ts
@@ -1,0 +1,187 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { createVideoSource, findProduct } from "../../api/client.js";
+import { logger } from "@releases/lib/logger";
+import { writeJson } from "../../lib/output.js";
+
+/**
+ * True when `value` points at a supported video host. YouTube only today
+ * (`youtube.com` incl. subdomains like `m.`/`music.`, or `youtu.be`), with or
+ * without a scheme. Shared with the generic `create` guard so a pasted YouTube
+ * URL is redirected to `create-video` rather than mis-fetched as a `scrape`/
+ * `feed` source — a generic feed source over a YouTube URL silently produces
+ * empty release bodies (the feed parser drops `media:group/media:description`).
+ * See issue #1260.
+ */
+export function isVideoUrl(value: string): boolean {
+  let candidate = value.trim();
+  if (!candidate) return false;
+  if (!/^https?:\/\//i.test(candidate)) candidate = `https://${candidate}`;
+  try {
+    const { hostname } = new URL(candidate);
+    return /(^|\.)youtube\.com$/i.test(hostname) || /^youtu\.be$/i.test(hostname);
+  } catch {
+    return false;
+  }
+}
+
+/** Resolved provider + channel display name, pulled from the source's metadata JSON. */
+function videoMetaFromSource(metadata: string | null): { provider?: string; channel?: string } {
+  if (!metadata) return {};
+  try {
+    const block = (
+      JSON.parse(metadata) as {
+        video?: { provider?: string; channel?: { title?: string; playlistTitle?: string } };
+      } | null
+    )?.video;
+    return {
+      provider: block?.provider,
+      channel: block?.channel?.playlistTitle ?? block?.channel?.title,
+    };
+  } catch {
+    return {};
+  }
+}
+
+type CreateVideoOpts = {
+  org?: string;
+  product?: string;
+  json?: boolean;
+  dryRun?: boolean;
+};
+
+export async function createVideoAction(url: string, opts: CreateVideoOpts): Promise<void> {
+  const trimmed = (url ?? "").trim();
+  if (!trimmed) {
+    logger.error(chalk.red("Provide a YouTube channel or playlist URL."));
+    process.exit(1);
+  }
+  if (!isVideoUrl(trimmed)) {
+    logger.error(
+      chalk.red(
+        `Could not recognize "${url}" as a video URL. Expected a YouTube channel or playlist URL (youtube.com / youtu.be).`,
+      ),
+    );
+    process.exit(1);
+  }
+  if (!opts.org) {
+    logger.error(
+      chalk.red("Video sources require --org <slug> (no org is derived from the channel feed)."),
+    );
+    process.exit(1);
+  }
+
+  // The endpoint accepts `orgSlug` OR `orgId`. Forward a typed `org_…`
+  // identifier as `orgId`; otherwise treat the value as a slug.
+  const orgIsTypedId = opts.org.startsWith("org_");
+  const orgSlug = orgIsTypedId ? undefined : opts.org;
+  const orgId = orgIsTypedId ? opts.org : undefined;
+
+  if (opts.dryRun) {
+    // Show the planned request without writing. Skip the product slug→id
+    // lookup so dry-run stays network-free; the resolution happens at create
+    // time on the real path.
+    const preview: Record<string, string> = { url: trimmed };
+    if (orgId) preview.orgId = orgId;
+    if (orgSlug) preview.orgSlug = orgSlug;
+    if (opts.product) preview.product = opts.product;
+    if (opts.json) {
+      await writeJson({ wouldPost: "/v1/sources/video", body: preview });
+    } else {
+      logger.info(chalk.yellow("[dry-run] Would POST /v1/sources/video"));
+      for (const [k, v] of Object.entries(preview)) logger.info(`  ${k}: ${v}`);
+      if (opts.product) {
+        logger.info(chalk.dim("Note: --product resolves the slug to a product id at create time."));
+      }
+      logger.info(
+        chalk.dim(
+          "Note: the source name + slug are resolved from the channel feed at create time.",
+        ),
+      );
+    }
+    return;
+  }
+
+  // The video endpoint takes a typed `productId` (not a slug), so resolve a
+  // `--product <slug>` client-side, matching the slug UX of `create`/`create-appstore`.
+  let productId: string | undefined;
+  if (opts.product) {
+    let prod;
+    try {
+      prod = await findProduct(opts.product);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.error(chalk.red(`Failed to resolve --product "${opts.product}": ${msg}`));
+      process.exit(1);
+    }
+    if (!prod) {
+      logger.error(chalk.red(`Product not found: "${opts.product}"`));
+      process.exit(1);
+    }
+    productId = prod.id;
+  }
+
+  let result;
+  try {
+    result = await createVideoSource({ url: trimmed, orgSlug, orgId, productId });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.error(chalk.red(`Failed to create video source: ${msg}`));
+    process.exit(1);
+  }
+
+  if (opts.json) {
+    await writeJson(result);
+    return;
+  }
+
+  const { source, releaseCount, status } = result;
+  const { provider, channel } = videoMetaFromSource(source.metadata);
+  const tag = provider ? chalk.dim(`[${provider}]`) : "";
+  const channelLabel = channel ? ` — ${channel}` : "";
+  const releaseLabel = `${releaseCount} release${releaseCount === 1 ? "" : "s"}`;
+  if (status === "existing") {
+    logger.info(
+      chalk.yellow(
+        `Video source already indexed: ${source.name} (${source.slug}) ${tag}${channelLabel} — ${releaseLabel}`,
+      ),
+    );
+  } else {
+    logger.info(
+      chalk.green(
+        `Video source created: ${source.name} (${source.slug}) ${tag}${channelLabel} — ${releaseLabel} indexed`,
+      ),
+    );
+  }
+}
+
+export function registerCreateVideoCommand(program: Command) {
+  program
+    .command("create-video")
+    .description(
+      "Create a video source from a YouTube channel/playlist (resolves the feed, backfills current videos as releases)",
+    )
+    .argument("<channel-or-playlist-url>", "YouTube channel or playlist URL")
+    .option("--org <slug>", "Organization slug or org_ id (required — must already exist)")
+    .option("--product <slug>", "Existing product slug to attach the source to")
+    .option("--json", "Output as JSON")
+    .option("--dry-run", "Show the request that would be sent without creating")
+    .addHelpText(
+      "after",
+      `
+Examples:
+  releases admin source create-video https://www.youtube.com/@AnthropicAI --org anthropic
+  releases admin source create-video https://www.youtube.com/playlist?list=PLf2m23nhTg1P --org anthropic --product claude
+  releases admin source create-video https://www.youtube.com/@AnthropicAI --org anthropic --dry-run
+
+Notes:
+  - The org is required and must already exist — unlike create-appstore, no org
+    is derived from the channel. Backfilled videos are description-only and run
+    through the marketing-filtered ingest. The verb is idempotent on the
+    resolved feed URL; re-running reports the existing source.
+  - Do not use generic 'source create' for a YouTube URL — it builds a feed
+    source that drops the video descriptions (empty release bodies). 'create'
+    rejects YouTube URLs with a pointer here.`,
+    )
+    .action(createVideoAction);
+}

--- a/src/cli/commands/create.ts
+++ b/src/cli/commands/create.ts
@@ -15,6 +15,7 @@ import { writeJson } from "../../lib/output.js";
 import { readContentArg } from "../../lib/input.js";
 import { parseMetadataSetFlag, parseTagList } from "../../lib/flags.js";
 import { isAppStoreUrl, isAppStoreCoordinate } from "./create-appstore.js";
+import { isVideoUrl } from "./create-video.js";
 
 function isValidType(t: string): t is SourceType {
   return (SOURCE_TYPES as readonly string[]).includes(t);
@@ -24,6 +25,12 @@ const APPSTORE_REDIRECT =
   "App Store sources use a dedicated command: `releases admin source create-appstore <url-or-id>` " +
   "(it resolves the listing, mints the first release, and backfills the app icon). " +
   "`source create` cannot materialize them.";
+
+const VIDEO_REDIRECT =
+  "Video sources use a dedicated command: `releases admin source create-video <channel-or-playlist-url> --org <slug>` " +
+  "(it resolves the channel/playlist feed, mints a `video` source, and backfills video descriptions through the " +
+  "marketing-filtered ingest). `source create` cannot materialize them — a generic feed/scrape source over a " +
+  "YouTube URL silently produces empty release bodies.";
 
 export function isGitHubUrl(url: string): boolean {
   return /^https?:\/\/(www\.)?github\.com\/[^/]+\/[^/]+/.test(url);
@@ -60,6 +67,27 @@ interface CreateSourceResult {
 
 async function createSingleSource(input: CreateSourceInput): Promise<CreateSourceResult> {
   const { name, url } = input;
+
+  // Video sources (YouTube channels/playlists) can't be materialized through
+  // the generic create path — the dedicated endpoint resolves the channel/
+  // playlist to its Atom feed, mints a `video` source, and backfills video
+  // descriptions through the marketing-filtered ingest. A generic feed/scrape
+  // source over a YouTube URL silently produces empty release bodies (the feed
+  // parser drops `media:group/media:description`) — issue #1260. Reject an
+  // explicit `--type video` or a pasted youtube.com/youtu.be URL, pointing the
+  // caller at `create-video`. Runs BEFORE the isValidType check because `video`
+  // is a dedicated endpoint-only type, not a generic-`create` source type (and
+  // may not be present in this CLI's pinned source-type enum).
+  if (input.type === "video" || isVideoUrl(url)) {
+    return {
+      name,
+      slug: input.slug ?? toSlug(name),
+      type: "video",
+      url,
+      status: "error",
+      error: VIDEO_REDIRECT,
+    };
+  }
 
   if (input.type && !isValidType(input.type)) {
     return {
@@ -470,7 +498,7 @@ function attachCreateOptions(cmd: Command): Command {
     .argument("[name]", "Display name for the source")
     .option(
       "--type <type>",
-      "Source type: github, scrape, feed, or agent (auto-detected from URL if omitted). App Store apps use `source create-appstore`.",
+      "Source type: github, scrape, feed, or agent (auto-detected from URL if omitted). App Store apps use `source create-appstore`; YouTube channels/playlists use `source create-video`.",
     )
     .option("--url <url>", "URL of the source")
     .option("--slug <slug>", "Custom slug (auto-derived from name if omitted)")

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -3,6 +3,7 @@ import chalk from "chalk";
 import { registerAddCommand } from "./commands/add.js";
 import { registerCreateCommand } from "./commands/create.js";
 import { registerCreateAppStoreCommand } from "./commands/create-appstore.js";
+import { registerCreateVideoCommand } from "./commands/create-video.js";
 import { registerEditCommand } from "./commands/edit.js";
 import { registerUpdateCommand } from "./commands/update.js";
 import { registerRemoveCommand } from "./commands/remove.js";
@@ -257,6 +258,7 @@ registerListCommand(sourceAdmin);
 // Canonical verbs: create, update, delete. Deprecated aliases: add, edit, remove (each emits a warning).
 registerCreateCommand(sourceAdmin);
 registerCreateAppStoreCommand(sourceAdmin);
+registerCreateVideoCommand(sourceAdmin);
 registerAddCommand(sourceAdmin);
 registerUpdateCommand(sourceAdmin);
 registerEditCommand(sourceAdmin);

--- a/tests/cli/video-source.test.ts
+++ b/tests/cli/video-source.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "bun:test";
+import { runCli } from "../utils.js";
+
+/**
+ * CLI-surface coverage for video source support (#1260). These exercise flags,
+ * validation, the dry-run preview, and the generic-`create` redirect guard —
+ * all of which short-circuit before any network call, so no API is needed.
+ */
+describe("source create-video --help", () => {
+  it("documents the verb and its flags", () => {
+    const { stdout, exitCode } = runCli(["admin", "source", "create-video", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--org");
+    expect(stdout).toContain("--product");
+    expect(stdout).toContain("--dry-run");
+    expect(stdout).toContain("youtube.com");
+  });
+});
+
+describe("source create-video validation", () => {
+  it("rejects a non-video URL", () => {
+    const { stdout, stderr, exitCode } = runCli([
+      "admin",
+      "source",
+      "create-video",
+      "https://example.com/changelog",
+      "--org",
+      "acme",
+      "--dry-run",
+    ]);
+    expect(exitCode).toBe(1);
+    expect(stdout + stderr).toContain("video URL");
+  });
+
+  it("requires --org", () => {
+    const { stdout, stderr, exitCode } = runCli([
+      "admin",
+      "source",
+      "create-video",
+      "https://www.youtube.com/@AnthropicAI",
+      "--dry-run",
+    ]);
+    expect(exitCode).toBe(1);
+    expect(stdout + stderr).toContain("--org");
+  });
+
+  it("dry-run prints the planned request without creating", () => {
+    const { stdout, stderr, exitCode } = runCli([
+      "admin",
+      "source",
+      "create-video",
+      "https://www.youtube.com/@AnthropicAI",
+      "--org",
+      "anthropic",
+      "--dry-run",
+    ]);
+    expect(exitCode).toBe(0);
+    const out = stdout + stderr;
+    expect(out).toContain("dry-run");
+    expect(out).toContain("/v1/sources/video");
+    expect(out).toContain("orgSlug");
+    expect(out).toContain("anthropic");
+  });
+
+  it("dry-run forwards a typed org_ id as orgId", () => {
+    const { stdout, stderr, exitCode } = runCli([
+      "admin",
+      "source",
+      "create-video",
+      "https://www.youtube.com/@AnthropicAI",
+      "--org",
+      "org_abc123",
+      "--dry-run",
+    ]);
+    expect(exitCode).toBe(0);
+    const out = stdout + stderr;
+    expect(out).toContain("orgId");
+    expect(out).toContain("org_abc123");
+  });
+});
+
+describe("source create rejects video inputs with a redirect", () => {
+  it("rejects an explicit --type video", () => {
+    const { stdout, stderr, exitCode } = runCli([
+      "admin",
+      "source",
+      "create",
+      "Anthropic",
+      "--url",
+      "https://example.com/x",
+      "--type",
+      "video",
+    ]);
+    expect(exitCode).toBe(1);
+    expect(stdout + stderr).toContain("create-video");
+  });
+
+  it("rejects a pasted YouTube URL (auto-detected)", () => {
+    const { stdout, stderr, exitCode } = runCli([
+      "admin",
+      "source",
+      "create",
+      "Anthropic",
+      "--url",
+      "https://www.youtube.com/@AnthropicAI",
+    ]);
+    expect(exitCode).toBe(1);
+    expect(stdout + stderr).toContain("create-video");
+  });
+});

--- a/tests/unit/video-input.test.ts
+++ b/tests/unit/video-input.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "bun:test";
+import { isVideoUrl } from "../../src/cli/commands/create-video.js";
+
+describe("isVideoUrl", () => {
+  it("matches youtube.com channel/playlist URLs with and without scheme", () => {
+    expect(isVideoUrl("https://www.youtube.com/@AnthropicAI")).toBe(true);
+    expect(isVideoUrl("www.youtube.com/@AnthropicAI")).toBe(true);
+    expect(isVideoUrl("youtube.com/@AnthropicAI")).toBe(true);
+    expect(
+      isVideoUrl("https://www.youtube.com/playlist?list=PLf2m23nhTg1P_pl05on_Qbob_qx_Vw"),
+    ).toBe(true);
+  });
+
+  it("matches youtube subdomains and the youtu.be short host", () => {
+    expect(isVideoUrl("https://m.youtube.com/@AnthropicAI")).toBe(true);
+    expect(isVideoUrl("https://music.youtube.com/channel/UC123")).toBe(true);
+    expect(isVideoUrl("https://youtu.be/dQw4w9WgXcQ")).toBe(true);
+  });
+
+  it("rejects other hosts and look-alikes", () => {
+    expect(isVideoUrl("https://example.com/watch")).toBe(false);
+    expect(isVideoUrl("https://notyoutube.com/@x")).toBe(false);
+    expect(isVideoUrl("https://youtube.com.evil.com/@x")).toBe(false);
+    expect(isVideoUrl("https://vimeo.com/12345")).toBe(false);
+  });
+
+  it("rejects empty/blank input", () => {
+    expect(isVideoUrl("")).toBe(false);
+    expect(isVideoUrl("   ")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a `releases admin source create-video <channel-or-playlist-url> --org <slug>` verb that materializes a `video` source from a YouTube channel/playlist via `POST /v1/sources/video`, and a redirect guard so the generic `source create` no longer silently mis-creates YouTube URLs as empty-bodied feed sources. Mirrors the App Store precedent (`create-appstore`, cli#247 / releases#1240).

Resolves the CLI portion of buildinternet/releases#1260.

## What's in it

- **`create-video` verb** (`src/cli/commands/create-video.ts`) — POSTs `{ url, orgSlug | orgId, productId? }` to `/v1/sources/video` and prints the resolved source, provider/channel, and backfilled release count, distinguishing `indexed` (new, HTTP 201) vs `existing` (idempotent on the resolved feed URL, HTTP 200).
  - `--org` is **required** and must already exist — unlike `create-appstore`, no org is derived from the channel feed. Accepts a slug or a typed `org_…` id.
  - `--product <slug>` is resolved to a `productId` client-side via `findProduct` (the endpoint takes a typed id, not a slug). Skipped on `--dry-run` so dry-run stays network-free.
  - `--json` and `--dry-run` supported.
- **Redirect guard** (`src/cli/commands/create.ts`) — `source create` (and its deprecated `add` alias, which shares the same path) rejects `--type video` and pasted `youtube.com`/`youtu.be` URLs with a pointer to `create-video`. The guard runs **before** the source-type validation, because the CLI's pinned `@buildinternet/releases-core` does not yet carry `video` in `SOURCE_TYPES` — otherwise `--type video` would fall through to a generic "Invalid type" error instead of the redirect.
- **Local wire type** (`src/api/types.ts`) — `VideoMaterializeResponse`, structurally identical to `AppStoreMaterializeResponse`. Defined locally because `@buildinternet/releases-api-types` doesn't yet ship a video schema (the route is hidden from the prod OpenAPI surface); swap to the published type once api-types exports one.
- **Docs** — `skills/releases-cli/references/admin.md` and `skills/managing-sources/SKILL.md` gain a "Create Video" / "Video sources" section and the `create` rejection note.
- **Changeset** — `@buildinternet/releases`: minor.

## Why the guard matters

From the issue's severity note: a YouTube URL handed to generic `create` built a `feed` source whose parser drops `media:group/media:description`, producing a source with titles and dates but **empty release bodies** — a silent failure that previously required deleting and re-creating via the raw API to fix. The guard turns that into a hard error pointing at the right verb.

## Tests

- `tests/unit/video-input.test.ts` — `isVideoUrl` matching (scheme-less, subdomains, `youtu.be`, host-spoof look-alikes like `youtube.com.evil.com`).
- `tests/cli/video-source.test.ts` — `--help`, validation (non-video URL, missing `--org`), dry-run preview (slug + typed `org_` id), and both `create` redirect paths.

All checks green locally: `tsc --noEmit`, `oxlint`, `prettier --check`, and the full `bun test` suite (747 pass). A code-review pass confirmed the guard ordering, host-spoof safety, and metadata-parse null safety.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
