### PR TITLE
feat(cli): add --primary to `admin source create` (#263)

### DIFF
--- a/.changeset/cli-source-create-primary.md
+++ b/.changeset/cli-source-create-primary.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": minor
+---
+
+Add `--primary` to `admin source create` so an org's primary changelog can be marked in one step (`isPrimary` on the create POST), instead of creating the source and then running a follow-up `admin source update <slug> --primary`. The REST create endpoint and the `manage_source` "add" action already accepted this — the CLI was the only surface missing it, so it no longer rejects the `--primary` the `managing-sources` skill documents.

--- a/skills/releases-cli/references/admin.md
+++ b/skills/releases-cli/references/admin.md
@@ -60,6 +60,12 @@ releases admin source create "Acme" --url https://acme.dev/changelog \
 
 Do this rather than a follow-up `source update --metadata-set`: `create` triggers the onboard workflow's auto-fetch, which reads the source's metadata **before** any post-create edit lands. Setting a feed filter on create keeps that first ingest filtered; setting it afterward races the auto-fetch and ingests the whole unfiltered feed.
 
+Mark the org's primary changelog in one step with `--primary` (sets `isPrimary` on create — no follow-up `source update --primary` needed). Only pass it when the source is the org's main, company-wide changelog:
+
+```bash
+releases admin source create "Vitest" --url https://github.com/vitest-dev/vitest --org vitest --primary
+```
+
 Evaluate without adding:
 
 ```bash

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -973,6 +973,7 @@ export async function createSource(data: {
   orgId?: string | null;
   productId?: string | null;
   metadata?: string;
+  isPrimary?: boolean;
 }): Promise<Source> {
   // Strip null/undefined values so the API's z.string().optional() schema
   // doesn't reject an explicit `"productId": null` in the JSON body.

--- a/src/cli/commands/create.ts
+++ b/src/cli/commands/create.ts
@@ -48,6 +48,8 @@ interface CreateSourceInput {
   keywordAllow?: string;
   /** Raw `key=value` tokens → arbitrary `metadata` keys (mirrors `source update`). */
   metadataSet?: string[];
+  /** Mark the source as the org's primary changelog (→ `isPrimary: true` on create). */
+  primary?: boolean;
   batch?: boolean;
   strict?: boolean;
   dryRun?: boolean;
@@ -308,6 +310,9 @@ async function createSingleSource(input: CreateSourceInput): Promise<CreateSourc
       orgId,
       productId,
       metadata: Object.keys(metadata).length > 0 ? JSON.stringify(metadata) : undefined,
+      // Omit unless explicitly set so the create body stays minimal and the API
+      // applies its own default (matches the `metadata` omit-when-empty pattern).
+      isPrimary: input.primary ? true : undefined,
     });
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
@@ -343,6 +348,7 @@ export type CreateSourceOpts = {
   feedUrl?: string;
   keywordAllow?: string;
   metadataSet?: string[];
+  primary?: boolean;
   batch?: string;
   json?: boolean;
   strict?: boolean;
@@ -453,6 +459,7 @@ export async function createSourceAction(
     feedUrl: opts.feedUrl,
     keywordAllow: opts.keywordAllow,
     metadataSet: opts.metadataSet,
+    primary: opts.primary,
     strict: opts.strict,
     dryRun: opts.dryRun,
   });
@@ -523,6 +530,10 @@ function attachCreateOptions(cmd: Command): Command {
       },
       [] as string[],
     )
+    .option(
+      "--primary",
+      "Mark as the org's primary changelog source (sets isPrimary on create — no follow-up `source update --primary` needed)",
+    )
     .option("--batch <file>", "JSON file with sources to add (use - for stdin)")
     .option("--json", "Output as JSON")
     .option("--strict", "Exit 1 if the source URL already exists (default: return existing)")
@@ -539,6 +550,7 @@ export function registerCreateCommand(program: Command) {
         `
 Examples:
   releases admin source create "Next.js" --url https://github.com/vercel/next.js
+  releases admin source create "Vitest" --url https://github.com/vitest-dev/vitest --org vitest --primary
   releases admin source create "Astro" --url https://astro.build/blog --type scrape
   releases admin source create "Discord" --url https://discord.com/blog --type feed \\
     --feed-url https://discord.com/blog/rss.xml --keyword-allow changelog,patch-notes

--- a/tests/cli/source-create-primary.test.ts
+++ b/tests/cli/source-create-primary.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "bun:test";
+import { runCli } from "../utils.js";
+
+/**
+ * #263 — surface coverage: `source create` exposes `--primary` so an org's
+ * primary changelog can be set in one step. Behavioral coverage (the flag lands
+ * as `isPrimary` in the create POST body) lives in
+ * tests/unit/create-primary.test.ts.
+ */
+describe("source create --primary flag (--help surface)", () => {
+  it("exposes --primary on source create --help", () => {
+    const { stdout, exitCode } = runCli(["admin", "source", "create", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--primary");
+  });
+});

--- a/tests/unit/create-primary.test.ts
+++ b/tests/unit/create-primary.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Drive the real mode.ts via env (a top-level mock.module leaks across files —
+// see api-client.test.ts).
+const prevEnv: { url?: string; key?: string } = {};
+beforeAll(() => {
+  prevEnv.url = process.env.RELEASES_API_URL;
+  prevEnv.key = process.env.RELEASES_API_KEY;
+  process.env.RELEASES_API_URL = "https://test.example.com";
+  process.env.RELEASES_API_KEY = "test-key";
+});
+afterAll(() => {
+  if (prevEnv.url === undefined) delete process.env.RELEASES_API_URL;
+  else process.env.RELEASES_API_URL = prevEnv.url;
+  if (prevEnv.key === undefined) delete process.env.RELEASES_API_KEY;
+  else process.env.RELEASES_API_KEY = prevEnv.key;
+});
+
+const { createSourceAction } = await import("../../src/cli/commands/create.js");
+
+/**
+ * #263 — `source create` could not mark a source as the org's primary changelog
+ * in one step; `--primary` errored and callers had to follow up with
+ * `source update --primary`. The REST create endpoint already accepts
+ * `isPrimary`, so these tests pin that the flag travels in the create POST body.
+ */
+describe("source create --primary flag", () => {
+  let originalFetch: typeof globalThis.fetch;
+  let dir: string;
+  let postBody: Record<string, unknown> | null = null;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    dir = mkdtempSync(join(tmpdir(), "rel-create-primary-"));
+    process.env.RELEASES_RUN_DIR = dir;
+    postBody = null;
+    globalThis.fetch = (async (url: string, init?: RequestInit) => {
+      const method = init?.method ?? "GET";
+      if (method === "POST" && url.includes("/v1/sources")) {
+        postBody = JSON.parse(String(init?.body ?? "{}"));
+        return new Response(
+          JSON.stringify({
+            id: "src_new",
+            slug: "changelog",
+            name: "Vitest",
+            type: "github",
+            url: "https://github.com/vitest-dev/vitest",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      // GET findSourcesByUrls() → no existing source at this URL.
+      if (url.includes("filterByUrls=true")) {
+        return new Response("[]", { status: 200, headers: { "Content-Type": "application/json" } });
+      }
+      // GET findBlockedUrl() → not excluded (404 → null).
+      return new Response("null", { status: 404 });
+    }) as unknown as typeof globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    delete process.env.RELEASES_RUN_DIR;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("sends isPrimary: true in the create POST body when --primary is set", async () => {
+    await createSourceAction("Vitest", {
+      url: "https://github.com/vitest-dev/vitest",
+      type: "github",
+      primary: true,
+    });
+    expect(postBody).not.toBeNull();
+    expect((postBody as { isPrimary?: boolean }).isPrimary).toBe(true);
+  });
+
+  it("omits isPrimary from the create POST body when --primary is not set", async () => {
+    await createSourceAction("Vitest", {
+      url: "https://github.com/vitest-dev/vitest",
+      type: "github",
+    });
+    expect(postBody).not.toBeNull();
+    expect((postBody as { isPrimary?: boolean }).isPrimary).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #263.

## Problem

`releases admin source create` could not mark a source as the org's primary changelog in one step. Passing `--primary` errored with `unknown option '--primary'`, forcing the two-call workaround:

```
releases admin source create "Vitest" --url https://github.com/vitest-dev/vitest --org vitest --type github
releases admin source update vitest --primary
```

This left the CLI behind both the wire contract and its own docs:

- The REST create endpoint already accepts `isPrimary` (`CreateSourceBodySchema.isPrimary`, persisted by the `POST /v1/sources` handler), and the `manage_source` "add" action accepts `is_primary`.
- The `managing-sources` admin skill explicitly documents `--primary` on `source create` ("pass `--primary` to `releases admin source create`, not a follow-up `source update`") — so agents following the skill hit the error.

## Fix

Add a `--primary` boolean to `source create` that maps to `isPrimary: true` on the create POST (mirroring the existing `source update --primary`). It's omitted from the body unless explicitly set, so the API applies its own default — matching the `metadata` omit-when-empty pattern in the same call.

It also flows through the **batch** path for free: `CreateSourceInput` now carries `primary`, so a batch entry `{ "name": ..., "url": ..., "primary": true }` sets `isPrimary` too.

```
releases admin source create "Vitest" --url https://github.com/vitest-dev/vitest --org vitest --primary
```

## Changes

- `src/cli/commands/create.ts` — `--primary` flag, threaded through `CreateSourceOpts` → `CreateSourceInput` → the `createSource()` call; help example added.
- `src/api/client.ts` — `createSource()` accepts optional `isPrimary`.
- `skills/releases-cli/references/admin.md` — document `--primary` on `create`.
- `.changeset/cli-source-create-primary.md` — minor bump.

## Tests

- `tests/unit/create-primary.test.ts` — behavioral: `isPrimary: true` lands in the create POST body when `--primary` is set; omitted otherwise (written test-first, watched it fail on the missing wiring).
- `tests/cli/source-create-primary.test.ts` — surface: `--primary` appears on `source create --help`.

## Verification

- `npx tsc --noEmit` — clean
- `bun test` — 750 pass, 0 fail
- `bun run lint` — 0 warnings/errors
- `bun run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
