### PR TITLE
feat(cli): add --hard to `release delete --source` and `source delete` (#1184)

### DIFF
--- a/.changeset/release-source-delete-hard.md
+++ b/.changeset/release-source-delete-hard.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": minor
+---
+
+Add `--hard` to `admin release delete --source` and `admin source delete`. The default stays a soft delete (releases suppress, sources tombstone), but `--hard` passes `?hard=true` so rows are removed outright and the `UNIQUE(source_id, url)` dedup slot frees up — enabling a clean purge + re-ingest without a full org hard-delete (#1184). Also fixes the soft `release delete --source` summary, which previously printed `Deleted undefined releases` because the API returns `{ suppressed }` on that path.

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -911,8 +911,15 @@ export async function updateSource(
   });
 }
 
-export async function deleteSource(source: Pick<Source, "id">): Promise<void> {
-  await apiFetch(`/v1/sources/${encodeURIComponent(source.id)}`, { method: "DELETE" });
+export async function deleteSource(
+  source: Pick<Source, "id">,
+  opts?: { hard?: boolean },
+): Promise<void> {
+  // Soft delete (default) tombstones the row (sets deletedAt + mangles the
+  // slug); `?hard=true` removes it outright so the URL can be re-onboarded
+  // fresh. See #1184.
+  const query = opts?.hard ? "?hard=true" : "";
+  await apiFetch(`/v1/sources/${encodeURIComponent(source.id)}${query}`, { method: "DELETE" });
 }
 
 export async function insertReleasesBatch(
@@ -961,8 +968,16 @@ export async function insertReleasesBatch(
 
 export async function deleteReleasesForSource(
   source: Pick<Source, "id">,
-): Promise<{ deleted: number }> {
-  return apiFetch(`/v1/sources/${encodeURIComponent(source.id)}/releases`, { method: "DELETE" });
+  opts?: { hard?: boolean },
+): Promise<{ suppressed: number } | { deleted: number; hard: true }> {
+  // Default (soft) suppresses rows with reason "force_refetch" but leaves them
+  // occupying UNIQUE(source_id, url) — a re-fetch upserts on top but never
+  // un-suppresses, so the rows stay hidden. `?hard=true` removes them so the
+  // dedup slot frees up and a corrected re-fetch ingests clean. See #1184.
+  const query = opts?.hard ? "?hard=true" : "";
+  return apiFetch(`/v1/sources/${encodeURIComponent(source.id)}/releases${query}`, {
+    method: "DELETE",
+  });
 }
 
 export async function createSource(data: {
@@ -1950,8 +1965,11 @@ export async function findSourcesBySlugs(slugs: string[]): Promise<Source[]> {
   return results.filter((r): r is Source => r !== null);
 }
 
-export async function deleteSources(sources: Array<Pick<Source, "id">>): Promise<void> {
-  await Promise.all(sources.map((s) => deleteSource(s)));
+export async function deleteSources(
+  sources: Array<Pick<Source, "id">>,
+  opts?: { hard?: boolean },
+): Promise<void> {
+  await Promise.all(sources.map((s) => deleteSource(s, opts)));
 }
 
 // ── Exclusion check (compose blocked + ignored) ──

--- a/src/cli/commands/delete.ts
+++ b/src/cli/commands/delete.ts
@@ -7,6 +7,7 @@ import { writeJson } from "../../lib/output.js";
 export type DeleteSourceOpts = {
   ignore?: boolean;
   reason?: string;
+  hard?: boolean;
   json?: boolean;
   dryRun?: boolean;
 };
@@ -21,6 +22,7 @@ export async function deleteSourceAction(slugs: string[], opts: DeleteSourceOpts
     name?: string;
     url?: string;
     status: "removed" | "not_found";
+    hard?: boolean;
     ignored?: boolean;
   }[] = [];
   let hasError = false;
@@ -38,7 +40,12 @@ export async function deleteSourceAction(slugs: string[], opts: DeleteSourceOpts
     } else {
       for (const r of dryResults) {
         if (r.status === "not_found") console.error(chalk.red(`Source not found: ${r.slug}`));
-        else console.log(chalk.yellow(`[dry-run] Would remove: ${r.name} (${r.slug})`));
+        else
+          console.log(
+            chalk.yellow(
+              `[dry-run] Would ${opts.hard ? "hard-delete" : "remove"}: ${r.name} (${r.slug})`,
+            ),
+          );
       }
     }
 
@@ -81,7 +88,7 @@ export async function deleteSourceAction(slugs: string[], opts: DeleteSourceOpts
   }
 
   if (existing.length > 0) {
-    await deleteSources(existing);
+    await deleteSources(existing, { hard: opts.hard });
 
     for (const source of existing) {
       results.push({
@@ -89,10 +96,15 @@ export async function deleteSourceAction(slugs: string[], opts: DeleteSourceOpts
         name: source.name,
         url: source.url,
         status: "removed",
+        ...(opts.hard ? { hard: true } : {}),
         ...(opts.ignore && ignoredUrlSet.has(source.url) ? { ignored: true } : {}),
       });
       if (!opts.json) {
-        logger.info(chalk.green(`Removed source: ${source.name} (${source.slug})`));
+        logger.info(
+          chalk.green(
+            `${opts.hard ? "Hard-deleted" : "Removed"} source: ${source.name} (${source.slug})`,
+          ),
+        );
       }
     }
   }
@@ -108,6 +120,10 @@ export function registerDeleteCommand(program: Command) {
     .argument("<sources...>", "Source IDs (src_…) or slugs to delete")
     .option("--ignore", "Add each source URL to the ignored list before deleting")
     .option("--reason <reason>", "Reason for ignoring (used with --ignore)")
+    .option(
+      "--hard",
+      "Permanently remove the source row (instead of tombstoning it) so its URL can be re-onboarded fresh.",
+    )
     .option("--dry-run", "Show what would be deleted without deleting")
     .option("--json", "Output as JSON")
     .action(deleteSourceAction);

--- a/src/cli/commands/release.ts
+++ b/src/cli/commands/release.ts
@@ -184,12 +184,16 @@ export function registerReleaseCommand(program: Command) {
     .description("Delete a release by ID, or all releases for a source")
     .argument("[id]", "Release ID to delete")
     .option("--source <identifier>", "Delete all releases for a source (src_… or slug)")
+    .option(
+      "--hard",
+      "With --source: permanently remove rows (frees the UNIQUE(source_id, url) dedup slot) instead of soft-suppressing. Use before a corrected re-fetch.",
+    )
     .option("--dry-run", "Show what would be deleted without deleting")
     .option("--json", "Output as JSON")
     .action(
       async (
         rawId: string | undefined,
-        opts: { source?: string; json?: boolean; dryRun?: boolean },
+        opts: { source?: string; hard?: boolean; json?: boolean; dryRun?: boolean },
       ) => {
         const id = rawId ? normalizeReleaseId(rawId) : undefined;
         if (!id && !opts.source) {
@@ -239,22 +243,30 @@ export function registerReleaseCommand(program: Command) {
           if (opts.dryRun) {
             console.log(
               chalk.yellow(
-                `[dry-run] Would delete all releases for source: ${resolvedSource.slug}`,
+                `[dry-run] Would ${opts.hard ? "hard-delete" : "suppress"} all releases for source: ${resolvedSource.slug}`,
               ),
             );
             return;
           }
           let result: Awaited<ReturnType<typeof deleteReleasesForSource>>;
           try {
-            result = await deleteReleasesForSource(resolvedSource);
+            result = await deleteReleasesForSource(resolvedSource, { hard: opts.hard });
           } catch (err) {
             console.error(chalk.red(err instanceof Error ? err.message : String(err)));
             process.exit(1);
           }
           if (opts.json) await writeJson(result);
+          else if ("deleted" in result)
+            console.log(
+              chalk.green(
+                `Hard-deleted ${result.deleted} release${result.deleted === 1 ? "" : "s"}.`,
+              ),
+            );
           else
             console.log(
-              chalk.green(`Deleted ${result.deleted} release${result.deleted === 1 ? "" : "s"}.`),
+              chalk.green(
+                `Suppressed ${result.suppressed} release${result.suppressed === 1 ? "" : "s"} (soft — rows still occupy the URL dedup slot; pass --hard to free it for a clean re-fetch).`,
+              ),
             );
           return;
         }

--- a/tests/cli/delete-hard.test.ts
+++ b/tests/cli/delete-hard.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "bun:test";
+import { runCli } from "../utils.js";
+
+/**
+ * #1184 — surface coverage for the `--hard` purge flag on `release delete` and
+ * `source delete`. Behavioral wire-contract coverage (the `?hard=true` query
+ * param) lives in tests/unit/delete-hard.test.ts.
+ */
+describe("delete --hard (--help surface)", () => {
+  it("exposes --hard on `release delete`", () => {
+    const { stdout, exitCode } = runCli(["admin", "release", "delete", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--hard");
+    expect(stdout).toContain("--source");
+  });
+
+  it("exposes --hard on `source delete`", () => {
+    const { stdout, exitCode } = runCli(["admin", "source", "delete", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--hard");
+  });
+});

--- a/tests/unit/delete-hard.test.ts
+++ b/tests/unit/delete-hard.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
+
+/**
+ * #1184 — wire contract for the new `--hard` purge path on `release delete
+ * --source` and `source delete`. Both delete client helpers must append
+ * `?hard=true` only when `{ hard: true }` is passed, so the default stays a
+ * soft delete and the hard path actually frees the UNIQUE(source_id, url) slot.
+ */
+
+const prevEnv: { url?: string; key?: string } = {};
+beforeAll(() => {
+  prevEnv.url = process.env.RELEASES_API_URL;
+  prevEnv.key = process.env.RELEASES_API_KEY;
+  process.env.RELEASES_API_URL = "https://test.example.com";
+  process.env.RELEASES_API_KEY = "test-key";
+});
+afterAll(() => {
+  if (prevEnv.url === undefined) delete process.env.RELEASES_API_URL;
+  else process.env.RELEASES_API_URL = prevEnv.url;
+  if (prevEnv.key === undefined) delete process.env.RELEASES_API_KEY;
+  else process.env.RELEASES_API_KEY = prevEnv.key;
+});
+
+const { deleteReleasesForSource, deleteSource, deleteSources } =
+  await import("../../src/api/client.js");
+
+describe("delete --hard wire contract", () => {
+  let originalFetch: typeof globalThis.fetch;
+  let capturedUrls: string[] = [];
+  let capturedMethods: string[] = [];
+  let responseBody = "{}";
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    capturedUrls = [];
+    capturedMethods = [];
+    responseBody = "{}";
+    globalThis.fetch = (async (url: string, init?: RequestInit) => {
+      capturedUrls.push(url);
+      capturedMethods.push(String(init?.method ?? "GET"));
+      return new Response(responseBody, {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof globalThis.fetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("deleteReleasesForSource omits ?hard by default (soft suppress)", async () => {
+    responseBody = JSON.stringify({ suppressed: 3 });
+    const result = await deleteReleasesForSource({ id: "src_abc" });
+    expect(capturedUrls[0]).toBe("https://test.example.com/v1/sources/src_abc/releases");
+    expect(capturedUrls[0]).not.toContain("hard");
+    expect(capturedMethods[0]).toBe("DELETE");
+    expect(result).toEqual({ suppressed: 3 });
+  });
+
+  it("deleteReleasesForSource appends ?hard=true when hard", async () => {
+    responseBody = JSON.stringify({ deleted: 3, hard: true });
+    const result = await deleteReleasesForSource({ id: "src_abc" }, { hard: true });
+    expect(capturedUrls[0]).toBe("https://test.example.com/v1/sources/src_abc/releases?hard=true");
+    expect(result).toEqual({ deleted: 3, hard: true });
+  });
+
+  it("deleteSource omits ?hard by default", async () => {
+    await deleteSource({ id: "src_xyz" });
+    expect(capturedUrls[0]).toBe("https://test.example.com/v1/sources/src_xyz");
+    expect(capturedUrls[0]).not.toContain("hard");
+  });
+
+  it("deleteSource appends ?hard=true when hard", async () => {
+    await deleteSource({ id: "src_xyz" }, { hard: true });
+    expect(capturedUrls[0]).toBe("https://test.example.com/v1/sources/src_xyz?hard=true");
+  });
+
+  it("deleteSources threads hard through to each source", async () => {
+    await deleteSources([{ id: "src_1" }, { id: "src_2" }], { hard: true });
+    expect(capturedUrls.toSorted()).toEqual([
+      "https://test.example.com/v1/sources/src_1?hard=true",
+      "https://test.example.com/v1/sources/src_2?hard=true",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Addresses the CLI half of buildinternet/releases#1184 — operators could not purge a source's releases and re-ingest clean without nuking the whole org.

- `release delete --source` **soft-suppresses** releases (`suppressed=1`, reason `force_refetch`). Those rows keep occupying `UNIQUE(source_id, url)`; a corrected re-fetch upserts on top but **never un-suppresses**, so the rows stay hidden and the fetch reports `no_change` / 0 inserted.
- `source delete` **tombstones** the row (sets `deletedAt`, mangles the slug).
- The only escape was `org delete --hard` + recreate everything.

The API already supports a true hard delete via `?hard=true` on `DELETE /v1/sources/:slug/releases` and `DELETE /v1/sources/:slug` — the CLI just never passed it.

## Changes

- **`src/api/client.ts`** — `deleteReleasesForSource`, `deleteSource`, and `deleteSources` take `{ hard?: boolean }` and append `?hard=true`. `deleteReleasesForSource`'s return type is now the discriminated union the API actually sends: `{ suppressed: number } | { deleted: number; hard: true }`.
- **`src/cli/commands/release.ts`** — `--hard` flag on `release delete` (applies with `--source`). Default stays soft. Also fixes the summary line, which printed `Deleted undefined releases` on the soft path because it read `.deleted` from a `{ suppressed }` response; it now reports suppressed vs hard-deleted counts and nudges toward `--hard` for a clean re-fetch.
- **`src/cli/commands/delete.ts`** — `--hard` flag on `source delete`, threaded through `deleteSources`; output and dry-run text distinguish tombstone vs hard delete.
- **Tests** — `tests/unit/delete-hard.test.ts` (wire contract: `?hard=true` present only when requested, threaded across both helpers + the bulk path) and `tests/cli/delete-hard.test.ts` (`--help` surface on both verbs).
- **`.changeset/release-source-delete-hard.md`** — minor bump for `@buildinternet/releases`.

Note: this PR does not add `--resurrect` or change soft-delete defaults. The companion API PR (buildinternet/releases#1339) stops `source create` from reviving tombstones by excluding soft-deleted rows from the `filterByUrls` dedup lookup.

## Test plan

- [x] `bun test` — 757 pass, 0 fail (7 new)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — 0 warnings, 0 errors
- [x] `bun run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
