### PR TITLE
feat(cli): in-progress fetch banner on `source fetch-log` (#1360)

### DIFF
--- a/.changeset/fetch-log-inprogress-banner.md
+++ b/.changeset/fetch-log-inprogress-banner.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": patch
+---
+
+`admin source fetch-log <source>` now shows an in-progress banner when a managed-agent fetch is still running for that source — the session id plus how long it has been running — so an operator can tell a live fetch from a stuck one instead of seeing only terminal history (#1360). The source-filtered query reads the API's enveloped `activeSession`; `--json` output is unchanged (still the bare logs array). The status column also labels the `crawl_timeout` (#1361) and `blocked` (#1171) states distinctly instead of rendering them as "no change".

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "releases-cli",
       "dependencies": {
-        "@buildinternet/releases-api-types": "^0.27.0",
+        "@buildinternet/releases-api-types": "^0.28.0",
         "@buildinternet/releases-core": "^0.22.1",
         "@buildinternet/releases-lib": "workspace:*",
         "@buildinternet/releases-skills": "workspace:*",
@@ -27,7 +27,7 @@
     },
     "npm/releases": {
       "name": "@buildinternet/releases",
-      "version": "0.54.0",
+      "version": "0.55.0",
       "bin": {
         "releases": "bin/releases",
       },
@@ -41,31 +41,31 @@
     },
     "npm/releases-darwin-arm64": {
       "name": "@buildinternet/releases-darwin-arm64",
-      "version": "0.54.0",
+      "version": "0.55.0",
     },
     "npm/releases-darwin-x64": {
       "name": "@buildinternet/releases-darwin-x64",
-      "version": "0.54.0",
+      "version": "0.55.0",
     },
     "npm/releases-linux-arm64": {
       "name": "@buildinternet/releases-linux-arm64",
-      "version": "0.54.0",
+      "version": "0.55.0",
     },
     "npm/releases-linux-x64": {
       "name": "@buildinternet/releases-linux-x64",
-      "version": "0.54.0",
+      "version": "0.55.0",
     },
     "npm/releases-windows-x64": {
       "name": "@buildinternet/releases-windows-x64",
-      "version": "0.54.0",
+      "version": "0.55.0",
     },
     "packages/lib": {
       "name": "@buildinternet/releases-lib",
-      "version": "0.54.0",
+      "version": "0.55.0",
     },
     "packages/skills": {
       "name": "@buildinternet/releases-skills",
-      "version": "0.54.0",
+      "version": "0.55.0",
     },
   },
   "packages": {
@@ -73,7 +73,7 @@
 
     "@buildinternet/releases": ["@buildinternet/releases@workspace:npm/releases"],
 
-    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.27.0", "", { "dependencies": { "@buildinternet/releases-core": "^0.22.0", "zod": "^4.4.3" } }, "sha512-en/v99LkW5ULDrd8LUmpKtypEm9gPsUY41Z0+LXtQX8cj5iZZPWsfocHiZEtKU7rCtYCpqZqJUdT3B6Y+rN0gQ=="],
+    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.28.0", "", { "dependencies": { "@buildinternet/releases-core": "^0.22.0", "zod": "^4.4.3" } }, "sha512-2iJvrxf0dy1Hj7VIZHnR8KIBCk7V9UosXVH7BMtCUj9M26XXd2zpMOHHNECiX93m1zSHxYeuhseaTjuSujIaBw=="],
 
     "@buildinternet/releases-core": ["@buildinternet/releases-core@0.22.1", "", { "dependencies": { "drizzle-orm": "^0.45.2", "js-tiktoken": "^1.0.21", "nanoid": "^5.1.7" } }, "sha512-srKTkcKaEUeQsNcujf+Kbqh+LWBSpO4EUgZ0GNwNHip9A6AeEk8V907fRCEcOhhbljJOguL2tXmnmr4gUXWqlA=="],
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "homepage": "https://releases.sh",
   "dependencies": {
-    "@buildinternet/releases-api-types": "^0.27.0",
+    "@buildinternet/releases-api-types": "^0.28.0",
     "@buildinternet/releases-core": "^0.22.1",
     "@buildinternet/releases-lib": "workspace:*",
     "@buildinternet/releases-skills": "workspace:*",

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -26,6 +26,7 @@ import type {
   ReleaseWithSource,
   StatsSummary,
   FetchLogEntry,
+  ActiveFetchSession,
   LatestRelease,
   UsageStatsResponse,
   Session,
@@ -74,6 +75,7 @@ export type {
   ReleaseWithSource,
   StatsSummary,
   FetchLogEntry,
+  ActiveFetchSession,
   LatestRelease,
   UsageBreakdownRow,
   UsageStatsResponse,
@@ -621,21 +623,6 @@ export async function postFetchLog(entry: {
 }
 
 // ── Fetch log read ──
-
-/**
- * The managed-agent session currently fetching a source (#1360), surfaced on the
- * enveloped fetch-log response so a poll can tell "a fetch is in flight" from a
- * stale history. Only running sessions are reported. Defined locally because the
- * published api-types may not yet export it.
- */
-export interface ActiveFetchSession {
-  sessionId: string;
-  status: string;
-  /** Session start, epoch ms. */
-  startedAt: number;
-  /** Last session activity, epoch ms. */
-  lastUpdatedAt: number;
-}
 
 interface RawFetchLogRow {
   id: string;

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -622,30 +622,37 @@ export async function postFetchLog(entry: {
 
 // ── Fetch log read ──
 
-export async function getFetchLogs(opts: {
-  /** Source identifier (src_… or slug). */
-  source?: string;
-  limit: number;
-}): Promise<FetchLogEntry[]> {
-  const params = new URLSearchParams({ limit: String(opts.limit) });
-  if (opts.source) params.set("source", opts.source);
-  const logs = await apiFetch<
-    Array<{
-      id: string;
-      sourceId: string;
-      releasesFound: number;
-      releasesInserted: number;
-      durationMs: number | null;
-      status: string;
-      error: string | null;
-      rawContent: string | null;
-      createdAt: string;
-    }>
-  >(`/v1/admin/logs/fetch?${params}`);
+/**
+ * The managed-agent session currently fetching a source (#1360), surfaced on the
+ * enveloped fetch-log response so a poll can tell "a fetch is in flight" from a
+ * stale history. Only running sessions are reported. Defined locally because the
+ * published api-types may not yet export it.
+ */
+export interface ActiveFetchSession {
+  sessionId: string;
+  status: string;
+  /** Session start, epoch ms. */
+  startedAt: number;
+  /** Last session activity, epoch ms. */
+  lastUpdatedAt: number;
+}
 
-  // The API fetch-log endpoint returns raw fetch_log rows without source name/slug.
-  // In remote mode we don't have the join data, so we provide what we can.
-  return logs.map((l) => ({
+interface RawFetchLogRow {
+  id: string;
+  sourceId: string;
+  releasesFound: number;
+  releasesInserted: number;
+  durationMs: number | null;
+  status: string;
+  error: string | null;
+  rawContent: string | null;
+  createdAt: string;
+}
+
+// The API fetch-log endpoint returns raw fetch_log rows without source name/slug.
+// In remote mode we don't have the join data, so we provide what we can.
+function toFetchLogEntry(l: RawFetchLogRow): FetchLogEntry {
+  return {
     id: l.id,
     sourceName: "",
     sourceSlug: "",
@@ -655,7 +662,33 @@ export async function getFetchLogs(opts: {
     durationMs: l.durationMs,
     error: l.error,
     createdAt: l.createdAt,
-  }));
+  };
+}
+
+export async function getFetchLogs(opts: {
+  /** Source identifier (src_… or slug). */
+  source?: string;
+  limit: number;
+}): Promise<{ logs: FetchLogEntry[]; activeSession: ActiveFetchSession | null }> {
+  const params = new URLSearchParams({ limit: String(opts.limit) });
+  if (opts.source) {
+    params.set("source", opts.source);
+    // Ask for the envelope so the response carries the live in-flight fetch
+    // (`activeSession`) alongside the history. The global (no-source) list has
+    // no single active session, so it stays on the bare-array form.
+    params.set("envelope", "true");
+    const env = await apiFetch<{
+      items: RawFetchLogRow[];
+      activeSession: ActiveFetchSession | null;
+    }>(`/v1/admin/logs/fetch?${params}`);
+    return {
+      logs: (env.items ?? []).map(toFetchLogEntry),
+      activeSession: env.activeSession ?? null,
+    };
+  }
+
+  const rows = await apiFetch<RawFetchLogRow[]>(`/v1/admin/logs/fetch?${params}`);
+  return { logs: rows.map(toFetchLogEntry), activeSession: null };
 }
 
 // ── Stuck sources ──

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -670,25 +670,19 @@ export async function getFetchLogs(opts: {
   source?: string;
   limit: number;
 }): Promise<{ logs: FetchLogEntry[]; activeSession: ActiveFetchSession | null }> {
-  const params = new URLSearchParams({ limit: String(opts.limit) });
-  if (opts.source) {
-    params.set("source", opts.source);
-    // Ask for the envelope so the response carries the live in-flight fetch
-    // (`activeSession`) alongside the history. The global (no-source) list has
-    // no single active session, so it stays on the bare-array form.
-    params.set("envelope", "true");
-    const env = await apiFetch<{
-      items: RawFetchLogRow[];
-      activeSession: ActiveFetchSession | null;
-    }>(`/v1/admin/logs/fetch?${params}`);
-    return {
-      logs: (env.items ?? []).map(toFetchLogEntry),
-      activeSession: env.activeSession ?? null,
-    };
-  }
-
-  const rows = await apiFetch<RawFetchLogRow[]>(`/v1/admin/logs/fetch?${params}`);
-  return { logs: rows.map(toFetchLogEntry), activeSession: null };
+  // Always request the envelope: for a source-filtered query it carries the live
+  // in-flight fetch (`activeSession`); for the global list it degrades to just
+  // `items` (no single active session). One response shape instead of branching.
+  const params = new URLSearchParams({ limit: String(opts.limit), envelope: "true" });
+  if (opts.source) params.set("source", opts.source);
+  const env = await apiFetch<{
+    items: RawFetchLogRow[];
+    activeSession?: ActiveFetchSession | null;
+  }>(`/v1/admin/logs/fetch?${params}`);
+  return {
+    logs: (env.items ?? []).map(toFetchLogEntry),
+    activeSession: env.activeSession ?? null,
+  };
 }
 
 // ── Stuck sources ──

--- a/src/cli/commands/fetch-log.ts
+++ b/src/cli/commands/fetch-log.ts
@@ -1,11 +1,49 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import { renderTable } from "../render/table.js";
-import { findSource, getFetchLogs } from "../../api/client.js";
+import { findSource, getFetchLogs, type ActiveFetchSession } from "../../api/client.js";
 import { timeAgo } from "@buildinternet/releases-core/dates";
 import { stripAnsi } from "../../lib/sanitize.js";
 import { writeJson } from "../../lib/output.js";
 import { sourceNotFound } from "../suggest.js";
+
+/**
+ * Colour a fetch_log status for the table. crawl_timeout (#1361) and blocked
+ * (#1171) are distinct degraded states — surfacing them as their own labels
+ * (not the catch-all "no change") is the point of #1360; an unknown status is
+ * shown verbatim rather than mislabeled.
+ */
+export function formatStatusLabel(status: string): string {
+  switch (status) {
+    case "dry_run":
+      return chalk.magenta("dry run");
+    case "success":
+      return chalk.green("success");
+    case "error":
+      return chalk.red("error");
+    case "crawl_timeout":
+      return chalk.yellow("crawl timeout");
+    case "blocked":
+      return chalk.yellow("blocked");
+    case "no_change":
+      return chalk.dim("no change");
+    default:
+      return chalk.dim(status);
+  }
+}
+
+/**
+ * One-line banner for a source whose managed-agent fetch is still running
+ * (#1360), so an operator polling the fetch log can tell "in flight" from
+ * "stuck/dead" instead of seeing only terminal history.
+ */
+export function formatActiveFetchBanner(session: ActiveFetchSession): string {
+  const startedAgo = timeAgo(new Date(session.startedAt).toISOString()) ?? "just now";
+  return (
+    chalk.yellow("● fetch in progress") +
+    chalk.dim(` — session ${session.sessionId} · started ${startedAgo}`)
+  );
+}
 
 export function registerFetchLogCommand(program: Command) {
   program
@@ -34,19 +72,24 @@ Examples:
         if (!found) return sourceNotFound(source);
         resolvedSource = found.id;
       }
-      const logs = await getFetchLogs({ source: resolvedSource, limit });
+      const { logs, activeSession } = await getFetchLogs({ source: resolvedSource, limit });
 
-      if (logs.length === 0) {
-        if (opts.json) {
-          await writeJson([]);
-        } else {
-          console.log("No fetch logs found.");
-        }
+      // --json stays the bare logs array for back-compat with existing scripts;
+      // the in-progress banner is human-output only.
+      if (opts.json) {
+        await writeJson(logs);
         return;
       }
 
-      if (opts.json) {
-        await writeJson(logs);
+      // Show the live in-flight fetch first — it's meaningful even when there is
+      // no terminal history yet (a brand-new source mid-first-fetch).
+      if (activeSession) {
+        console.log(formatActiveFetchBanner(activeSession));
+        console.log("");
+      }
+
+      if (logs.length === 0) {
+        console.log("No fetch logs found.");
         return;
       }
 
@@ -62,14 +105,7 @@ Examples:
             { label: "When", noTruncate: true },
           ],
           rows: logs.map((log) => {
-            const statusLabel =
-              log.status === "dry_run"
-                ? chalk.magenta("dry run")
-                : log.status === "success"
-                  ? chalk.green("success")
-                  : log.status === "error"
-                    ? chalk.red("error")
-                    : chalk.dim("no change");
+            const statusLabel = formatStatusLabel(log.status);
             const sourceLabel = log.sourceName
               ? `${stripAnsi(log.sourceName)} ${chalk.dim(`(${log.sourceSlug})`)}`
               : log.sourceSlug || chalk.dim("—");

--- a/tests/unit/api-client.test.ts
+++ b/tests/unit/api-client.test.ts
@@ -781,16 +781,18 @@ describe("getFetchLogs activeSession overlay (#1360)", () => {
     expect(result.logs).toHaveLength(1);
   });
 
-  it("uses the bare-array form (no envelope) with a null activeSession when no source is given", async () => {
+  it("requests the envelope for the global list too, with a null activeSession", async () => {
     let calledUrl = "";
     globalThis.fetch = (async (url: string) => {
       calledUrl = url;
-      return jsonResponse([rawRow("fl_1"), rawRow("fl_2")]);
+      // The global (no-source) list degrades to just items — no activeSession.
+      return jsonResponse({ items: [rawRow("fl_1"), rawRow("fl_2")], pagination: {} });
     }) as any;
 
     const result = await client.getFetchLogs({ limit: 20 });
 
-    expect(calledUrl).not.toContain("envelope=true");
+    expect(calledUrl).toContain("envelope=true");
+    expect(calledUrl).not.toContain("source=");
     expect(result.logs).toHaveLength(2);
     expect(result.activeSession).toBeNull();
   });

--- a/tests/unit/api-client.test.ts
+++ b/tests/unit/api-client.test.ts
@@ -726,3 +726,72 @@ describe("findSource bare-slug ambiguity (#264)", () => {
     expect(urls.some((u) => u.includes("/v1/sources?"))).toBe(false);
   });
 });
+
+const rawFetchLogRow = (id: string) => ({
+  id,
+  sourceId: "src_a1",
+  releasesFound: 0,
+  releasesInserted: 0,
+  durationMs: 1200,
+  status: "no_change",
+  error: null,
+  rawContent: null,
+  createdAt: "2026-06-01T00:00:00.000Z",
+});
+
+describe("getFetchLogs activeSession overlay (#1360)", () => {
+  let originalFetch: typeof globalThis.fetch;
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const rawRow = rawFetchLogRow;
+
+  it("requests envelope=true and returns the activeSession when a source is given", async () => {
+    let calledUrl = "";
+    const active = { sessionId: "ma-run", status: "running", startedAt: 1000, lastUpdatedAt: 2000 };
+    globalThis.fetch = (async (url: string) => {
+      calledUrl = url;
+      return jsonResponse({
+        items: [rawRow("fl_1")],
+        activeSession: active,
+        pagination: { page: 1, pageSize: 20, returned: 1, hasMore: false },
+      });
+    }) as any;
+
+    const result = await client.getFetchLogs({ source: "src_a1", limit: 20 });
+
+    expect(calledUrl).toContain("source=src_a1");
+    expect(calledUrl).toContain("envelope=true");
+    expect(result.logs).toHaveLength(1);
+    expect(result.logs[0].id).toBe("fl_1");
+    expect(result.activeSession).toEqual(active);
+  });
+
+  it("returns a null activeSession when the envelope reports none", async () => {
+    globalThis.fetch = (async () =>
+      jsonResponse({ items: [rawRow("fl_1")], activeSession: null, pagination: {} })) as any;
+
+    const result = await client.getFetchLogs({ source: "src_a1", limit: 20 });
+
+    expect(result.activeSession).toBeNull();
+    expect(result.logs).toHaveLength(1);
+  });
+
+  it("uses the bare-array form (no envelope) with a null activeSession when no source is given", async () => {
+    let calledUrl = "";
+    globalThis.fetch = (async (url: string) => {
+      calledUrl = url;
+      return jsonResponse([rawRow("fl_1"), rawRow("fl_2")]);
+    }) as any;
+
+    const result = await client.getFetchLogs({ limit: 20 });
+
+    expect(calledUrl).not.toContain("envelope=true");
+    expect(result.logs).toHaveLength(2);
+    expect(result.activeSession).toBeNull();
+  });
+});

--- a/tests/unit/fetch-log-banner.test.ts
+++ b/tests/unit/fetch-log-banner.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "bun:test";
+import { stripAnsi } from "../../src/lib/sanitize.js";
+import { formatActiveFetchBanner, formatStatusLabel } from "../../src/cli/commands/fetch-log.js";
+
+/**
+ * #1360: the fetch-log view renders an in-progress banner for a source whose
+ * managed-agent fetch is still running, so an operator can tell "running" from
+ * "stuck". Tested as a pure formatter — command wiring stays thin.
+ */
+describe("formatActiveFetchBanner (#1360)", () => {
+  it("includes the session id, an in-progress marker, and a started-ago time", () => {
+    const banner = stripAnsi(
+      formatActiveFetchBanner({
+        sessionId: "ma-1a2b3c4d",
+        status: "running",
+        startedAt: Date.now() - 120_000,
+        lastUpdatedAt: Date.now(),
+      }),
+    );
+
+    expect(banner.toLowerCase()).toContain("in progress");
+    expect(banner).toContain("ma-1a2b3c4d");
+    expect(banner.toLowerCase()).toContain("started");
+  });
+
+  it("falls back to 'just now' when the start time does not yield a relative string", () => {
+    const banner = stripAnsi(
+      formatActiveFetchBanner({
+        sessionId: "ma-x",
+        status: "running",
+        startedAt: Date.now(),
+        lastUpdatedAt: Date.now(),
+      }),
+    );
+
+    // A near-now start should still produce a readable "started …" clause.
+    expect(banner.toLowerCase()).toContain("started");
+  });
+});
+
+describe("formatStatusLabel (#1360)", () => {
+  it("labels crawl_timeout and blocked distinctly, not as 'no change'", () => {
+    expect(stripAnsi(formatStatusLabel("crawl_timeout"))).toBe("crawl timeout");
+    expect(stripAnsi(formatStatusLabel("blocked"))).toBe("blocked");
+  });
+
+  it("keeps the existing labels for known statuses", () => {
+    expect(stripAnsi(formatStatusLabel("success"))).toBe("success");
+    expect(stripAnsi(formatStatusLabel("error"))).toBe("error");
+    expect(stripAnsi(formatStatusLabel("no_change"))).toBe("no change");
+    expect(stripAnsi(formatStatusLabel("dry_run"))).toBe("dry run");
+  });
+
+  it("shows an unknown status verbatim instead of mislabeling it 'no change'", () => {
+    expect(stripAnsi(formatStatusLabel("something_new"))).toBe("something_new");
+  });
+});


### PR DESCRIPTION
Follow-up to monorepo [buildinternet/releases#1360](https://github.com/buildinternet/releases/issues/1360) — the API side shipped in [releases#1383](https://github.com/buildinternet/releases/pull/1383), which added a live `activeSession` to the enveloped fetch-log response. This renders it in the CLI.

## Why

`fetch_log` only records terminal states, so during a multi-minute crawl `releases admin source fetch-log <source>` showed only stale history — an operator couldn't tell a running fetch from a stuck/dead one. The API now exposes the in-flight managed-agent session; this surfaces it.

## Changes

- **`fetch-log` command** — renders an in-progress banner above the table via `formatActiveFetchBanner` (session id + how long it's been running), shown even when there's no terminal history yet (a brand-new source mid-first-fetch). `--json` is unchanged — still the bare logs array — so existing scripts don't break; the banner is human-output only.
- **`getFetchLogs`** — returns `{ logs, activeSession }`. It always requests `envelope=true`: the source-filtered query carries `activeSession`, the global list degrades to just `items`. One response shape, no branching.
- **`formatStatusLabel`** — surfaces `crawl_timeout` (#1361) and `blocked` (#1171) as their own labels instead of the catch-all "no change" (the same mislabeling #1360 addressed API-side); unknown statuses render verbatim.
- **`ActiveFetchSession` from api-types** — bumps the pin to `^0.28.0` ([releases#1384](https://github.com/buildinternet/releases/pull/1384) publishes the type) and consumes the canonical wire shape instead of a local copy.

## Example

```
● fetch in progress — session ma-1a2b3c4d · started 2m ago

  Source           Status         Found  Inserted  Duration  Error  When
  acme (acme-one)  crawl timeout      0         0     298.4s  …      5m ago
```

## Testing

Pure-function unit tests: `getFetchLogs` envelope parsing (source + global), `formatActiveFetchBanner`, `formatStatusLabel`. Full suite **803 pass / 0 fail**; `tsc --noEmit`, `oxlint`, `prettier --check` clean. Patch changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
