### PR TITLE
feat(cli): `--local` handoff flag on `source fetch` (stages local-ingest, no remote MA) (#273)

### DIFF
--- a/.changeset/local-handoff-flag.md
+++ b/.changeset/local-handoff-flag.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": minor
+---
+
+Add a `--local` handoff flag to `admin source fetch <slug>` (#273). It stages local onboarding for the `local-ingest` skill instead of dispatching the remote managed agent: it runs the same robots.txt / Content-Signal opt-out preflight as the monorepo skill (refuses on `ai-input=no` / `ai-train=no`, e.g. `conductor.build`; `--force` overrides with explicit publisher permission), resolves the source, discovers candidate page URLs from `/sitemap.xml` (filtered to the changelog path) or the index HTML, classifies the page shape, and prints a structured handoff brief (`--json` supported) — the org-scoped batch endpoint, the preflight verdict + parsed Content-Signal, and a capped candidate-URL list with an explicit skip note (no silent truncation). No managed-agent session, no model call, and no Anthropic/adapter dependency added to the thin client — HTTP fetch + string parsing only. Exit codes: 0 proceed, 1 refuse, 2 unknown.

--- a/src/cli/commands/fetch-local.ts
+++ b/src/cli/commands/fetch-local.ts
@@ -1,0 +1,174 @@
+/**
+ * `source fetch --local` — the local-ingest handoff.
+ *
+ * This is the discoverable on-ramp for the monorepo `local-ingest` skill
+ * (buildinternet/releases#1344). Instead of POSTing to `/v1/workflows/update`
+ * (which dispatches a remote managed-agent extraction session, billed even when
+ * it writes zero releases), `--local` stages the local path: it runs the
+ * robots.txt / Content-Signal opt-out preflight, resolves the source, discovers
+ * candidate page URLs, and prints a structured handoff brief the skill consumes.
+ *
+ * No managed agent, no model call, no Anthropic/adapter dependency — the thin
+ * client only does HTTP `fetch` + string parsing. The skill does the extraction.
+ */
+
+import chalk from "chalk";
+import { findSource, findOrg } from "../../api/client.js";
+import { sourceNotFound } from "../suggest.js";
+import { writeJson } from "../../lib/output.js";
+import {
+  contentSignalPreflight,
+  type ContentSignalResult,
+  type ContentSignalVerdict,
+} from "../../lib/content-signal.js";
+import { discoverCandidateUrls, type DiscoveryResult } from "../../lib/page-discovery.js";
+
+export interface LocalHandoffOpts {
+  json?: boolean;
+  force?: boolean;
+}
+
+interface HandoffBrief {
+  source: { id: string; slug: string; type: string; url: string };
+  org: { slug: string } | null;
+  /** Org-scoped batch endpoint (preferred); falls back to the typed-id form. */
+  batchEndpoint: string;
+  preflight: {
+    verdict: ContentSignalVerdict;
+    forced: boolean;
+    reason: string;
+    robotsUrl: string;
+    robotsStatus: number | null;
+    contentSignal: Record<string, string> | null;
+    sitemaps: string[];
+    blocked: string[];
+  };
+  /** Null when the preflight refused and `--force` was not passed. */
+  discovery: DiscoveryResult | null;
+  nextStep: string;
+}
+
+/**
+ * Exit codes mirror the skill's preflight gate so automation can branch:
+ *   0 proceed (or operator --force override)
+ *   1 refuse  (ai-input=no / ai-train=no, no --force)
+ *   2 unknown (could not read robots.txt; surfaced, not assumed)
+ */
+function exitCodeFor(verdict: ContentSignalVerdict, force: boolean): number {
+  if (force) return 0;
+  if (verdict === "refuse") return 1;
+  if (verdict === "unknown") return 2;
+  return 0;
+}
+
+/**
+ * Stage the local-ingest handoff for a single source. Resolves the source +
+ * org, runs the Content-Signal preflight, and (unless refused without --force)
+ * discovers candidate URLs, then prints the brief. Returns normally on a clean
+ * proceed; calls `process.exit` with the gate code on refuse/unknown.
+ */
+export async function runLocalHandoff(identifier: string, opts: LocalHandoffOpts): Promise<void> {
+  const source = await findSource(identifier);
+  if (!source) return sourceNotFound(identifier); // exits 1 (AmbiguousSourceError propagates)
+
+  const org = source.orgId ? await findOrg(source.orgId).catch(() => null) : null;
+  const batchEndpoint = org?.slug
+    ? `/v1/orgs/${org.slug}/sources/${source.slug}/releases/batch`
+    : `/v1/sources/${source.id}/releases/batch`;
+
+  const pf = await contentSignalPreflight(source.url);
+  const force = opts.force === true;
+  const refusedWithoutForce = pf.verdict === "refuse" && !force;
+
+  // On a hard refusal we stop before enumerating pages — the point is not to
+  // stage ingestion against an opt-out. --force re-opens discovery.
+  const discovery = refusedWithoutForce
+    ? null
+    : await discoverCandidateUrls({ sourceUrl: source.url, sitemaps: pf.sitemaps });
+
+  const brief: HandoffBrief = {
+    source: { id: source.id, slug: source.slug, type: source.type, url: source.url },
+    org: org?.slug ? { slug: org.slug } : null,
+    batchEndpoint,
+    preflight: {
+      verdict: pf.verdict,
+      forced: pf.verdict === "refuse" && force,
+      reason: pf.reason,
+      robotsUrl: pf.robotsUrl,
+      robotsStatus: pf.robotsStatus,
+      contentSignal: pf.contentSignal,
+      sitemaps: pf.sitemaps,
+      blocked: pf.blocked,
+    },
+    discovery,
+    nextStep: refusedWithoutForce
+      ? "Refused by the Content-Signal opt-out. Re-run with --force only if you have explicit publisher permission."
+      : "Run the `local-ingest` skill: extract releases yourself and write them via the batch endpoint above (no managed agent).",
+  };
+
+  const exitCode = exitCodeFor(pf.verdict, force);
+
+  if (opts.json) {
+    await writeJson({ ...brief, exitCode });
+  } else {
+    printHandoffBrief(brief, pf, { force, exitCode });
+  }
+
+  // Return normally on a clean proceed so callers/tests don't trip process.exit;
+  // signal refuse/unknown with the gate code.
+  if (exitCode !== 0) process.exit(exitCode);
+}
+
+const VERDICT_BADGE: Record<ContentSignalVerdict, (s: string) => string> = {
+  proceed: (s) => chalk.green(s),
+  refuse: (s) => chalk.red(s),
+  unknown: (s) => chalk.yellow(s),
+};
+
+function printHandoffBrief(
+  brief: HandoffBrief,
+  pf: ContentSignalResult,
+  ctx: { force: boolean; exitCode: number },
+): void {
+  const coord = brief.org ? `${brief.org.slug}/${brief.source.slug}` : brief.source.slug;
+  const badge = ctx.force && pf.verdict === "refuse" ? "FORCED" : pf.verdict.toUpperCase();
+
+  // The whole brief goes to stdout so it stays readable and pipeable; the exit
+  // code is the machine signal (0 proceed / 1 refuse / 2 unknown).
+  console.log(`${VERDICT_BADGE[pf.verdict](`[preflight ${badge}]`)} ${coord}`);
+  console.log(`  source:  ${brief.source.type}  ${brief.source.url}  (${brief.source.id})`);
+  console.log(`  robots:  ${pf.robotsUrl} (HTTP ${pf.robotsStatus ?? "—"})`);
+  if (pf.contentSignal) {
+    const pairs = Object.entries(pf.contentSignal)
+      .map(([k, v]) => `${k}=${v}`)
+      .join(", ");
+    console.log(`  signal:  ${pairs}`);
+  }
+  if (pf.sitemaps.length) console.log(`  sitemap: ${pf.sitemaps.join(", ")}`);
+  console.log(`  reason:  ${pf.reason}`);
+
+  if (!brief.discovery) {
+    // Refused without --force — stop here, no candidate enumeration.
+    console.log("");
+    console.log(chalk.red(brief.nextStep));
+    return;
+  }
+
+  const d = brief.discovery;
+  console.log("");
+  console.log(`  batch:   POST ${brief.batchEndpoint}`);
+  console.log(`  shape:   ${d.pageStructure} (via ${d.via})`);
+  console.log(`  ${chalk.dim(d.note)}`);
+  if (d.candidates.length) {
+    console.log(chalk.dim(`  candidate URLs (${d.candidates.length}):`));
+    for (const url of d.candidates) console.log(`    ${url}`);
+  }
+  if (ctx.exitCode === 2) {
+    console.log("");
+    console.log(
+      chalk.yellow("  Preflight could not confirm the opt-out policy — operator review advised."),
+    );
+  }
+  console.log("");
+  console.log(chalk.dim(`Next: ${brief.nextStep}`));
+}

--- a/src/cli/commands/fetch.ts
+++ b/src/cli/commands/fetch.ts
@@ -22,6 +22,7 @@ import {
   NOT_FOUND_GRACE_MS,
   POLL_INTERVAL_MS,
 } from "./fetch-wait.js";
+import { runLocalHandoff } from "./fetch-local.js";
 import type { Session } from "@buildinternet/releases-api-types";
 
 export function registerFetchCommand(program: Command) {
@@ -33,6 +34,17 @@ export function registerFetchCommand(program: Command) {
     .argument("[identifier]", "Source ID (src_…), org/slug coordinate, or slug to fetch")
     .option("--source <identifier>", "Source ID (src_…), org/slug coordinate, or slug")
     .option("--json", "Output as JSON")
+    .option(
+      "--local",
+      "Stage local onboarding for the `local-ingest` skill instead of dispatching the remote managed agent: " +
+        "runs the robots.txt/Content-Signal preflight, resolves the source, discovers candidate page URLs, " +
+        "and prints a handoff brief. No model call, no extraction billing. Single source only.",
+    )
+    .option(
+      "--force",
+      "With --local, override a Content-Signal refusal (ai-input=no / ai-train=no). " +
+        "Use only with explicit publisher permission.",
+    )
     .option("--unfetched", "Only fetch sources that have never been fetched")
     .option("--stale <hours>", "Only fetch sources older than N hours")
     .option("--changed", "Only fetch sources where poll detected upstream changes")
@@ -62,7 +74,9 @@ Examples:
   releases admin source fetch --retry-errors        Retry sources that errored last time
   releases admin source fetch --org acme            Fetch all active sources for an org
   releases admin source fetch --org acme --wait     Wait for completion; exit non-zero on failure
-  releases admin source fetch --org acme --wait 60  Wait up to 60 seconds`,
+  releases admin source fetch --org acme --wait 60  Wait up to 60 seconds
+  releases admin source fetch my-source --local     Stage local-ingest handoff (no managed agent)
+  releases admin source fetch my-source --local --force   Override a Content-Signal refusal`,
     )
     .action(
       async (
@@ -70,6 +84,8 @@ Examples:
         opts: {
           source?: string;
           json?: boolean;
+          local?: boolean;
+          force?: boolean;
           unfetched?: boolean;
           stale?: string;
           changed?: boolean;
@@ -80,6 +96,42 @@ Examples:
         },
       ) => {
         const identifier = slugArg ?? opts.source;
+
+        // --local short-circuits the remote managed-agent path entirely: it stages
+        // the local-ingest handoff (preflight + URL discovery + brief) and never
+        // POSTs to /v1/workflows/update. Single-source only — the batch filters
+        // and --org fan-out don't apply to a one-source handoff brief.
+        if (opts.local) {
+          if (!identifier) {
+            logger.error(
+              "--local needs a single source identifier (src_…, org/slug coordinate, or slug).",
+            );
+            process.exit(1);
+          }
+          const conflicting = (
+            [
+              ["--org", opts.org],
+              ["--unfetched", opts.unfetched],
+              ["--stale", opts.stale],
+              ["--changed", opts.changed],
+              ["--retry-errors", opts.retryErrors],
+              ["--wait", opts.wait !== undefined],
+            ] as const
+          )
+            .filter(([, v]) => v)
+            .map(([name]) => name);
+          if (conflicting.length > 0) {
+            logger.error(
+              `--local stages a single-source handoff and can't combine with ${conflicting.join(", ")}.`,
+            );
+            process.exit(1);
+          }
+          return runLocalHandoff(identifier, { json: opts.json, force: opts.force });
+        }
+
+        if (opts.force) {
+          logger.warn("--force only applies with --local; ignoring it for the remote fetch path.");
+        }
 
         // Resolve --wait up front so a malformed value fails before we kick off a remote workflow.
         let waitSeconds: number | null = null;

--- a/src/lib/content-signal.ts
+++ b/src/lib/content-signal.ts
@@ -1,0 +1,200 @@
+/**
+ * Content-Signal preflight — robots.txt / Content-Signal opt-out gate for the
+ * `--local` handoff (`source fetch --local`).
+ *
+ * This is the thin-client mirror of the monorepo skill's gate at
+ * `src/agent/skills/local-ingest/preflight.ts`. The `--local` flow stages local
+ * onboarding for the `local-ingest` skill, so before we hand a source off we run
+ * the SAME opt-out check the skill runs: if a publisher declares `ai-input=no`
+ * or `ai-train=no` via Cloudflare's Content Signals policy in robots.txt, refuse
+ * the handoff rather than stage a path that would ingest content against the
+ * opt-out. (`conductor.build` serves `Content-Signal: ai-train=no, search=yes,
+ * ai-input=no` and must be refused.)
+ *
+ * The refusal is a POLICY choice, not a technical limit — the bytes are still
+ * reachable. Honor the signal anyway; `--force` is the operator escape hatch for
+ * sources where there is explicit publisher permission.
+ *
+ * Dependency-free on purpose: `fetch` + string parsing only, no Anthropic or
+ * adapter import. The thin client never extracts.
+ */
+
+import { RELEASES_CLI_UA } from "./user-agent.js";
+
+export type ContentSignalVerdict = "proceed" | "refuse" | "unknown";
+
+export interface ContentSignalResult {
+  /** The url-or-domain we were asked to check. */
+  input: string;
+  /** The resolved robots.txt URL we fetched. */
+  robotsUrl: string;
+  /** HTTP status of the robots.txt fetch, or null when the request never completed. */
+  robotsStatus: number | null;
+  /** Merged Content-Signal directives (strictest reading), or null when none declared. */
+  contentSignal: Record<string, string> | null;
+  /** `Sitemap:` URLs surfaced by robots.txt — page discovery prefers these. */
+  sitemaps: string[];
+  /** The blocking directives that triggered a refusal (e.g. `["ai-input=no"]`). */
+  blocked: string[];
+  verdict: ContentSignalVerdict;
+  reason: string;
+}
+
+/** Content-Signal keys whose `=no` value blocks the local-ingest handoff. */
+export const BLOCKING_SIGNALS = ["ai-input", "ai-train"] as const;
+
+const ROBOTS_TIMEOUT_MS = 20_000;
+
+/** Map a url-or-bare-domain to its origin's `/robots.txt`. */
+export function robotsUrlFor(input: string): string {
+  const withScheme = /^https?:\/\//i.test(input) ? input : `https://${input}`;
+  return `${new URL(withScheme).origin}/robots.txt`;
+}
+
+/**
+ * robots.txt served as HTML (not a real policy file) usually means a
+ * challenge/login wall — we can't read the opt-out, so fail closed.
+ */
+export function looksLikeHtml(body: string): boolean {
+  const head = body.slice(0, 200).toLowerCase().trimStart();
+  return head.startsWith("<!doctype html") || head.startsWith("<html") || head.includes("<head");
+}
+
+/**
+ * Collect every `Content-Signal:` directive in the file and union their
+ * key=value pairs, taking the strictest reading across all groups. A publisher
+ * declaring an opt-out anywhere is honored: once a signal is `no`, a later `yes`
+ * (another line / UA group) must not override it. `Sitemap:` lines are surfaced
+ * for page discovery. We deliberately ignore user-agent grouping.
+ */
+export function parseRobotsTxt(body: string): {
+  contentSignal: Record<string, string> | null;
+  sitemaps: string[];
+  blocked: string[];
+} {
+  const merged: Record<string, string> = {};
+  const sitemaps: string[] = [];
+
+  for (const rawLine of body.split(/\r?\n/)) {
+    const line = rawLine.replace(/#.*$/, "").trim();
+    if (!line) continue;
+    const colon = line.indexOf(":");
+    if (colon === -1) continue;
+    const key = line.slice(0, colon).trim().toLowerCase();
+    const value = line.slice(colon + 1).trim();
+
+    if (key === "sitemap" && value) {
+      sitemaps.push(value);
+      continue;
+    }
+    if (key !== "content-signal" || !value) continue;
+
+    // e.g. "ai-train=no, search=yes, ai-input=no" — tokens have no internal spaces.
+    for (const token of value.split(/[,\s]+/)) {
+      const eq = token.indexOf("=");
+      if (eq === -1) continue;
+      const sig = token.slice(0, eq).trim().toLowerCase();
+      if (!sig) continue;
+      // Strictest reading: a "no" wins and is never overwritten.
+      if (merged[sig] === "no") continue;
+      merged[sig] = token
+        .slice(eq + 1)
+        .trim()
+        .toLowerCase();
+    }
+  }
+
+  const blocked = BLOCKING_SIGNALS.filter((sig) => merged[sig] === "no").map((sig) => `${sig}=no`);
+  return { contentSignal: Object.keys(merged).length > 0 ? merged : null, sitemaps, blocked };
+}
+
+/**
+ * Fetch and evaluate `<origin>/robots.txt` for the given url-or-domain.
+ *
+ * Verdicts:
+ *   proceed — permissive or absent Content-Signal
+ *   refuse  — `ai-input=no` or `ai-train=no` declared
+ *   unknown — could not fetch/parse robots.txt (network error, non-404 error
+ *             status, or an HTML challenge wall); surface, never assume proceed
+ *
+ * Best-effort and total: never throws. Follows redirects (apex→www `307`s are
+ * common, e.g. `conductor.build` → `www.conductor.build/robots.txt`).
+ */
+export async function contentSignalPreflight(input: string): Promise<ContentSignalResult> {
+  const robotsUrl = robotsUrlFor(input);
+  const base: Omit<ContentSignalResult, "verdict" | "reason"> = {
+    input,
+    robotsUrl,
+    robotsStatus: null,
+    contentSignal: null,
+    sitemaps: [],
+    blocked: [],
+  };
+
+  let res: Response;
+  try {
+    res = await fetch(robotsUrl, {
+      headers: { "User-Agent": RELEASES_CLI_UA, Accept: "text/plain" },
+      redirect: "follow", // apex→www 307s are common (e.g. conductor.build)
+      signal: AbortSignal.timeout(ROBOTS_TIMEOUT_MS),
+    });
+  } catch (err) {
+    return {
+      ...base,
+      verdict: "unknown",
+      reason: `Could not fetch robots.txt (${err instanceof Error ? err.message : String(err)}). Surface to the operator — do not assume proceed.`,
+    };
+  }
+
+  base.robotsStatus = res.status;
+
+  if (res.status === 404 || res.status === 410) {
+    return {
+      ...base,
+      verdict: "proceed",
+      reason: `No robots.txt (HTTP ${res.status}) — no opt-out declared.`,
+    };
+  }
+  if (!res.ok) {
+    return {
+      ...base,
+      verdict: "unknown",
+      reason: `robots.txt returned HTTP ${res.status}. Surface to the operator — do not assume proceed.`,
+    };
+  }
+
+  const body = await res.text();
+  if (looksLikeHtml(body)) {
+    return {
+      ...base,
+      verdict: "unknown",
+      reason:
+        "robots.txt served HTML (likely a challenge/login wall) — could not read the opt-out policy. Operator review required before fetching.",
+    };
+  }
+
+  const { contentSignal, sitemaps, blocked } = parseRobotsTxt(body);
+  base.contentSignal = contentSignal;
+  base.sitemaps = sitemaps;
+  base.blocked = blocked;
+
+  if (blocked.length > 0) {
+    return {
+      ...base,
+      verdict: "refuse",
+      reason: `Content-Signal opt-out: ${blocked.join(", ")}. Publisher disallows AI input/training. Pass --force only with explicit publisher permission.`,
+    };
+  }
+  if (!contentSignal) {
+    return {
+      ...base,
+      verdict: "proceed",
+      reason: "robots.txt present, no Content-Signal directive — no opt-out declared.",
+    };
+  }
+  return {
+    ...base,
+    verdict: "proceed",
+    reason: "Content-Signal present and permissive for ai-input/ai-train.",
+  };
+}

--- a/src/lib/page-discovery.ts
+++ b/src/lib/page-discovery.ts
@@ -1,0 +1,282 @@
+/**
+ * Candidate page-URL discovery for the `--local` handoff.
+ *
+ * Given a source's display URL (and any `Sitemap:` URLs the Content-Signal
+ * preflight surfaced), find the per-release detail pages a local-ingest run
+ * would extract, and classify the page shape. This mirrors the skill's
+ * approach: prefer `/sitemap.xml` filtered to the changelog path, otherwise
+ * parse the index HTML for per-release links (see
+ * `src/agent/skills/local-ingest/SKILL.md` Step 3).
+ *
+ * Nothing here extracts or calls AI — `fetch` + string parsing only. Every
+ * network step is best-effort and total: a failed fetch degrades to the
+ * single-page fallback rather than throwing.
+ */
+
+import { RELEASES_CLI_UA } from "./user-agent.js";
+
+export type PageStructure = "single-page" | "index" | "unknown";
+
+export interface DiscoveryResult {
+  pageStructure: PageStructure;
+  /** Where the candidate URLs came from. */
+  via: "sitemap" | "index-html" | "source-url" | "none";
+  /** The candidate page URLs (capped — see `truncated`/`totalFound`). */
+  candidates: string[];
+  /** Total detail URLs discovered before the cap. */
+  totalFound: number;
+  /** Whether the candidate list was capped below `totalFound`. */
+  truncated: boolean;
+  /** Human-readable window/skip note — never silently truncates. */
+  note: string;
+}
+
+/** Cap surfaced candidate URLs — the skill works a ~25–50 most-recent window. */
+export const MAX_CANDIDATES = 50;
+/** At least this many path-children mark an index→detail page (vs. a stray sub-link). */
+const INDEX_THRESHOLD = 2;
+/** Bound the number of sitemap documents we fetch (incl. one level of sitemap-index). */
+const MAX_SITEMAP_FETCHES = 4;
+const FETCH_TIMEOUT_MS = 20_000;
+
+type FetchImpl = typeof globalThis.fetch;
+
+async function getText(url: string, fetchImpl: FetchImpl): Promise<string | null> {
+  try {
+    const res = await fetchImpl(url, {
+      headers: { "User-Agent": RELEASES_CLI_UA },
+      redirect: "follow",
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!res.ok) return null;
+    return await res.text();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Pull `<loc>` URLs out of a sitemap document and report whether it is a
+ * sitemap-index (a sitemap of sitemaps) so the caller can recurse one level.
+ * Tolerant of namespaces and whitespace; pure string parsing, no XML parser.
+ */
+export function parseSitemapLocs(xml: string): { locs: string[]; isIndex: boolean } {
+  const isIndex = /<sitemapindex[\s>]/i.test(xml);
+  const locs: string[] = [];
+  for (const m of xml.matchAll(/<loc>\s*([^<\s][^<]*?)\s*<\/loc>/gi)) {
+    const url = decodeXmlEntities(m[1]!.trim());
+    if (url) locs.push(url);
+  }
+  return { locs, isIndex };
+}
+
+/**
+ * Same site, treating apex and `www.` as one host (scheme + port must match).
+ * Sources are stored at the canonical URL a human lands on, which may be the
+ * apex while the sitemap/links use `www.` (or vice versa) — the gotcha that
+ * `conductor.build` 307s to `www.conductor.build`. Without this, path-children
+ * on the other host would be wrongly dropped.
+ */
+function bareHost(u: URL): string {
+  return u.hostname.replace(/^www\./i, "");
+}
+function sameSite(a: URL, b: URL): boolean {
+  return a.protocol === b.protocol && a.port === b.port && bareHost(a) === bareHost(b);
+}
+
+function decodeXmlEntities(s: string): string {
+  return s
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'");
+}
+
+/**
+ * Extract same-host absolute URLs from anchor `href`s in an HTML document.
+ * Relative hrefs resolve against `baseUrl`; fragments, mailto:, tel:, and
+ * javascript: are dropped, and the hash is stripped so `#anchor` variants
+ * dedupe. Pure.
+ */
+export function extractSameHostLinks(html: string, baseUrl: string): string[] {
+  let base: URL;
+  try {
+    base = new URL(baseUrl);
+  } catch {
+    return [];
+  }
+  const out = new Set<string>();
+  for (const m of html.matchAll(/<a\b[^>]*\bhref\s*=\s*["']([^"']+)["']/gi)) {
+    const raw = m[1]!.trim();
+    if (!raw || raw.startsWith("#") || /^(mailto|tel|javascript):/i.test(raw)) continue;
+    try {
+      const u = new URL(raw, base);
+      if (!sameSite(u, base)) continue;
+      u.hash = "";
+      out.add(u.toString());
+    } catch {
+      // skip unparseable href
+    }
+  }
+  return [...out];
+}
+
+/**
+ * Keep only URLs that are strict path-children of the source URL — same origin,
+ * with a pathname nested under the source's path. The source URL itself and the
+ * source's path prefix are excluded (they are the index, not a detail page).
+ *
+ * A root source path (`/`) yields no children: prefix matching at the domain
+ * root would sweep in every page, so root URLs default to single-page. Pure.
+ */
+export function filterDetailUrls(sourceUrl: string, urls: string[]): string[] {
+  let base: URL;
+  try {
+    base = new URL(sourceUrl);
+  } catch {
+    return [];
+  }
+  const basePath = base.pathname.replace(/\/+$/, "");
+  if (basePath === "") return [];
+  const prefix = basePath + "/";
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of urls) {
+    let u: URL;
+    try {
+      u = new URL(raw);
+    } catch {
+      continue;
+    }
+    if (!sameSite(u, base)) continue;
+    const path = u.pathname.replace(/\/+$/, "");
+    if (path === basePath || !path.startsWith(prefix)) continue;
+    const key = u.toString();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(key);
+  }
+  return out;
+}
+
+/**
+ * Apply the cap and build the window/skip note. Pure — the orchestrator decides
+ * `pageStructure`/`via`/`anyFetchSucceeded`; this just enforces "no silent
+ * truncation".
+ */
+export function capCandidates(
+  detailUrls: string[],
+  via: DiscoveryResult["via"],
+  sourceUrl: string,
+  anyFetchSucceeded: boolean,
+): DiscoveryResult {
+  if (detailUrls.length >= INDEX_THRESHOLD) {
+    const totalFound = detailUrls.length;
+    const truncated = totalFound > MAX_CANDIDATES;
+    const candidates = detailUrls.slice(0, MAX_CANDIDATES);
+    const note = truncated
+      ? `Index → detail: ${totalFound} candidate URLs found; showing the first ${candidates.length} (${totalFound - candidates.length} not shown — backfill the rest in a later window, re-runs are idempotent).`
+      : `Index → detail: ${candidates.length} candidate URL(s) found.`;
+    return { pageStructure: "index", via, candidates, totalFound, truncated, note };
+  }
+
+  // Fewer than the index threshold of child URLs.
+  if (!anyFetchSucceeded) {
+    return {
+      pageStructure: "unknown",
+      via: "none",
+      candidates: [sourceUrl],
+      totalFound: 0,
+      truncated: false,
+      note: "Could not fetch a sitemap or the index page — page shape unknown. Treat as single-page and have the skill confirm.",
+    };
+  }
+  return {
+    pageStructure: "single-page",
+    via: "source-url",
+    candidates: [sourceUrl],
+    totalFound: detailUrls.length,
+    truncated: false,
+    note: "Single-page changelog — extract all releases from this one URL.",
+  };
+}
+
+/**
+ * Discover candidate detail URLs for a source. Tries sitemaps first (those
+ * surfaced by robots.txt, plus the conventional `/sitemap.xml`), filtered to
+ * the source's changelog path; falls back to parsing the index HTML. Always
+ * resolves (best-effort) — degrades to single-page / unknown rather than
+ * throwing.
+ */
+export async function discoverCandidateUrls(args: {
+  sourceUrl: string;
+  sitemaps?: string[];
+  fetchImpl?: FetchImpl;
+}): Promise<DiscoveryResult> {
+  const { sourceUrl } = args;
+  const fetchImpl = args.fetchImpl ?? globalThis.fetch;
+  let anyFetchSucceeded = false;
+
+  // 1) Sitemap path — robots-surfaced sitemaps first, then the conventional one.
+  const sitemapQueue: string[] = [];
+  const enqueue = (u: string) => {
+    if (u && !sitemapQueue.includes(u)) sitemapQueue.push(u);
+  };
+  for (const s of args.sitemaps ?? []) enqueue(s);
+  try {
+    enqueue(`${new URL(sourceUrl).origin}/sitemap.xml`);
+  } catch {
+    // sourceUrl unparseable — sitemap discovery is impossible; fall through.
+  }
+
+  const sitemapLocs: string[] = [];
+  let fetches = 0;
+  for (const sm of sitemapQueue) {
+    if (fetches >= MAX_SITEMAP_FETCHES) break;
+    // oxlint-disable-next-line no-await-in-loop -- bounded sequential sitemap walk (≤MAX_SITEMAP_FETCHES)
+    const xml = await getText(sm, fetchImpl);
+    fetches++;
+    if (xml === null) continue;
+    anyFetchSucceeded = true;
+    const { locs, isIndex } = parseSitemapLocs(xml);
+    if (isIndex) {
+      // One level of recursion: a sitemap-index points at child sitemaps. Walk
+      // the ones whose own URL sits under the changelog path when we can tell,
+      // else the first few, staying within the fetch budget.
+      const childOrder = [
+        ...filterDetailUrls(sourceUrl, locs),
+        ...locs.filter((l) => !filterDetailUrls(sourceUrl, [l]).length),
+      ];
+      for (const child of childOrder) {
+        if (fetches >= MAX_SITEMAP_FETCHES) break;
+        // oxlint-disable-next-line no-await-in-loop -- bounded sequential sitemap walk
+        const childXml = await getText(child, fetchImpl);
+        fetches++;
+        if (childXml === null) continue;
+        anyFetchSucceeded = true;
+        sitemapLocs.push(...parseSitemapLocs(childXml).locs);
+      }
+    } else {
+      sitemapLocs.push(...locs);
+    }
+  }
+
+  const sitemapDetail = filterDetailUrls(sourceUrl, sitemapLocs);
+  if (sitemapDetail.length >= INDEX_THRESHOLD) {
+    return capCandidates(sitemapDetail, "sitemap", sourceUrl, true);
+  }
+
+  // 2) Index-HTML fallback — parse the source page for per-release links.
+  const html = await getText(sourceUrl, fetchImpl);
+  if (html !== null) {
+    anyFetchSucceeded = true;
+    const htmlDetail = filterDetailUrls(sourceUrl, extractSameHostLinks(html, sourceUrl));
+    if (htmlDetail.length >= INDEX_THRESHOLD) {
+      return capCandidates(htmlDetail, "index-html", sourceUrl, true);
+    }
+  }
+
+  // 3) Nothing index-shaped — single-page (or unknown if every fetch failed).
+  return capCandidates([], "source-url", sourceUrl, anyFetchSucceeded);
+}

--- a/tests/cli/source-fetch-local.test.ts
+++ b/tests/cli/source-fetch-local.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "bun:test";
+import { runCli } from "../utils.js";
+
+/**
+ * #273 — surface coverage for `releases admin source fetch --local`. The
+ * preflight gate, URL discovery, and brief shape are covered behaviorally in
+ * tests/unit/{content-signal,page-discovery,fetch-local}.test.ts.
+ */
+describe("source fetch --local (surface + guards)", () => {
+  it("advertises --local and --force in help", () => {
+    const { stdout, exitCode } = runCli(["admin", "source", "fetch", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--local");
+    expect(stdout).toContain("--force");
+    expect(stdout).toContain("local-ingest");
+  });
+
+  it("requires a single source identifier with --local", () => {
+    const { exitCode, stderr } = runCli(["admin", "source", "fetch", "--local"]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr.toLowerCase()).toContain("single source identifier");
+  });
+
+  it("rejects --local combined with --org (single-source only)", () => {
+    const { exitCode, stderr } = runCli([
+      "admin",
+      "source",
+      "fetch",
+      "my-source",
+      "--local",
+      "--org",
+      "acme",
+    ]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("--org");
+  });
+
+  it("rejects --local combined with the --changed batch filter", () => {
+    const { exitCode, stderr } = runCli([
+      "admin",
+      "source",
+      "fetch",
+      "my-source",
+      "--local",
+      "--changed",
+    ]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("--changed");
+  });
+});

--- a/tests/unit/content-signal.test.ts
+++ b/tests/unit/content-signal.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import {
+  robotsUrlFor,
+  looksLikeHtml,
+  parseRobotsTxt,
+  contentSignalPreflight,
+} from "../../src/lib/content-signal.js";
+
+// ── Pure parsing ─────────────────────────────────────────────────────────────
+
+describe("robotsUrlFor", () => {
+  it("maps a bare domain to its origin robots.txt over https", () => {
+    expect(robotsUrlFor("conductor.build")).toBe("https://conductor.build/robots.txt");
+  });
+
+  it("collapses a deep URL to the origin", () => {
+    expect(robotsUrlFor("https://example.com/blog/changelog?page=2")).toBe(
+      "https://example.com/robots.txt",
+    );
+  });
+
+  it("preserves an explicit http scheme and port", () => {
+    expect(robotsUrlFor("http://localhost:8787/x")).toBe("http://localhost:8787/robots.txt");
+  });
+});
+
+describe("looksLikeHtml", () => {
+  it("detects a doctype / html / head challenge wall", () => {
+    expect(looksLikeHtml("<!DOCTYPE html><html>…")).toBe(true);
+    expect(looksLikeHtml("\n  <html lang=en>")).toBe(true);
+    expect(looksLikeHtml("<head><title>Just a moment…</title></head>")).toBe(true);
+  });
+
+  it("treats a plain robots policy as not-HTML", () => {
+    expect(looksLikeHtml("User-agent: *\nDisallow:\n")).toBe(false);
+  });
+});
+
+describe("parseRobotsTxt", () => {
+  it("flags ai-input=no / ai-train=no from a single Content-Signal line (conductor.build)", () => {
+    const body = [
+      "User-agent: *",
+      "Content-Signal: ai-train=no, search=yes, ai-input=no",
+      "Disallow:",
+      "Sitemap: https://conductor.build/sitemap.xml",
+    ].join("\n");
+    const { contentSignal, sitemaps, blocked } = parseRobotsTxt(body);
+    expect(blocked.toSorted()).toEqual(["ai-input=no", "ai-train=no"]);
+    expect(contentSignal).toMatchObject({ "ai-train": "no", search: "yes", "ai-input": "no" });
+    expect(sitemaps).toEqual(["https://conductor.build/sitemap.xml"]);
+  });
+
+  it("takes the strictest reading — an earlier =no is never overwritten by a later =yes", () => {
+    const body = [
+      "Content-Signal: ai-input=no",
+      "User-agent: GoodBot",
+      "Content-Signal: ai-input=yes, ai-train=yes",
+    ].join("\n");
+    const { blocked, contentSignal } = parseRobotsTxt(body);
+    expect(contentSignal?.["ai-input"]).toBe("no");
+    expect(blocked).toContain("ai-input=no");
+  });
+
+  it("returns no block and null signal for a permissive / signal-free file", () => {
+    const { contentSignal, blocked } = parseRobotsTxt("User-agent: *\nDisallow: /private\n");
+    expect(contentSignal).toBeNull();
+    expect(blocked).toEqual([]);
+  });
+
+  it("treats a permissive Content-Signal as proceed-worthy (signal present, nothing blocked)", () => {
+    const { contentSignal, blocked } = parseRobotsTxt("Content-Signal: ai-input=yes, search=yes");
+    expect(contentSignal).toMatchObject({ "ai-input": "yes", search: "yes" });
+    expect(blocked).toEqual([]);
+  });
+
+  it("ignores comments and collects multiple sitemaps", () => {
+    const body = [
+      "# a comment",
+      "Sitemap: https://a.example/sitemap.xml",
+      "Sitemap: https://a.example/news-sitemap.xml # inline note",
+    ].join("\n");
+    const { sitemaps } = parseRobotsTxt(body);
+    expect(sitemaps).toEqual([
+      "https://a.example/sitemap.xml",
+      "https://a.example/news-sitemap.xml",
+    ]);
+  });
+});
+
+// ── Fetch + verdict (mocked global fetch) ────────────────────────────────────
+
+describe("contentSignalPreflight", () => {
+  let originalFetch: typeof globalThis.fetch;
+  afterEach(() => {
+    if (originalFetch) globalThis.fetch = originalFetch;
+  });
+
+  function mockRobots(body: string, init?: { status?: number }) {
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response(body, {
+        status: init?.status ?? 200,
+        headers: { "Content-Type": "text/plain" },
+      })) as unknown as typeof globalThis.fetch;
+  }
+
+  it("REFUSES conductor.build (ai-input=no, ai-train=no) — the negative regression target", async () => {
+    mockRobots("Content-Signal: ai-train=no, search=yes, ai-input=no\n");
+    const r = await contentSignalPreflight("conductor.build");
+    expect(r.verdict).toBe("refuse");
+    expect(r.blocked.toSorted()).toEqual(["ai-input=no", "ai-train=no"]);
+    expect(r.robotsUrl).toBe("https://conductor.build/robots.txt");
+  });
+
+  it("PROCEEDS on a permissive file and surfaces the sitemap", async () => {
+    mockRobots("User-agent: *\nDisallow:\nSitemap: https://ex.com/sitemap.xml\n");
+    const r = await contentSignalPreflight("https://ex.com/changelog");
+    expect(r.verdict).toBe("proceed");
+    expect(r.sitemaps).toEqual(["https://ex.com/sitemap.xml"]);
+  });
+
+  it("PROCEEDS when robots.txt is absent (404) — no opt-out declared", async () => {
+    mockRobots("", { status: 404 });
+    const r = await contentSignalPreflight("ex.com");
+    expect(r.verdict).toBe("proceed");
+    expect(r.robotsStatus).toBe(404);
+  });
+
+  it("returns UNKNOWN on a non-404 error status (fail closed, do not assume proceed)", async () => {
+    mockRobots("", { status: 503 });
+    const r = await contentSignalPreflight("ex.com");
+    expect(r.verdict).toBe("unknown");
+  });
+
+  it("returns UNKNOWN when robots.txt is an HTML challenge wall", async () => {
+    mockRobots("<!DOCTYPE html><html><head><title>Just a moment…</title></head></html>");
+    const r = await contentSignalPreflight("ex.com");
+    expect(r.verdict).toBe("unknown");
+  });
+
+  it("returns UNKNOWN on a network error rather than throwing", async () => {
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof globalThis.fetch;
+    const r = await contentSignalPreflight("ex.com");
+    expect(r.verdict).toBe("unknown");
+    expect(r.reason).toMatch(/ECONNREFUSED/);
+  });
+});

--- a/tests/unit/fetch-local.test.ts
+++ b/tests/unit/fetch-local.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
+
+// Drive the real mode.ts via env. Use the suite-wide convention URL: getApiUrl()
+// memoizes its base process-wide on first call, so a divergent value here would
+// poison the cache for whatever client-mocking test runs after us. The mock
+// routes API calls by path suffix, so the exact host is irrelevant to us anyway.
+const prevEnv: { url?: string; key?: string } = {};
+beforeAll(() => {
+  prevEnv.url = process.env.RELEASES_API_URL;
+  prevEnv.key = process.env.RELEASES_API_KEY;
+  process.env.RELEASES_API_URL = "https://test.example.com";
+  process.env.RELEASES_API_KEY = "test-key";
+});
+afterAll(() => {
+  if (prevEnv.url === undefined) delete process.env.RELEASES_API_URL;
+  else process.env.RELEASES_API_URL = prevEnv.url;
+  if (prevEnv.key === undefined) delete process.env.RELEASES_API_KEY;
+  else process.env.RELEASES_API_KEY = prevEnv.key;
+});
+
+const { runLocalHandoff } = await import("../../src/cli/commands/fetch-local.js");
+
+const SOURCE = {
+  id: "src_abc",
+  slug: "my-changelog",
+  type: "scrape",
+  name: "My Changelog",
+  url: "https://ex.com/changelog",
+  orgId: "org_1",
+};
+const ORG = { id: "org_1", slug: "acme", name: "Acme" };
+
+/**
+ * Route by URL: the API host serves findSource/findOrg, ex.com serves
+ * robots.txt + sitemap. The API routes match by path suffix because
+ * `getApiUrl()` memoizes its base URL process-wide on first call (mode.ts),
+ * so the host depends on whichever client-mocking test file ran first.
+ * `robots` overrides the robots.txt body/status.
+ */
+function installFetch(robots: { body: string; status?: number }, sitemap?: string) {
+  globalThis.fetch = (async (url: string) => {
+    const u = String(url);
+    if (u.endsWith("/v1/sources/src_abc")) return json(SOURCE);
+    if (u.endsWith("/v1/orgs/org_1")) return json(ORG);
+    if (u === "https://ex.com/robots.txt")
+      return new Response(robots.body, {
+        status: robots.status ?? 200,
+        headers: { "Content-Type": "text/plain" },
+      });
+    if (u === "https://ex.com/sitemap.xml" && sitemap)
+      return new Response(sitemap, { status: 200 });
+    return new Response("", { status: 404 });
+  }) as unknown as typeof globalThis.fetch;
+}
+
+function json(value: unknown): Response {
+  return new Response(JSON.stringify(value), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+// Capture stdout (the brief) and stub process.exit (refuse/unknown call it).
+function captureRun() {
+  let out = "";
+  const origWrite = process.stdout.write;
+  const origLog = console.log;
+  const origExit = process.exit;
+  let exitCode: number | null = null;
+  process.stdout.write = ((s: string) => {
+    out += s;
+    return true;
+  }) as unknown as typeof process.stdout.write;
+  console.log = (...a: unknown[]) => {
+    out += a.join(" ") + "\n";
+  };
+  process.exit = ((code?: number) => {
+    exitCode = code ?? 0;
+    throw new ExitSignal();
+  }) as unknown as typeof process.exit;
+  return {
+    out: () => out,
+    exitCode: () => exitCode,
+    restore: () => {
+      process.stdout.write = origWrite;
+      console.log = origLog;
+      process.exit = origExit;
+    },
+  };
+}
+class ExitSignal extends Error {}
+
+async function run(identifier: string, opts: { json?: boolean; force?: boolean }) {
+  const cap = captureRun();
+  try {
+    await runLocalHandoff(identifier, opts);
+  } catch (e) {
+    if (!(e instanceof ExitSignal)) throw e;
+  } finally {
+    cap.restore();
+  }
+  return { out: cap.out(), exitCode: cap.exitCode() };
+}
+
+describe("runLocalHandoff", () => {
+  let originalFetch: typeof globalThis.fetch;
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("PROCEEDS: emits a JSON brief with the org-scoped batch endpoint and never POSTs to the MA", async () => {
+    const sitemap = `<urlset>
+      <url><loc>https://ex.com/changelog/v1</loc></url>
+      <url><loc>https://ex.com/changelog/v2</loc></url>
+    </urlset>`;
+    let posted = false;
+    installFetch({ body: "User-agent: *\nDisallow:\n" }, sitemap);
+    const baseFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: string, init?: RequestInit) => {
+      if (init?.method === "POST" && String(url).includes("/workflows/update")) posted = true;
+      return baseFetch(url as unknown as string, init);
+    }) as unknown as typeof globalThis.fetch;
+
+    const { out, exitCode } = await run("src_abc", { json: true });
+    const brief = JSON.parse(out);
+    expect(exitCode).toBeNull(); // clean proceed returns normally (no process.exit)
+    expect(brief.preflight.verdict).toBe("proceed");
+    expect(brief.batchEndpoint).toBe("/v1/orgs/acme/sources/my-changelog/releases/batch");
+    expect(brief.discovery.pageStructure).toBe("index");
+    expect(brief.discovery.candidates).toEqual([
+      "https://ex.com/changelog/v1",
+      "https://ex.com/changelog/v2",
+    ]);
+    expect(brief.exitCode).toBe(0);
+    expect(posted).toBe(false);
+  });
+
+  it("REFUSES conductor-style ai-input=no/ai-train=no and exits 1, with no discovery", async () => {
+    installFetch({ body: "Content-Signal: ai-train=no, search=yes, ai-input=no\n" });
+    const { out, exitCode } = await run("src_abc", { json: true });
+    const brief = JSON.parse(out);
+    expect(exitCode).toBe(1);
+    expect(brief.preflight.verdict).toBe("refuse");
+    expect(brief.preflight.blocked.toSorted()).toEqual(["ai-input=no", "ai-train=no"]);
+    expect(brief.discovery).toBeNull();
+    expect(brief.exitCode).toBe(1);
+  });
+
+  it("--force overrides the refusal: exit 0, discovery runs, forced flag set", async () => {
+    const sitemap = `<urlset>
+      <url><loc>https://ex.com/changelog/v1</loc></url>
+      <url><loc>https://ex.com/changelog/v2</loc></url>
+    </urlset>`;
+    installFetch({ body: "Content-Signal: ai-input=no\n" }, sitemap);
+    const { out, exitCode } = await run("src_abc", { json: true, force: true });
+    const brief = JSON.parse(out);
+    expect(exitCode).toBeNull();
+    expect(brief.preflight.verdict).toBe("refuse");
+    expect(brief.preflight.forced).toBe(true);
+    expect(brief.exitCode).toBe(0);
+    expect(brief.discovery).not.toBeNull();
+  });
+
+  it("UNKNOWN (robots unreadable) exits 2 but still surfaces a best-effort brief", async () => {
+    installFetch({ body: "", status: 503 });
+    const { out, exitCode } = await run("src_abc", { json: true });
+    const brief = JSON.parse(out);
+    expect(exitCode).toBe(2);
+    expect(brief.preflight.verdict).toBe("unknown");
+    expect(brief.exitCode).toBe(2);
+    expect(brief.discovery).not.toBeNull(); // surfaced, not assumed
+  });
+});

--- a/tests/unit/page-discovery.test.ts
+++ b/tests/unit/page-discovery.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from "bun:test";
+import {
+  parseSitemapLocs,
+  extractSameHostLinks,
+  filterDetailUrls,
+  capCandidates,
+  discoverCandidateUrls,
+  MAX_CANDIDATES,
+} from "../../src/lib/page-discovery.js";
+
+// ── parseSitemapLocs ─────────────────────────────────────────────────────────
+
+describe("parseSitemapLocs", () => {
+  it("extracts <loc> URLs and decodes XML entities", () => {
+    const xml = `<?xml version="1.0"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+      <url><loc>https://ex.com/changelog/a</loc></url>
+      <url><loc>https://ex.com/changelog/b?x=1&amp;y=2</loc></url>
+    </urlset>`;
+    const { locs, isIndex } = parseSitemapLocs(xml);
+    expect(isIndex).toBe(false);
+    expect(locs).toEqual(["https://ex.com/changelog/a", "https://ex.com/changelog/b?x=1&y=2"]);
+  });
+
+  it("flags a sitemap-index document", () => {
+    const xml = `<sitemapindex xmlns="x"><sitemap><loc>https://ex.com/sm-1.xml</loc></sitemap></sitemapindex>`;
+    const { locs, isIndex } = parseSitemapLocs(xml);
+    expect(isIndex).toBe(true);
+    expect(locs).toEqual(["https://ex.com/sm-1.xml"]);
+  });
+});
+
+// ── extractSameHostLinks ─────────────────────────────────────────────────────
+
+describe("extractSameHostLinks", () => {
+  it("resolves relative hrefs, keeps same-host, drops fragments/mailto, dedupes hashes", () => {
+    const html = `
+      <a href="/changelog/v1">v1</a>
+      <a href="https://ex.com/changelog/v2#top">v2</a>
+      <a href="https://ex.com/changelog/v2#bottom">v2 again</a>
+      <a href="https://other.com/x">offsite</a>
+      <a href="#section">in-page</a>
+      <a href="mailto:hi@ex.com">mail</a>`;
+    const links = extractSameHostLinks(html, "https://ex.com/changelog");
+    expect(links).toContain("https://ex.com/changelog/v1");
+    expect(links).toContain("https://ex.com/changelog/v2");
+    expect(links.filter((l) => l.includes("/changelog/v2"))).toHaveLength(1);
+    expect(links.some((l) => l.includes("other.com"))).toBe(false);
+    expect(links.some((l) => l.startsWith("mailto"))).toBe(false);
+  });
+});
+
+// ── filterDetailUrls ─────────────────────────────────────────────────────────
+
+describe("filterDetailUrls", () => {
+  it("keeps strict path-children, excludes the index itself and cross-origin", () => {
+    const out = filterDetailUrls("https://ex.com/changelog", [
+      "https://ex.com/changelog", // the index itself
+      "https://ex.com/changelog/", // index, trailing slash
+      "https://ex.com/changelog/post-a",
+      "https://ex.com/changelog/post-b",
+      "https://ex.com/about", // sibling, not under path
+      "https://other.com/changelog/x", // cross-origin
+    ]);
+    expect(out).toEqual(["https://ex.com/changelog/post-a", "https://ex.com/changelog/post-b"]);
+  });
+
+  it("returns nothing for a root source path (defaults to single-page)", () => {
+    expect(filterDetailUrls("https://ex.com/", ["https://ex.com/anything"])).toEqual([]);
+  });
+
+  it("treats apex and www as the same site (the conductor.build redirect gotcha)", () => {
+    // Source stored at the apex; sitemap lists www. URLs (or vice versa).
+    expect(
+      filterDetailUrls("https://conductor.build/changelog", [
+        "https://www.conductor.build/changelog/0.61.0",
+        "https://www.conductor.build/changelog/0.60.0",
+      ]),
+    ).toEqual([
+      "https://www.conductor.build/changelog/0.61.0",
+      "https://www.conductor.build/changelog/0.60.0",
+    ]);
+    expect(
+      filterDetailUrls("https://www.acme.io/releases", ["https://acme.io/releases/v2"]),
+    ).toEqual(["https://acme.io/releases/v2"]);
+  });
+});
+
+// ── capCandidates ────────────────────────────────────────────────────────────
+
+describe("capCandidates", () => {
+  it("classifies index and caps with an explicit skip note (no silent truncation)", () => {
+    const many = Array.from({ length: MAX_CANDIDATES + 7 }, (_, i) => `https://ex.com/c/${i}`);
+    const r = capCandidates(many, "sitemap", "https://ex.com/c", true);
+    expect(r.pageStructure).toBe("index");
+    expect(r.candidates).toHaveLength(MAX_CANDIDATES);
+    expect(r.totalFound).toBe(MAX_CANDIDATES + 7);
+    expect(r.truncated).toBe(true);
+    expect(r.note).toContain(`${7} not shown`);
+  });
+
+  it("classifies single-page when no children and a fetch succeeded", () => {
+    const r = capCandidates([], "source-url", "https://ex.com/changelog", true);
+    expect(r.pageStructure).toBe("single-page");
+    expect(r.candidates).toEqual(["https://ex.com/changelog"]);
+  });
+
+  it("classifies unknown when every fetch failed", () => {
+    const r = capCandidates([], "source-url", "https://ex.com/changelog", false);
+    expect(r.pageStructure).toBe("unknown");
+    expect(r.via).toBe("none");
+    expect(r.candidates).toEqual(["https://ex.com/changelog"]);
+  });
+});
+
+// ── discoverCandidateUrls (routed mock fetch) ────────────────────────────────
+
+function routedFetch(routes: Record<string, { body: string; status?: number }>): typeof fetch {
+  return (async (url: string) => {
+    const hit = routes[String(url)];
+    if (!hit) return new Response("", { status: 404 });
+    return new Response(hit.body, { status: hit.status ?? 200 });
+  }) as unknown as typeof fetch;
+}
+
+describe("discoverCandidateUrls", () => {
+  it("uses the robots-surfaced sitemap, filtered to the changelog path", async () => {
+    const sitemap = `<urlset>
+      <url><loc>https://ex.com/changelog/a</loc></url>
+      <url><loc>https://ex.com/changelog/b</loc></url>
+      <url><loc>https://ex.com/about</loc></url>
+    </urlset>`;
+    const r = await discoverCandidateUrls({
+      sourceUrl: "https://ex.com/changelog",
+      sitemaps: ["https://ex.com/news-sitemap.xml"],
+      fetchImpl: routedFetch({ "https://ex.com/news-sitemap.xml": { body: sitemap } }),
+    });
+    expect(r.pageStructure).toBe("index");
+    expect(r.via).toBe("sitemap");
+    expect(r.candidates).toEqual(["https://ex.com/changelog/a", "https://ex.com/changelog/b"]);
+  });
+
+  it("walks a sitemap-index one level deep", async () => {
+    const index = `<sitemapindex><sitemap><loc>https://ex.com/sm-posts.xml</loc></sitemap></sitemapindex>`;
+    const child = `<urlset>
+      <url><loc>https://ex.com/changelog/x</loc></url>
+      <url><loc>https://ex.com/changelog/y</loc></url>
+    </urlset>`;
+    const r = await discoverCandidateUrls({
+      sourceUrl: "https://ex.com/changelog",
+      fetchImpl: routedFetch({
+        "https://ex.com/sitemap.xml": { body: index },
+        "https://ex.com/sm-posts.xml": { body: child },
+      }),
+    });
+    expect(r.candidates).toEqual(["https://ex.com/changelog/x", "https://ex.com/changelog/y"]);
+  });
+
+  it("falls back to parsing the index HTML when the sitemap has no usable children", async () => {
+    const html = `<html><body>
+      <a href="/changelog/post-1">1</a>
+      <a href="/changelog/post-2">2</a>
+    </body></html>`;
+    const r = await discoverCandidateUrls({
+      sourceUrl: "https://ex.com/changelog",
+      fetchImpl: routedFetch({
+        // sitemap.xml 404s; only the source page resolves
+        "https://ex.com/changelog": { body: html },
+      }),
+    });
+    expect(r.pageStructure).toBe("index");
+    expect(r.via).toBe("index-html");
+    expect(r.candidates).toEqual([
+      "https://ex.com/changelog/post-1",
+      "https://ex.com/changelog/post-2",
+    ]);
+  });
+
+  it("classifies single-page when the page has no per-release children", async () => {
+    const html = `<html><body><h1>Changelog</h1><p>All in one page</p>
+      <a href="/about">about</a></body></html>`;
+    const r = await discoverCandidateUrls({
+      sourceUrl: "https://ex.com/changelog",
+      fetchImpl: routedFetch({ "https://ex.com/changelog": { body: html } }),
+    });
+    expect(r.pageStructure).toBe("single-page");
+    expect(r.candidates).toEqual(["https://ex.com/changelog"]);
+  });
+
+  it("classifies unknown when sitemap and index page both fail to fetch", async () => {
+    const r = await discoverCandidateUrls({
+      sourceUrl: "https://ex.com/changelog",
+      fetchImpl: routedFetch({}), // everything 404s
+    });
+    expect(r.pageStructure).toBe("unknown");
+    expect(r.candidates).toEqual(["https://ex.com/changelog"]);
+  });
+});


### PR DESCRIPTION
Closes #273. Part 2 of buildinternet/releases#1344 (Part 1 — the `local-ingest` skill + its `robots.txt`/`Content-Signal` preflight — lives in the monorepo).

## What

Adds a `--local` handoff flag to `releases admin source fetch <slug>`. Instead of POSTing to `/v1/workflows/update` (which dispatches a remote managed-agent extraction session, billed even when it writes zero releases), `--local` **stages the local path**: it runs the same opt-out preflight as the skill, resolves the source, discovers candidate page URLs, and prints a structured handoff brief the `local-ingest` skill consumes. **No managed agent, no model call, no Anthropic/adapter dependency** — HTTP `fetch` + string parsing only.

## Behavior

`releases admin source fetch <slug> --local`:
- **Skips `/v1/workflows/update` entirely.**
- Runs the robots.txt / Content-Signal preflight (plain fetch + regex): follows redirects (apex→www `307`s), refuses on `ai-input=no` / `ai-train=no` (strictest reading across all `Content-Signal:` lines), surfaces the `Sitemap:` URL. Fails closed (`unknown`) on an HTML challenge wall or error status — never assumes proceed.
- Resolves the source (slug / `src_…` / `org/slug`) → url, type, org.
- Discovers candidate URLs from `/sitemap.xml` (filtered to the changelog path, one level of sitemap-index) or the index HTML; classifies `single-page | index | unknown`; caps the list with an explicit skip note (no silent truncation).
- Prints the brief — source slug + `src_…` id, the org-scoped batch endpoint, the preflight verdict + parsed Content-Signal, the candidate URL list, and the next step. Honors `--json`.
- Exit codes: **0** proceed · **1** refuse · **2** unknown. `--force` overrides a refusal (operators with explicit publisher permission).

Single-source only — `--local` rejects `--org` / the batch filters / `--wait` with a clear error.

## Verification

`bun test` (795 pass), `tsc --noEmit` (clean), `oxlint` + prettier clean. Smoked live against prod sources:

- **`conductor/conductor-changelog`** (`Content-Signal: ai-train=no, search=yes, ai-input=no`) — the negative regression target → **REFUSE, exit 1**, no discovery. `--local --force` → **FORCED, exit 0**, discovers 169 sitemap URLs filtered to `/changelog`, caps at 50 with a "119 not shown" note.
- **`prisma/prisma-changelog`** (permissive) → **proceed, exit 0**, sitemap-driven `index` discovery (42 `/changelog/*` URLs), org-scoped batch endpoint, clean `--json`.

## Files

- `src/lib/content-signal.ts` — preflight gate (mirrors the skill's `preflight.ts`).
- `src/lib/page-discovery.ts` — sitemap/index URL discovery + classification.
- `src/cli/commands/fetch-local.ts` — `runLocalHandoff` orchestration + brief rendering.
- `src/cli/commands/fetch.ts` — `--local` / `--force` wiring + single-source guards.
- Tests: `tests/unit/{content-signal,page-discovery,fetch-local}.test.ts`, `tests/cli/source-fetch-local.test.ts`.
- Changeset: `@buildinternet/releases` minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Introduced `--local` flag for `admin source fetch <slug>` enabling local staging workflow
* Performs preflight validation and auto-discovers candidate URLs from sitemaps/pages  
* Outputs structured handoff brief with JSON support and explicit truncation messaging
* Configurable exit codes (0: proceed, 1: refused, 2: unknown) with `--force` override

<!-- end of auto-generated comment: release notes by coderabbit.ai -->