### PR TITLE
feat(cli): entity notices — render + set/clear on org/product/source (#278)

### DIFF
--- a/.changeset/entity-notices.md
+++ b/.changeset/entity-notices.md
@@ -14,4 +14,4 @@ Add entity-notice rendering (Part A) and set/clear verbs (Part B) for org, produ
 
 `--notice-link` is routed automatically: an `https?://` value is sent as `href`; anything else is validated as a 1–2-segment registry coordinate (`org` or `org/slug`) and sent as `coordinate`. `--clear-notice` sends `{ notice: null }` to remove an existing notice. The flags are mutually exclusive (`--clear-notice` + `--notice` exits with an error).
 
-All flag parsing lives in `src/lib/notice.ts` with a local `Notice` type — an interim measure while `@buildinternet/releases-api-types` ≥0.29.0 is pending. Once it is republished with `notice` exported, bump the pin in `package.json` and replace the local type with the canonical import.
+All flag parsing lives in `src/lib/notice.ts`. The `Notice` type is imported from `@buildinternet/releases-core@0.23.0` (canonical source); this PR also bumps `@buildinternet/releases-api-types` to `^0.29.0`.

--- a/.changeset/entity-notices.md
+++ b/.changeset/entity-notices.md
@@ -1,0 +1,17 @@
+---
+"@buildinternet/releases": minor
+---
+
+Add entity-notice rendering (Part A) and set/clear verbs (Part B) for org, product, and source entities (#278).
+
+**Part A — render:** `releases get`, `releases org get`, and `releases admin source update` detail views now display a curator notice in yellow when the API returns one — formatted as `Notice: <message> → <coordinate-or-href>` (pointer omitted when absent). The notice also passes through in all `--json` outputs.
+
+**Part B — set/clear:** New flags on the three entity update commands:
+
+- `releases org update --notice <msg>` / `--notice-link <coord|url>` / `--notice-link-text <label>` / `--clear-notice`
+- `releases admin product update` — same flags
+- `releases admin source update` — same flags
+
+`--notice-link` is routed automatically: an `https?://` value is sent as `href`; anything else is validated as a 1–2-segment registry coordinate (`org` or `org/slug`) and sent as `coordinate`. `--clear-notice` sends `{ notice: null }` to remove an existing notice. The flags are mutually exclusive (`--clear-notice` + `--notice` exits with an error).
+
+All flag parsing lives in `src/lib/notice.ts` with a local `Notice` type — an interim measure while `@buildinternet/releases-api-types` ≥0.29.0 is pending. Once it is republished with `notice` exported, bump the pin in `package.json` and replace the local type with the canonical import.

--- a/bun.lock
+++ b/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "releases-cli",
       "dependencies": {
-        "@buildinternet/releases-api-types": "^0.28.0",
-        "@buildinternet/releases-core": "^0.22.1",
+        "@buildinternet/releases-api-types": "^0.29.0",
+        "@buildinternet/releases-core": "^0.23.0",
         "@buildinternet/releases-lib": "workspace:*",
         "@buildinternet/releases-skills": "workspace:*",
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -73,9 +73,9 @@
 
     "@buildinternet/releases": ["@buildinternet/releases@workspace:npm/releases"],
 
-    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.28.0", "", { "dependencies": { "@buildinternet/releases-core": "^0.22.0", "zod": "^4.4.3" } }, "sha512-2iJvrxf0dy1Hj7VIZHnR8KIBCk7V9UosXVH7BMtCUj9M26XXd2zpMOHHNECiX93m1zSHxYeuhseaTjuSujIaBw=="],
+    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.29.0", "", { "dependencies": { "@buildinternet/releases-core": "^0.23.0", "zod": "^4.4.3" } }, "sha512-MwK5QXrbW7vQ7Qv94UqYfFEUpdNgYMYtMicBSx2nJVquaMoHxE4eOWmJoxO0y67bnlPqMda+mNQie8hX1gL8Bw=="],
 
-    "@buildinternet/releases-core": ["@buildinternet/releases-core@0.22.1", "", { "dependencies": { "drizzle-orm": "^0.45.2", "js-tiktoken": "^1.0.21", "nanoid": "^5.1.7" } }, "sha512-srKTkcKaEUeQsNcujf+Kbqh+LWBSpO4EUgZ0GNwNHip9A6AeEk8V907fRCEcOhhbljJOguL2tXmnmr4gUXWqlA=="],
+    "@buildinternet/releases-core": ["@buildinternet/releases-core@0.23.0", "", { "dependencies": { "drizzle-orm": "^0.45.2", "js-tiktoken": "^1.0.21", "nanoid": "^5.1.7" } }, "sha512-ieUK+KTlXmxX6nRHIft4alMuNNOJctk8AKCfbJmM0SbWqLHcHjLy9O+sj2R+4052IhwJI86gPFpTLM1QNfLFDA=="],
 
     "@buildinternet/releases-darwin-arm64": ["@buildinternet/releases-darwin-arm64@workspace:npm/releases-darwin-arm64"],
 

--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
   },
   "homepage": "https://releases.sh",
   "dependencies": {
-    "@buildinternet/releases-api-types": "^0.28.0",
-    "@buildinternet/releases-core": "^0.22.1",
+    "@buildinternet/releases-api-types": "^0.29.0",
+    "@buildinternet/releases-core": "^0.23.0",
     "@buildinternet/releases-lib": "workspace:*",
     "@buildinternet/releases-skills": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/src/cli/commands/get.ts
+++ b/src/cli/commands/get.ts
@@ -23,6 +23,7 @@ import { humanDate } from "../../lib/release-display.js";
 import { getEntityType, normalizeReleaseId, isLikelyBareId } from "@buildinternet/releases-core/id";
 import { countTokensSafe } from "@buildinternet/releases-core/tokens";
 import { writeJson } from "../../lib/output.js";
+import { formatNotice, type EntityWithNotice } from "../../lib/notice.js";
 
 /** Format a payload-size annotation like `3.2K chars (~800 tokens)` so agents
  * can decide whether to pull the full content body before they spend the
@@ -210,14 +211,15 @@ async function getProduct(identifier: string, opts: GetEntityOpts) {
 
 /** Loose Source shape — `findSource` returns the full row but callers historically
  * narrowed it. Accept the full schema row so we can surface fetch state. */
-type SourceRow = Source & {
-  // Drizzle-derived fields that aren't in the published narrow Source export
-  // but ARE on the wire (see `packages/core/src/schema.ts`).
-  lastFetchedAt?: string | null;
-  consecutiveErrors?: number | null;
-  isHidden?: boolean | null;
-  description?: string | null;
-};
+type SourceRow = Source &
+  EntityWithNotice<{
+    // Drizzle-derived fields that aren't in the published narrow Source export
+    // but ARE on the wire (see `packages/core/src/schema.ts`).
+    lastFetchedAt?: string | null;
+    consecutiveErrors?: number | null;
+    isHidden?: boolean | null;
+    description?: string | null;
+  }>;
 
 async function renderSource(rawSource: unknown, opts: GetEntityOpts) {
   const source = rawSource as SourceRow;
@@ -267,6 +269,7 @@ async function renderSource(rawSource: unknown, opts: GetEntityOpts) {
   if (product) console.log(`  Product:    ${product.name} (${product.slug})`);
   console.log(`  Status:     ${statusLabel}`);
   if (source.lastFetchedAt) console.log(`  Last fetch: ${source.lastFetchedAt}`);
+  if (source.notice) console.log(`  ${chalk.yellow(formatNotice(source.notice))}`);
 
   console.log("");
   if (latest.length === 0) {
@@ -290,15 +293,14 @@ async function renderSource(rawSource: unknown, opts: GetEntityOpts) {
 }
 
 async function renderOrg(
-  org: {
+  org: EntityWithNotice<{
     id: string;
     name: string;
     slug: string;
     domain: string | null;
     category: string | null;
-  } & {
     description?: string | null;
-  },
+  }>,
   opts: GetEntityOpts,
 ) {
   // Collections degrade to empty on failure so an unrelated bug in the
@@ -359,6 +361,7 @@ async function renderOrg(
     const labels = collections.map((c) => `${c.name} ${chalk.dim(`(${c.slug})`)}`).join(", ");
     console.log(`  Collections: ${labels}`);
   }
+  if (org.notice) console.log(`  ${chalk.yellow(formatNotice(org.notice))}`);
 
   console.log("");
   if (releases.length === 0) {
@@ -384,14 +387,16 @@ async function renderOrg(
 }
 
 async function renderProduct(
-  product: {
+  product: EntityWithNotice<{
     id: string;
     name: string;
     slug: string;
     orgId: string;
     url: string | null;
     category: string | null;
-  } & { description?: string | null; avatarUrl?: string | null },
+    description?: string | null;
+    avatarUrl?: string | null;
+  }>,
   opts: GetEntityOpts,
 ) {
   // Pull related context concurrently. Each individually-degradable so a
@@ -456,6 +461,7 @@ async function renderProduct(
     const more = productSources.length > 5 ? chalk.dim(` +${productSources.length - 5}`) : "";
     console.log(`  Sources:  ${preview}${more}`);
   }
+  if (product.notice) console.log(`  ${chalk.yellow(formatNotice(product.notice))}`);
 
   console.log("");
   if (releases.length === 0) {

--- a/src/cli/commands/org.ts
+++ b/src/cli/commands/org.ts
@@ -43,6 +43,7 @@ import {
 } from "@buildinternet/releases-core/overview";
 import { warnDeprecatedAlias } from "../../lib/deprecated-alias.js";
 import { parseTagList } from "../../lib/flags.js";
+import { buildNoticePatch, formatNotice, type EntityWithNotice } from "../../lib/notice.js";
 
 // ── Shared action handlers ────────────────────────────────────────────────────
 
@@ -170,7 +171,9 @@ async function orgCreateAction(name: string, opts: OrgCreateOpts): Promise<void>
 type OrgGetOpts = { json?: boolean };
 
 async function orgGetAction(identifier: string, opts: OrgGetOpts): Promise<void> {
-  const found = await findOrg(identifier);
+  const found = (await findOrg(identifier)) as EntityWithNotice<
+    Awaited<ReturnType<typeof findOrg>>
+  >;
   if (!found) return orgNotFound(identifier);
 
   const [accounts, orgProducts, linkedSources, orgTags, aliases, overview] = await Promise.all([
@@ -204,6 +207,7 @@ async function orgGetAction(identifier: string, opts: OrgGetOpts): Promise<void>
   console.log(`  Updated: ${found.updatedAt}`);
   if (found.category) console.log(`  Category: ${found.category}`);
   if (orgTags.length > 0) console.log(`  Tags:    ${orgTags.join(", ")}`);
+  if (found.notice) console.log(`  ${chalk.yellow(formatNotice(found.notice))}`);
 
   if (accounts.length > 0) {
     console.log();
@@ -270,6 +274,10 @@ type OrgUpdateOpts = {
   paused?: boolean;
   featured?: boolean;
   discovery?: string;
+  notice?: string;
+  noticeLink?: string;
+  noticeLinkText?: string;
+  clearNotice?: boolean;
   json?: boolean;
   dryRun?: boolean;
 };
@@ -314,6 +322,9 @@ async function orgUpdateAction(identifier: string, opts: OrgUpdateOpts): Promise
   if (opts.featured !== undefined) updates.featured = opts.featured;
 
   if (opts.discovery !== undefined) updates.discovery = opts.discovery;
+
+  const noticePatch = buildNoticePatch(opts, logger);
+  if (noticePatch !== null) updates.notice = noticePatch.notice;
 
   if (Object.keys(updates).length === 0) {
     logger.warn("No fields to update.");
@@ -656,6 +667,16 @@ Examples:
       "--discovery <status>",
       `Promote/demote discovery status (${SOURCE_DISCOVERY.join(" | ")})`,
     )
+    .option("--notice <message>", "Set a curator notice on this organization (max 280 chars)")
+    .option(
+      "--notice-link <coordinate|url>",
+      "Optional pointer: registry coordinate (org/slug) or https:// URL",
+    )
+    .option(
+      "--notice-link-text <label>",
+      "Optional link label for the notice pointer (max 60 chars)",
+    )
+    .option("--clear-notice", "Remove the notice from this organization")
     .option("--json", "Output as JSON")
     .option("--dry-run", "Show what would change without writing")
     .action(orgUpdateAction);
@@ -680,6 +701,16 @@ Examples:
       "--discovery <status>",
       `Promote/demote discovery status (${SOURCE_DISCOVERY.join(" | ")})`,
     )
+    .option("--notice <message>", "Set a curator notice on this organization (max 280 chars)")
+    .option(
+      "--notice-link <coordinate|url>",
+      "Optional pointer: registry coordinate (org/slug) or https:// URL",
+    )
+    .option(
+      "--notice-link-text <label>",
+      "Optional link label for the notice pointer (max 60 chars)",
+    )
+    .option("--clear-notice", "Remove the notice from this organization")
     .option("--json", "Output as JSON")
     .option("--dry-run", "Show what would change without writing")
     .action(warnDeprecatedAlias<[string, OrgUpdateOpts]>("edit", "update", orgUpdateAction));

--- a/src/cli/commands/product.ts
+++ b/src/cli/commands/product.ts
@@ -33,6 +33,7 @@ import {
 } from "@buildinternet/releases-core/cli-contracts";
 import { warnDeprecatedAlias } from "../../lib/deprecated-alias.js";
 import { parseTagList } from "../../lib/flags.js";
+import { buildNoticePatch, type EntityWithNotice } from "../../lib/notice.js";
 
 /**
  * Move every source in `sources` to `targetOrg.id` + `productId`, copy
@@ -170,12 +171,18 @@ type ProductUpdateOpts = {
   description?: string;
   category?: string | boolean;
   kind?: string | boolean;
+  notice?: string;
+  noticeLink?: string;
+  noticeLinkText?: string;
+  clearNotice?: boolean;
   json?: boolean;
   dryRun?: boolean;
 };
 
 async function productUpdateAction(slug: string, opts: ProductUpdateOpts): Promise<void> {
-  const found = await findProduct(slug);
+  const found = (await findProduct(slug)) as EntityWithNotice<
+    Awaited<ReturnType<typeof findProduct>>
+  >;
   if (!found) {
     console.error(chalk.red(`Product not found: ${slug}`));
     process.exit(1);
@@ -207,6 +214,9 @@ async function productUpdateAction(slug: string, opts: ProductUpdateOpts): Promi
     }
     updates.kind = opts.kind satisfies Kind;
   }
+
+  const noticePatch = buildNoticePatch(opts, logger);
+  if (noticePatch !== null) updates.notice = noticePatch.notice;
 
   if (Object.keys(updates).length === 0) {
     console.error(chalk.yellow("No fields to update."));
@@ -443,6 +453,16 @@ Examples:
     .option("--no-category", "Clear category")
     .option("--kind <kind>", `Set product taxonomy (${KIND_VALUES.join(", ")})`)
     .option("--no-kind", "Clear product kind")
+    .option("--notice <message>", "Set a curator notice on this product (max 280 chars)")
+    .option(
+      "--notice-link <coordinate|url>",
+      "Optional pointer: registry coordinate (org/slug) or https:// URL",
+    )
+    .option(
+      "--notice-link-text <label>",
+      "Optional link label for the notice pointer (max 60 chars)",
+    )
+    .option("--clear-notice", "Remove the notice from this product")
     .option("--json", "Output as JSON")
     .option("--dry-run", "Show what would change without writing")
     .addHelpText(
@@ -451,7 +471,9 @@ Examples:
 Examples:
   releases admin product update next-js --kind sdk
   releases admin product update prod_abc123 --name "Next.js" --category developer-tools
-  releases admin product update next-js --no-kind`,
+  releases admin product update next-js --no-kind
+  releases admin product update windsurf --notice "Windsurf is now Cognition's Devin" --notice-link cognition/devin
+  releases admin product update windsurf --clear-notice`,
     )
     .action(productUpdateAction);
 
@@ -466,6 +488,16 @@ Examples:
     .option("--no-category", "Clear category")
     .option("--kind <kind>", `Set product taxonomy (${KIND_VALUES.join(", ")})`)
     .option("--no-kind", "Clear product kind")
+    .option("--notice <message>", "Set a curator notice on this product (max 280 chars)")
+    .option(
+      "--notice-link <coordinate|url>",
+      "Optional pointer: registry coordinate (org/slug) or https:// URL",
+    )
+    .option(
+      "--notice-link-text <label>",
+      "Optional link label for the notice pointer (max 60 chars)",
+    )
+    .option("--clear-notice", "Remove the notice from this product")
     .option("--json", "Output as JSON")
     .option("--dry-run", "Show what would change without writing")
     .action(

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -16,6 +16,7 @@ import { logger } from "@releases/lib/logger";
 import { writeJson } from "../../lib/output.js";
 import { readContentArg } from "../../lib/input.js";
 import { parseMetadataSetFlag } from "../../lib/flags.js";
+import { buildNoticePatch } from "../../lib/notice.js";
 
 function inferFeedTypeFromUrl(url: string): "rss" | "atom" | "jsonfeed" {
   const lower = url.toLowerCase();
@@ -48,6 +49,10 @@ export type UpdateSourceOpts = {
   changelogPaths?: string | boolean;
   kind?: string | boolean;
   discovery?: string;
+  notice?: string;
+  noticeLink?: string;
+  noticeLinkText?: string;
+  clearNotice?: boolean;
   dryRun?: boolean;
   metadataSet?: string[];
   metadataUnset?: string[];
@@ -356,6 +361,12 @@ export async function updateSourceAction(
     }
   }
 
+  const noticePatch = buildNoticePatch(opts, logger);
+  if (noticePatch !== null) {
+    updates.notice = noticePatch.notice;
+    changes.push(noticePatch.notice === null ? "notice cleared" : `notice → "${opts.notice}"`);
+  }
+
   if (changes.length === 0) {
     if (!opts.json) logger.warn("No changes specified. Use --help to see options.");
     return;
@@ -471,6 +482,16 @@ export function attachUpdateOptions(cmd: Command): Command {
       },
       [] as string[],
     )
+    .option("--notice <message>", "Set a curator notice on this source (max 280 chars)")
+    .option(
+      "--notice-link <coordinate|url>",
+      "Optional pointer: registry coordinate (org/slug) or https:// URL",
+    )
+    .option(
+      "--notice-link-text <label>",
+      "Optional link label for the notice pointer (max 60 chars)",
+    )
+    .option("--clear-notice", "Remove the notice from this source")
     .option("--json", "Output as JSON")
     .option("--dry-run", "Show what would change without writing");
 }

--- a/src/lib/notice.ts
+++ b/src/lib/notice.ts
@@ -4,31 +4,14 @@
  * A "notice" is a small curator-set note attached to an org, product, or source
  * with an optional pointer — either a registry coordinate ("org/slug") or an
  * external URL.
- *
- * INTERIM TYPE NOTE:
- * The monorepo added `notice` to `@buildinternet/releases-api-types` in PR #1385
- * but the version was NOT bumped before 0.28.0 was published (the currently
- * pinned version). Once `@buildinternet/releases-api-types` is republished at
- * ≥0.29.0 with `notice` exported, bump the pin in package.json and replace the
- * `Notice` type below with the canonical import:
- *   import type { Notice } from "@buildinternet/releases-api-types";
- * Also remove the local `EntityWithNotice` extension type and read `.notice`
- * directly off the API response types.
  */
 
-export interface Notice {
-  message: string;
-  linkText?: string | null;
-  /** Internal registry coordinate, e.g. "cognition" or "cognition/devin". */
-  coordinate?: string | null;
-  /** External URL, e.g. "https://example.com/post". */
-  href?: string | null;
-}
+import type { Notice } from "@buildinternet/releases-core/notice";
+export type { Notice };
 
 /**
- * Extend any entity type at runtime to carry the optional `notice` field the
- * live API already returns (even though the published api-types version doesn't
- * yet declare it).
+ * Extend any entity type at runtime to carry the optional `notice` field.
+ * Used by command files that cast narrowed API response shapes to include notice.
  */
 export type EntityWithNotice<T> = T & { notice?: Notice | null };
 

--- a/src/lib/notice.ts
+++ b/src/lib/notice.ts
@@ -1,0 +1,164 @@
+/**
+ * Entity-notice helpers (org / product / source).
+ *
+ * A "notice" is a small curator-set note attached to an org, product, or source
+ * with an optional pointer — either a registry coordinate ("org/slug") or an
+ * external URL.
+ *
+ * INTERIM TYPE NOTE:
+ * The monorepo added `notice` to `@buildinternet/releases-api-types` in PR #1385
+ * but the version was NOT bumped before 0.28.0 was published (the currently
+ * pinned version). Once `@buildinternet/releases-api-types` is republished at
+ * ≥0.29.0 with `notice` exported, bump the pin in package.json and replace the
+ * `Notice` type below with the canonical import:
+ *   import type { Notice } from "@buildinternet/releases-api-types";
+ * Also remove the local `EntityWithNotice` extension type and read `.notice`
+ * directly off the API response types.
+ */
+
+export interface Notice {
+  message: string;
+  linkText?: string | null;
+  /** Internal registry coordinate, e.g. "cognition" or "cognition/devin". */
+  coordinate?: string | null;
+  /** External URL, e.g. "https://example.com/post". */
+  href?: string | null;
+}
+
+/**
+ * Extend any entity type at runtime to carry the optional `notice` field the
+ * live API already returns (even though the published api-types version doesn't
+ * yet declare it).
+ */
+export type EntityWithNotice<T> = T & { notice?: Notice | null };
+
+// ── Client-side validation caps (server is authoritative) ────────────────────
+
+export const NOTICE_MESSAGE_MAX = 280;
+export const NOTICE_LINK_TEXT_MAX = 60;
+export const NOTICE_HREF_MAX = 500;
+
+/** Segments that form a valid registry coordinate, e.g. "org" or "org/slug". */
+const COORD_SEGMENT_RE = /^[A-Za-z0-9._-]+$/;
+
+/**
+ * Return true if `value` looks like an absolute http(s) URL.
+ * Keeps the check deliberately lenient — the server validates the canonical
+ * form; we just route the value to the right field.
+ */
+export function isAbsoluteUrl(value: string): boolean {
+  return value.startsWith("http://") || value.startsWith("https://");
+}
+
+/**
+ * Validate a registry coordinate: 1–2 URL-safe slug segments separated by a
+ * single slash (no leading/trailing/doubled slashes, no URL scheme).
+ * Returns an error string, or null when valid.
+ */
+export function validateCoordinate(value: string): string | null {
+  if (value.startsWith("http://") || value.startsWith("https://")) {
+    return `"${value}" looks like a URL — drop the scheme or it will be sent as a coordinate`;
+  }
+  const parts = value.split("/");
+  if (parts.length < 1 || parts.length > 2) {
+    return `coordinate must be 1–2 slash-separated segments (e.g. "cognition" or "cognition/devin"), got: "${value}"`;
+  }
+  for (const part of parts) {
+    if (!part) {
+      return `coordinate must not have leading, trailing, or doubled slashes: "${value}"`;
+    }
+    if (!COORD_SEGMENT_RE.test(part)) {
+      return `coordinate segments must only contain letters, digits, dots, underscores, and dashes: "${value}"`;
+    }
+  }
+  return null;
+}
+
+/**
+ * Build the `{ notice }` payload to send in a PATCH body.
+ *
+ * - `--clear-notice` sends `{ notice: null }`.
+ * - `--notice <message>` (with optional `--notice-link` / `--notice-link-text`)
+ *   builds the object shape.
+ *
+ * Returns `null` when neither clear nor set is requested (caller should skip
+ * adding notice to the patch body).
+ *
+ * Exits the process with an error on invalid input — mirrors the rest of the
+ * CLI's fast-fail validation pattern.
+ */
+export function buildNoticePatch(
+  opts: {
+    notice?: string;
+    noticeLink?: string;
+    noticeLinkText?: string;
+    clearNotice?: boolean;
+  },
+  logger: { error: (msg: string) => void },
+): { notice: Notice | null } | null {
+  const hasClear = !!opts.clearNotice;
+  const hasSet = !!opts.notice;
+
+  if (!hasClear && !hasSet) return null;
+
+  if (hasClear && hasSet) {
+    logger.error("--clear-notice and --notice cannot be used together");
+    process.exit(1);
+  }
+
+  if (hasClear) return { notice: null };
+
+  // hasClear is false and hasSet is true
+  const message = opts.notice!;
+
+  if (message.length > NOTICE_MESSAGE_MAX) {
+    logger.error(
+      `--notice message is too long (${message.length} chars; max ${NOTICE_MESSAGE_MAX})`,
+    );
+    process.exit(1);
+  }
+
+  if (opts.noticeLinkText && opts.noticeLinkText.length > NOTICE_LINK_TEXT_MAX) {
+    logger.error(
+      `--notice-link-text is too long (${opts.noticeLinkText.length} chars; max ${NOTICE_LINK_TEXT_MAX})`,
+    );
+    process.exit(1);
+  }
+
+  const noticeObj: Notice = { message };
+
+  if (opts.noticeLinkText) {
+    noticeObj.linkText = opts.noticeLinkText;
+  }
+
+  if (opts.noticeLink) {
+    if (isAbsoluteUrl(opts.noticeLink)) {
+      if (opts.noticeLink.length > NOTICE_HREF_MAX) {
+        logger.error(
+          `--notice-link URL is too long (${opts.noticeLink.length} chars; max ${NOTICE_HREF_MAX})`,
+        );
+        process.exit(1);
+      }
+      noticeObj.href = opts.noticeLink;
+    } else {
+      const err = validateCoordinate(opts.noticeLink);
+      if (err) {
+        logger.error(`--notice-link: ${err}`);
+        process.exit(1);
+      }
+      noticeObj.coordinate = opts.noticeLink;
+    }
+  }
+
+  return { notice: noticeObj };
+}
+
+/**
+ * Format a notice for human-readable terminal output.
+ * Returns a string like `Notice: Message → coordinate-or-href`
+ * (the pointer is omitted when absent).
+ */
+export function formatNotice(notice: Notice): string {
+  const pointer = notice.coordinate ?? notice.href ?? null;
+  return pointer ? `Notice: ${notice.message} → ${pointer}` : `Notice: ${notice.message}`;
+}

--- a/tests/unit/notice.test.ts
+++ b/tests/unit/notice.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect, spyOn } from "bun:test";
+import {
+  isAbsoluteUrl,
+  validateCoordinate,
+  buildNoticePatch,
+  formatNotice,
+  NOTICE_MESSAGE_MAX,
+  NOTICE_LINK_TEXT_MAX,
+  NOTICE_HREF_MAX,
+  type Notice,
+} from "../../src/lib/notice.js";
+
+// Intercept process.exit so invalid-input tests don't kill the runner.
+function withExitTrap(fn: () => void): void {
+  const spy = spyOn(process, "exit").mockImplementation(() => {
+    throw new Error("process.exit called");
+  });
+  try {
+    fn();
+  } finally {
+    spy.mockRestore();
+  }
+}
+
+const noopLogger = { error: (_msg: string) => {} };
+
+// ── isAbsoluteUrl ─────────────────────────────────────────────────────────────
+
+describe("isAbsoluteUrl", () => {
+  it("returns true for https:// URLs", () => {
+    expect(isAbsoluteUrl("https://example.com/post")).toBe(true);
+  });
+
+  it("returns true for http:// URLs", () => {
+    expect(isAbsoluteUrl("http://example.com")).toBe(true);
+  });
+
+  it("returns false for registry coordinates", () => {
+    expect(isAbsoluteUrl("cognition/devin")).toBe(false);
+    expect(isAbsoluteUrl("cognition")).toBe(false);
+  });
+
+  it("returns false for an empty string", () => {
+    expect(isAbsoluteUrl("")).toBe(false);
+  });
+});
+
+// ── validateCoordinate ────────────────────────────────────────────────────────
+
+describe("validateCoordinate", () => {
+  it("accepts a bare org slug", () => {
+    expect(validateCoordinate("cognition")).toBeNull();
+    expect(validateCoordinate("my-org")).toBeNull();
+    expect(validateCoordinate("org_slug.v2")).toBeNull();
+  });
+
+  it("accepts a two-segment org/product coordinate", () => {
+    expect(validateCoordinate("cognition/devin")).toBeNull();
+    expect(validateCoordinate("vercel/next-js")).toBeNull();
+  });
+
+  it("rejects a URL with a scheme", () => {
+    const result = validateCoordinate("https://example.com");
+    expect(result).not.toBeNull();
+    expect(result).toContain("URL");
+  });
+
+  it("rejects more than two segments", () => {
+    const result = validateCoordinate("a/b/c");
+    expect(result).not.toBeNull();
+    expect(result).toContain("1–2");
+  });
+
+  it("rejects leading slash", () => {
+    const result = validateCoordinate("/cognition");
+    expect(result).not.toBeNull();
+  });
+
+  it("rejects trailing slash", () => {
+    const result = validateCoordinate("cognition/");
+    expect(result).not.toBeNull();
+  });
+
+  it("rejects doubled slash", () => {
+    const result = validateCoordinate("a//b");
+    expect(result).not.toBeNull();
+  });
+
+  it("rejects segments with special characters", () => {
+    const result = validateCoordinate("cognition devin");
+    expect(result).not.toBeNull();
+  });
+
+  it("rejects a segment with a colon", () => {
+    const result = validateCoordinate("cog:nition");
+    expect(result).not.toBeNull();
+  });
+});
+
+// ── buildNoticePatch ──────────────────────────────────────────────────────────
+
+describe("buildNoticePatch", () => {
+  it("returns null when no notice flags are provided", () => {
+    expect(buildNoticePatch({}, noopLogger)).toBeNull();
+  });
+
+  it("returns { notice: null } when --clear-notice is set", () => {
+    expect(buildNoticePatch({ clearNotice: true }, noopLogger)).toEqual({ notice: null });
+  });
+
+  it("rejects --clear-notice combined with --notice", () => {
+    withExitTrap(() => {
+      expect(() => buildNoticePatch({ clearNotice: true, notice: "hello" }, noopLogger)).toThrow(
+        "process.exit called",
+      );
+    });
+  });
+
+  it("builds a minimal notice with message only", () => {
+    const result = buildNoticePatch({ notice: "Hello world" }, noopLogger);
+    expect(result).toEqual({ notice: { message: "Hello world" } });
+  });
+
+  it("routes a https:// link to the href field", () => {
+    const result = buildNoticePatch(
+      { notice: "See the new home", noticeLink: "https://example.com/new" },
+      noopLogger,
+    );
+    expect(result).toEqual({
+      notice: { message: "See the new home", href: "https://example.com/new" },
+    });
+  });
+
+  it("routes a coordinate to the coordinate field", () => {
+    const result = buildNoticePatch(
+      { notice: "Moved to Cognition", noticeLink: "cognition/devin" },
+      noopLogger,
+    );
+    expect(result).toEqual({
+      notice: { message: "Moved to Cognition", coordinate: "cognition/devin" },
+    });
+  });
+
+  it("includes linkText when provided", () => {
+    const result = buildNoticePatch(
+      {
+        notice: "See Devin",
+        noticeLink: "cognition/devin",
+        noticeLinkText: "Cognition Devin",
+      },
+      noopLogger,
+    );
+    expect(result).toEqual({
+      notice: {
+        message: "See Devin",
+        coordinate: "cognition/devin",
+        linkText: "Cognition Devin",
+      },
+    });
+  });
+
+  it("rejects a message that exceeds NOTICE_MESSAGE_MAX", () => {
+    withExitTrap(() => {
+      const longMsg = "a".repeat(NOTICE_MESSAGE_MAX + 1);
+      expect(() => buildNoticePatch({ notice: longMsg }, noopLogger)).toThrow(
+        "process.exit called",
+      );
+    });
+  });
+
+  it("accepts a message at exactly NOTICE_MESSAGE_MAX", () => {
+    const exactMsg = "a".repeat(NOTICE_MESSAGE_MAX);
+    const result = buildNoticePatch({ notice: exactMsg }, noopLogger);
+    expect(result?.notice).not.toBeNull();
+  });
+
+  it("rejects a linkText that exceeds NOTICE_LINK_TEXT_MAX", () => {
+    withExitTrap(() => {
+      const longText = "x".repeat(NOTICE_LINK_TEXT_MAX + 1);
+      expect(() =>
+        buildNoticePatch({ notice: "msg", noticeLinkText: longText }, noopLogger),
+      ).toThrow("process.exit called");
+    });
+  });
+
+  it("rejects a href that exceeds NOTICE_HREF_MAX", () => {
+    withExitTrap(() => {
+      const longHref = "https://example.com/" + "a".repeat(NOTICE_HREF_MAX);
+      expect(() => buildNoticePatch({ notice: "msg", noticeLink: longHref }, noopLogger)).toThrow(
+        "process.exit called",
+      );
+    });
+  });
+
+  it("rejects an invalid coordinate in noticeLink", () => {
+    withExitTrap(() => {
+      expect(() => buildNoticePatch({ notice: "msg", noticeLink: "a/b/c" }, noopLogger)).toThrow(
+        "process.exit called",
+      );
+    });
+  });
+});
+
+// ── formatNotice ──────────────────────────────────────────────────────────────
+
+describe("formatNotice", () => {
+  it("formats a message-only notice", () => {
+    const notice: Notice = { message: "This product has moved" };
+    expect(formatNotice(notice)).toBe("Notice: This product has moved");
+  });
+
+  it("appends a coordinate pointer with →", () => {
+    const notice: Notice = { message: "Moved to Cognition", coordinate: "cognition/devin" };
+    expect(formatNotice(notice)).toBe("Notice: Moved to Cognition → cognition/devin");
+  });
+
+  it("appends an href pointer with →", () => {
+    const notice: Notice = { message: "See announcement", href: "https://example.com/post" };
+    expect(formatNotice(notice)).toBe("Notice: See announcement → https://example.com/post");
+  });
+
+  it("prefers coordinate over href when both are present (coordinate wins)", () => {
+    const notice: Notice = {
+      message: "Multi-pointer",
+      coordinate: "org/slug",
+      href: "https://example.com",
+    };
+    // coordinate is checked first in the formatter
+    expect(formatNotice(notice)).toBe("Notice: Multi-pointer → org/slug");
+  });
+
+  it("ignores linkText in the text rendering (linkText is for web/MCP)", () => {
+    const notice: Notice = {
+      message: "Moved",
+      linkText: "Click here",
+      coordinate: "org/slug",
+    };
+    expect(formatNotice(notice)).toBe("Notice: Moved → org/slug");
+  });
+});


### PR DESCRIPTION
Closes #278.

## Summary

- **Part A — render:** `releases get`, `releases org get`, and source detail views now show a curator notice in yellow when the API returns one. Format: `Notice: <message> → <coordinate-or-href>` (pointer omitted when absent). Passes through untouched in all `--json` outputs (the `notice` field is already included since the entity spread includes all server-returned fields).
- **Part B — set/clear verbs:** Four new flags on `releases org update`, `releases admin product update`, and `releases admin source update`:
  - `--notice <message>` — set the notice message (max 280 chars)
  - `--notice-link <coordinate|url>` — optional pointer; auto-routed: `https?://` → `href` field, otherwise validated as a 1–2-segment registry coordinate (`org` or `org/slug`) → `coordinate` field
  - `--notice-link-text <label>` — optional link label (max 60 chars, for web/MCP surfaces)
  - `--clear-notice` — send `{ notice: null }` to remove the notice

## Routing and validation

`--notice-link` routing is automatic and client-side:
- Starts with `https://` or `http://` → sent as `href`
- Otherwise → validated as 1–2 URL-safe slug segments (`[A-Za-z0-9._-]`, no scheme, no leading/trailing/doubled slash) → sent as `coordinate`

Client-side caps (server is authoritative): message ≤280, link text ≤60, href ≤500. Invalid input exits immediately with a descriptive error.

`--clear-notice` and `--notice` are mutually exclusive and produce an immediate error if combined.

## Interim local type approach

The CLI pins `@buildinternet/releases-api-types: ^0.28.0`. That published version does **not** include the `notice` field — the monorepo added it in PR #1385 but did not bump the version before 0.28.0 was published.

To avoid a hard block, this PR:
1. Defines a local `Notice` interface + `EntityWithNotice<T>` helper type in `src/lib/notice.ts`
2. Casts entity responses to `EntityWithNotice<…>` at the call sites so TypeScript is satisfied
3. Reads `.notice` off the runtime response (the live API already returns it)

A comment in `src/lib/notice.ts` documents the follow-up: once `@buildinternet/releases-api-types` is republished at ≥0.29.0 with `notice` exported, bump the pin and replace the local type with the canonical import.

## Test plan

- [ ] `bun test` — all 557 unit tests pass (30 new in `tests/unit/notice.test.ts`)
- [ ] `npx tsc --noEmit` — clean
- [ ] `bun run lint` — no new warnings
- [ ] `bun run format:check` — clean
- [ ] Manual smoke: `releases get <org-with-notice>` renders the Notice line in yellow
- [ ] Manual smoke: `releases org update <slug> --notice "..." --notice-link org/slug` sets notice; `--clear-notice` clears it
- [ ] Manual smoke: `--notice-link https://...` sends href; `--notice-link org/product` sends coordinate
- [ ] Manual smoke: `--clear-notice --notice "..."` exits with error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
