### PR TITLE
feat(org): admin org avatar — one-step avatar ingest (#1406)

### DIFF
--- a/.changeset/org-avatar-verb.md
+++ b/.changeset/org-avatar-verb.md
@@ -1,0 +1,7 @@
+---
+"@buildinternet/releases": minor
+---
+
+feat(org): `admin org avatar <org> --from <source>` — one-step avatar ingest (#1406)
+
+Resolve an image, mirror it to R2, and set the org avatar in a single command. `--from` accepts an `https://` URL, or a shortcut derived from the org's own data (no fuzzy matching): `github` (the org's linked GitHub handle → `github.com/{handle}.png`), `favicon` (the org domain's apple-touch-icon), or `appstore` (the org's App Store source → iTunes 1024px artwork). Resolution runs CLI-side; the server fetches, validates it's a square raster, and stores it — CF credentials stay server-side. Backed by `POST /v1/orgs/:slug/avatar` (api-types 0.30.0).

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "releases-cli",
       "dependencies": {
-        "@buildinternet/releases-api-types": "^0.29.0",
+        "@buildinternet/releases-api-types": "^0.30.0",
         "@buildinternet/releases-core": "^0.23.0",
         "@buildinternet/releases-lib": "workspace:*",
         "@buildinternet/releases-skills": "workspace:*",
@@ -27,7 +27,7 @@
     },
     "npm/releases": {
       "name": "@buildinternet/releases",
-      "version": "0.55.0",
+      "version": "0.56.0",
       "bin": {
         "releases": "bin/releases",
       },
@@ -41,31 +41,31 @@
     },
     "npm/releases-darwin-arm64": {
       "name": "@buildinternet/releases-darwin-arm64",
-      "version": "0.55.0",
+      "version": "0.56.0",
     },
     "npm/releases-darwin-x64": {
       "name": "@buildinternet/releases-darwin-x64",
-      "version": "0.55.0",
+      "version": "0.56.0",
     },
     "npm/releases-linux-arm64": {
       "name": "@buildinternet/releases-linux-arm64",
-      "version": "0.55.0",
+      "version": "0.56.0",
     },
     "npm/releases-linux-x64": {
       "name": "@buildinternet/releases-linux-x64",
-      "version": "0.55.0",
+      "version": "0.56.0",
     },
     "npm/releases-windows-x64": {
       "name": "@buildinternet/releases-windows-x64",
-      "version": "0.55.0",
+      "version": "0.56.0",
     },
     "packages/lib": {
       "name": "@buildinternet/releases-lib",
-      "version": "0.55.0",
+      "version": "0.56.0",
     },
     "packages/skills": {
       "name": "@buildinternet/releases-skills",
-      "version": "0.55.0",
+      "version": "0.56.0",
     },
   },
   "packages": {
@@ -73,7 +73,7 @@
 
     "@buildinternet/releases": ["@buildinternet/releases@workspace:npm/releases"],
 
-    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.29.0", "", { "dependencies": { "@buildinternet/releases-core": "^0.23.0", "zod": "^4.4.3" } }, "sha512-MwK5QXrbW7vQ7Qv94UqYfFEUpdNgYMYtMicBSx2nJVquaMoHxE4eOWmJoxO0y67bnlPqMda+mNQie8hX1gL8Bw=="],
+    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.30.0", "", { "dependencies": { "@buildinternet/releases-core": "^0.23.0", "zod": "^4.4.3" } }, "sha512-aYaixgkuSpV93lz5x5sswqYnqHd7guJVK2Eulc/dS/cEY4HmEFqtTuRt/WwgzNGBMBeF4X5soflu0ravsfo4Hw=="],
 
     "@buildinternet/releases-core": ["@buildinternet/releases-core@0.23.0", "", { "dependencies": { "drizzle-orm": "^0.45.2", "js-tiktoken": "^1.0.21", "nanoid": "^5.1.7" } }, "sha512-ieUK+KTlXmxX6nRHIft4alMuNNOJctk8AKCfbJmM0SbWqLHcHjLy9O+sj2R+4052IhwJI86gPFpTLM1QNfLFDA=="],
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "homepage": "https://releases.sh",
   "dependencies": {
-    "@buildinternet/releases-api-types": "^0.29.0",
+    "@buildinternet/releases-api-types": "^0.30.0",
     "@buildinternet/releases-core": "^0.23.0",
     "@buildinternet/releases-lib": "workspace:*",
     "@buildinternet/releases-skills": "workspace:*",

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -55,6 +55,7 @@ import type {
   UpdateCollectionRequest,
   ReplaceCollectionMembersRequest,
   AddCollectionMemberRequest,
+  SetOrgAvatarResponse,
 } from "@buildinternet/releases-api-types";
 export type {
   DomainLookupResponse,
@@ -1124,6 +1125,21 @@ export async function updateOrg(
   return apiFetch<Organization>(`/v1/orgs/${encodeURIComponent(identifier)}`, {
     method: "PATCH",
     body: JSON.stringify(data),
+  });
+}
+
+/**
+ * Mirror a remote image to R2 and set it as the org avatar (#1406). The server
+ * fetches + validates (square raster) + stores at `orgs/{slug}.{ext}`, keeping CF
+ * credentials server-side; the CLI only resolves a concrete image URL.
+ */
+export async function setOrgAvatar(
+  identifier: string,
+  sourceUrl: string,
+): Promise<SetOrgAvatarResponse> {
+  return apiFetch<SetOrgAvatarResponse>(`/v1/orgs/${encodeURIComponent(identifier)}/avatar`, {
+    method: "POST",
+    body: JSON.stringify({ sourceUrl }),
   });
 }
 

--- a/src/cli/commands/org.ts
+++ b/src/cli/commands/org.ts
@@ -450,7 +450,12 @@ async function resolveAvatarSource(
   from: string,
   org: { id: string; slug: string; domain?: string | null },
 ): Promise<string> {
-  if (/^https?:\/\//i.test(from)) return from;
+  if (/^https:\/\//i.test(from)) return from;
+  if (/^http:\/\//i.test(from)) {
+    throw new Error(
+      `Refusing to fetch an avatar over plaintext http. Pass an https:// URL instead.`,
+    );
+  }
   switch (from) {
     case "github": {
       const accounts = await getOrgAccountsBySlug(org.slug);

--- a/src/cli/commands/org.ts
+++ b/src/cli/commands/org.ts
@@ -19,7 +19,14 @@ import {
   setAliases,
   getOverview,
   getOrgDependents,
+  setOrgAvatar,
 } from "../../api/client.js";
+import {
+  githubAvatarUrl,
+  faviconAvatarUrl,
+  appStoreTrackId,
+  appStoreArtworkUrl,
+} from "../../lib/avatar-source.js";
 import { promptConfirm } from "../../lib/confirm.js";
 import { stripAnsi } from "../../lib/sanitize.js";
 import { logger } from "@releases/lib/logger";
@@ -433,6 +440,49 @@ export async function orgDeleteAction(identifier: string, opts: OrgDeleteOpts): 
     );
 }
 
+/**
+ * Resolve a `--from` value to a concrete image URL. An https URL is used as-is;
+ * the shortcuts derive a URL from the org's own data (no fuzzy matching): `github`
+ * → the org's linked GitHub handle, `favicon` → the org domain's apple-touch-icon,
+ * `appstore` → the org's App Store source's iTunes artwork (#1406).
+ */
+async function resolveAvatarSource(
+  from: string,
+  org: { id: string; slug: string; domain?: string | null },
+): Promise<string> {
+  if (/^https?:\/\//i.test(from)) return from;
+  switch (from) {
+    case "github": {
+      const accounts = await getOrgAccountsBySlug(org.slug);
+      const gh = accounts.find((a) => a.platform === "github");
+      if (!gh)
+        throw new Error(`No GitHub account linked to ${org.slug}; pass --from <url> instead.`);
+      return githubAvatarUrl(gh.handle);
+    }
+    case "favicon": {
+      if (!org.domain) throw new Error(`${org.slug} has no domain; pass --from <url> instead.`);
+      return faviconAvatarUrl(org.domain);
+    }
+    case "appstore": {
+      const sources = await getSourcesByOrg(org.id);
+      const app = sources.find((s) => s.type === "appstore" && s.url);
+      if (!app?.url)
+        throw new Error(
+          `${org.slug} has no App Store source; pass the apps.apple.com artwork URL via --from <url>.`,
+        );
+      const trackId = appStoreTrackId(app.url);
+      if (!trackId) throw new Error(`Could not parse an App Store track id from ${app.url}.`);
+      const art = await appStoreArtworkUrl(trackId);
+      if (!art) throw new Error(`iTunes lookup returned no artwork for track ${trackId}.`);
+      return art;
+    }
+    default:
+      throw new Error(
+        `Unknown --from "${from}". Use an https:// URL, or appstore | github | favicon.`,
+      );
+  }
+}
+
 // ── Command registration ──────────────────────────────────────────────────────
 
 export function registerOrgCommand(program: Command) {
@@ -680,6 +730,47 @@ Examples:
     .option("--json", "Output as JSON")
     .option("--dry-run", "Show what would change without writing")
     .action(orgUpdateAction);
+
+  org
+    .command("avatar")
+    .description("Resolve an image, mirror it to R2, and set it as the org avatar")
+    .argument("<identifier>", "Organization ID (org_…), slug, domain, or name")
+    .requiredOption(
+      "--from <source>",
+      "Image source: an https:// URL, or a shortcut — appstore | github | favicon",
+    )
+    .option("--json", "Output as JSON")
+    .action(async (identifier: string, opts: { from: string; json?: boolean }) => {
+      const target = await findOrg(identifier);
+      if (!target) {
+        orgNotFound(identifier);
+        process.exitCode = 1;
+        return;
+      }
+
+      let sourceUrl: string;
+      try {
+        sourceUrl = await resolveAvatarSource(opts.from.trim(), target);
+      } catch (err) {
+        logger.error(err instanceof Error ? err.message : String(err));
+        process.exitCode = 1;
+        return;
+      }
+
+      try {
+        const result = await setOrgAvatar(target.slug, sourceUrl);
+        if (opts.json) {
+          console.log(JSON.stringify(result, null, 2));
+          return;
+        }
+        logger.info(
+          `${chalk.green("✓")} Set ${chalk.bold(target.slug)} avatar → ${result.avatarUrl} (${result.width}×${result.height})`,
+        );
+      } catch (err) {
+        logger.error(`Failed to set avatar: ${err instanceof Error ? err.message : String(err)}`);
+        process.exitCode = 1;
+      }
+    });
 
   org
     .command("edit")

--- a/src/lib/avatar-source.ts
+++ b/src/lib/avatar-source.ts
@@ -1,0 +1,47 @@
+/**
+ * Resolve a `releases admin org avatar --from <value>` shortcut to a concrete
+ * image URL. Resolution runs client-side so CF credentials stay server-side — the
+ * server does the fetch + square-raster validation + R2 mirror (#1406).
+ */
+
+/** GitHub's per-account avatar redirect — `github.com/{handle}.png`. */
+export function githubAvatarUrl(handle: string): string {
+  return `https://github.com/${encodeURIComponent(handle.replace(/^@/, ""))}.png`;
+}
+
+/**
+ * Convention apple-touch-icon for a domain. The endpoint validates it's a square
+ * raster, so a missing/odd icon is rejected with a clear error rather than stored.
+ */
+export function faviconAvatarUrl(domain: string): string {
+  const host = domain
+    .trim()
+    .replace(/^https?:\/\//i, "")
+    .replace(/\/.*$/, "");
+  return `https://${host}/apple-touch-icon.png`;
+}
+
+/** Numeric App Store track id from an apps.apple.com URL (`…/id123456`), else null. */
+export function appStoreTrackId(url: string): string | null {
+  const m = /\/id(\d+)/.exec(url);
+  return m ? m[1]! : null;
+}
+
+/** Upscale an iTunes artwork URL's `NxN` size segment to 1024×1024 (best-effort). */
+export function upscaleArtwork(url: string): string {
+  return url.replace(/\/\d+x\d+(bb)?\.(png|jpe?g|webp)(\?.*)?$/i, "/1024x1024$1.$2$3");
+}
+
+/** Look up an App Store app's largest artwork via the iTunes lookup API. */
+export async function appStoreArtworkUrl(
+  trackId: string,
+  fetchImpl: (input: string) => Promise<Response> = fetch,
+): Promise<string | null> {
+  const res = await fetchImpl(`https://itunes.apple.com/lookup?id=${encodeURIComponent(trackId)}`);
+  if (!res.ok) return null;
+  const data = (await res.json()) as {
+    results?: Array<{ artworkUrl512?: string; artworkUrl100?: string }>;
+  };
+  const art = data.results?.[0]?.artworkUrl512 ?? data.results?.[0]?.artworkUrl100;
+  return art ? upscaleArtwork(art) : null;
+}

--- a/tests/unit/avatar-source.test.ts
+++ b/tests/unit/avatar-source.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "bun:test";
+import {
+  githubAvatarUrl,
+  faviconAvatarUrl,
+  appStoreTrackId,
+  upscaleArtwork,
+  appStoreArtworkUrl,
+} from "../../src/lib/avatar-source.js";
+
+describe("githubAvatarUrl", () => {
+  it("builds the per-account avatar redirect, stripping a leading @", () => {
+    expect(githubAvatarUrl("vercel")).toBe("https://github.com/vercel.png");
+    expect(githubAvatarUrl("@stripe")).toBe("https://github.com/stripe.png");
+  });
+});
+
+describe("faviconAvatarUrl", () => {
+  it("builds the apple-touch-icon URL, tolerating protocol/path in the domain", () => {
+    expect(faviconAvatarUrl("acme.com")).toBe("https://acme.com/apple-touch-icon.png");
+    expect(faviconAvatarUrl("https://acme.com/blog")).toBe("https://acme.com/apple-touch-icon.png");
+  });
+});
+
+describe("appStoreTrackId", () => {
+  it("extracts the numeric id from an apps.apple.com URL", () => {
+    expect(appStoreTrackId("https://apps.apple.com/us/app/1password/id1511601750")).toBe(
+      "1511601750",
+    );
+    expect(appStoreTrackId("https://example.com/no-id")).toBeNull();
+  });
+});
+
+describe("upscaleArtwork", () => {
+  it("upscales the NxN size segment to 1024×1024", () => {
+    expect(upscaleArtwork("https://is1-ssl.mzstatic.com/image/x/512x512bb.png")).toBe(
+      "https://is1-ssl.mzstatic.com/image/x/1024x1024bb.png",
+    );
+    expect(upscaleArtwork("https://is1-ssl.mzstatic.com/image/x/100x100bb.jpg")).toBe(
+      "https://is1-ssl.mzstatic.com/image/x/1024x1024bb.jpg",
+    );
+  });
+  it("leaves an unrecognized URL unchanged (still a valid square ≥128px)", () => {
+    expect(upscaleArtwork("https://cdn.example.com/icon.png")).toBe(
+      "https://cdn.example.com/icon.png",
+    );
+  });
+});
+
+const fetchOk = (body: unknown) =>
+  (async () =>
+    new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    })) as unknown as (input: string) => Promise<Response>;
+
+describe("appStoreArtworkUrl", () => {
+  it("returns the upscaled 512 artwork from the iTunes lookup", async () => {
+    const url = await appStoreArtworkUrl(
+      "123",
+      fetchOk({ results: [{ artworkUrl512: "https://m.test/512x512bb.png" }] }),
+    );
+    expect(url).toBe("https://m.test/1024x1024bb.png");
+  });
+
+  it("falls back to artworkUrl100 when 512 is absent", async () => {
+    const url = await appStoreArtworkUrl(
+      "123",
+      fetchOk({ results: [{ artworkUrl100: "https://m.test/100x100bb.jpg" }] }),
+    );
+    expect(url).toBe("https://m.test/1024x1024bb.jpg");
+  });
+
+  it("returns null on an empty result set", async () => {
+    expect(await appStoreArtworkUrl("123", fetchOk({ results: [] }))).toBeNull();
+  });
+
+  it("returns null on a non-OK lookup", async () => {
+    const fetchFail = (async () => new Response("nope", { status: 404 })) as unknown as (
+      input: string,
+    ) => Promise<Response>;
+    expect(await appStoreArtworkUrl("123", fetchFail)).toBeNull();
+  });
+});


### PR DESCRIPTION
The user-facing half of buildinternet/releases#1406. The backend endpoint (`POST /v1/orgs/:slug/avatar`) shipped in the monorepo (#1414, merged) and published api-types 0.30.0; this adds the CLI verb that completes the "one command resolves + mirrors + sets the pointer" acceptance.

## What

```
releases admin org avatar <org> --from <source>
```

`--from` accepts:
- an **`https://` URL** (used as-is — e.g. paste an App Store 1024px artwork URL), or
- a **shortcut** derived from the org's own data (no fuzzy matching):
  - `github` → the org's linked GitHub handle → `github.com/{handle}.png`
  - `favicon` → the org domain's `/apple-touch-icon.png`
  - `appstore` → the org's App Store *source* → iTunes lookup → 1024px artwork

Resolution runs CLI-side; the server fetches, validates it's a square raster, and stores at `orgs/{slug}.{ext}` — so CF credentials stay server-side.

## How

- **`src/lib/avatar-source.ts`** — pure resolvers (`githubAvatarUrl`, `faviconAvatarUrl`, `appStoreTrackId`, `upscaleArtwork`) + `appStoreArtworkUrl` (iTunes lookup with an injectable fetch).
- **`src/api/client.ts`** — `setOrgAvatar(identifier, sourceUrl)`.
- **`src/cli/commands/org.ts`** — the `avatar` subcommand + `resolveAvatarSource`.
- **api-types `^0.30.0`** for `SetOrgAvatarResponse`.

## Verification

- 9 unit tests covering every resolver, the `@`-strip, protocol/path-tolerant favicon, track-id extraction, artwork upscaling (+ unchanged passthrough), and the iTunes lookup (512 → upscale, fallback to `artworkUrl100`, empty results → null, non-OK → null).
- Full CLI suite **842 pass**; `tsc --noEmit`, oxlint, prettier all clean.
- `--help` smoke confirms it registers under `admin org avatar`.

## Notes
- `appstore` derives the icon from the org's already-onboarded App Store source (exact track-id lookup, no name matching). If an org has no App Store source, the error points to passing the apps.apple.com artwork URL via `--from <url>` — exactly the manual flow this replaces.
- Changeset targets `@buildinternet/releases` (minor), per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `org avatar` CLI command to set organization avatars from multiple sources: direct HTTPS URLs, GitHub profiles, domain favicons, or App Store artwork.

* **Tests**
  * Added unit tests for avatar source resolution utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->