### PR TITLE
feat(cli): `releases login` — device authorization (RFC 8628)

### DIFF
--- a/src/cli/commands/login.ts
+++ b/src/cli/commands/login.ts
@@ -6,22 +6,19 @@ import { getDataDir } from "@releases/lib/config";
 import { getApiUrl } from "../../lib/mode.js";
 import { writeCredential, type StoredCredential } from "../../lib/credentials.js";
 import { openBrowser } from "../../lib/open-browser.js";
-import { runDeviceLogin, type UserScope } from "../../lib/device-auth.js";
+import { runDeviceLogin } from "../../lib/device-auth.js";
 
 export function registerLoginCommand(program: Command): void {
   program
     .command("login")
-    .description("Sign in via your browser and store an API key (device authorization)")
-    .option("--scope <scope>", "Requested scope: read or write", "write")
+    .description("Sign in via your browser and store a read-only API key (device authorization)")
     .option("--no-browser", "Print the URL instead of opening a browser")
-    .action(async (opts: { scope?: string; browser?: boolean }) => {
-      const scope: UserScope = opts.scope === "read" ? "read" : "write";
+    .action(async (opts: { browser?: boolean }) => {
       const apiUrl = getApiUrl();
 
       try {
         const result = await runDeviceLogin({
           apiUrl,
-          scope,
           openInBrowser: opts.browser !== false,
           deps: {
             openBrowser,

--- a/src/cli/commands/login.ts
+++ b/src/cli/commands/login.ts
@@ -1,0 +1,53 @@
+import { hostname } from "node:os";
+import { join } from "node:path";
+import type { Command } from "commander";
+import chalk from "chalk";
+import { getDataDir } from "@releases/lib/config";
+import { getApiUrl } from "../../lib/mode.js";
+import { writeCredential, type StoredCredential } from "../../lib/credentials.js";
+import { openBrowser } from "../../lib/open-browser.js";
+import { runDeviceLogin, type UserScope } from "../../lib/device-auth.js";
+
+export function registerLoginCommand(program: Command): void {
+  program
+    .command("login")
+    .description("Sign in via your browser and store an API key (device authorization)")
+    .option("--scope <scope>", "Requested scope: read or write", "write")
+    .option("--no-browser", "Print the URL instead of opening a browser")
+    .action(async (opts: { scope?: string; browser?: boolean }) => {
+      const scope: UserScope = opts.scope === "read" ? "read" : "write";
+      const apiUrl = getApiUrl();
+
+      try {
+        const result = await runDeviceLogin({
+          apiUrl,
+          scope,
+          openInBrowser: opts.browser !== false,
+          deps: {
+            openBrowser,
+            keyName: `releases-cli (${hostname()})`,
+            print: (line) => console.log(line),
+          },
+        });
+
+        const cred: StoredCredential = {
+          token: result.token,
+          name: result.name,
+          scopes: result.scopes,
+          apiUrl: result.apiUrl,
+          savedAt: new Date().toISOString(),
+        };
+        writeCredential(cred);
+
+        console.log(
+          `${chalk.green("Signed in")} ${chalk.dim(
+            `(scopes: ${(result.scopes ?? []).join(", ")})`,
+          )}`,
+        );
+        console.log(chalk.dim(`  Saved to ${join(getDataDir(), "credentials")}`));
+      } catch (err) {
+        console.error(chalk.red((err as Error).message));
+        process.exit(1);
+      }
+    });
+}

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -54,6 +54,7 @@ import { CATEGORIES } from "@buildinternet/releases-core/categories";
 import { isAuthenticated } from "../lib/mode.js";
 import { preflightScopeWarning } from "../lib/preflight.js";
 import { registerAuthCommand } from "./commands/auth.js";
+import { registerLoginCommand } from "./commands/login.js";
 import { VERSION } from "./version.js";
 import { writeJson } from "../lib/output.js";
 
@@ -233,6 +234,7 @@ registerFeedbackCommand(program);
 registerSubmitCommand(program);
 registerWhoamiCommand(program);
 registerAuthCommand(program);
+registerLoginCommand(program);
 registerAgentContextCommand(program);
 registerCompletionCommand(program);
 registerSkillsCommand(program);

--- a/src/lib/device-auth.ts
+++ b/src/lib/device-auth.ts
@@ -3,8 +3,10 @@
  * against the API worker's Better Auth handler — no `better-auth` dependency, so
  * the thin client stays thin. The flow: request a device+user code, have the
  * human approve it in a browser, poll for a session access token, then exchange
- * that session for a durable `relu_` API key (created server-side, capped at the
- * requested scope) and hand it back to the caller to store.
+ * that session for a durable `relu_` API key and hand it back to the caller to
+ * store. User keys are READ-ONLY: the server caps the relu_ lane at read
+ * (USER_API_KEY_MAX_SCOPE), so there is no scope choice here — login mints a
+ * read key that can search and read the catalog but not modify it.
  */
 
 // Must match DEVICE_AUTH_CLIENT_ID in @buildinternet/releases-core/api-token — the
@@ -13,8 +15,6 @@
 // the literal in lockstep until then.
 const CLIENT_ID = "releases-cli";
 const GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code";
-
-export type UserScope = "read" | "write";
 
 export interface DeviceCodeResponse {
   device_code: string;
@@ -27,13 +27,14 @@ export interface DeviceCodeResponse {
 
 export async function requestDeviceCode(
   apiUrl: string,
-  scope: UserScope,
   fetchImpl: typeof fetch = fetch,
 ): Promise<DeviceCodeResponse> {
   const res = await fetchImpl(`${apiUrl}/api/auth/device/code`, {
     method: "POST",
     headers: { "content-type": "application/json", "user-agent": CLIENT_ID },
-    body: JSON.stringify({ client_id: CLIENT_ID, scope }),
+    // No OAuth scope on the device-grant request: the minted key's scope is fixed
+    // read-only server-side, so there is nothing to request here.
+    body: JSON.stringify({ client_id: CLIENT_ID }),
   });
   if (!res.ok) {
     throw new Error(`Could not start device login (HTTP ${res.status}).`);
@@ -124,7 +125,7 @@ export async function getSessionUser(
 export interface CreatedKey {
   key: string;
   name?: string | null;
-  /** Single ladder label the server granted ("read" | "write"). */
+  /** Ladder label the server granted — "read" for the user lane today. */
   scope?: string;
 }
 
@@ -132,15 +133,15 @@ export interface CreatedKey {
  * Exchange the device-flow session for a durable `relu_` API key. Hits the API
  * worker's own `/v1/api-keys` route — the SAME surface the web panel uses, NOT
  * Better Auth's raw `/api/auth/api-key/create` — so the server injects the owner,
- * caps the scope to read/write, and encodes the permission ladder in one place. The
- * device-flow session token rides as a Bearer credential, which the worker's
- * `requireSession` honors via its `bearer()` plugin.
+ * caps the scope, and encodes the permission ladder in one place. We request
+ * `read` explicitly: user keys are capped read-only server-side, and asking for
+ * anything higher is a 400. The device-flow session token rides as a Bearer
+ * credential, which the worker's `requireSession` honors via its `bearer()` plugin.
  */
 export async function createUserApiKey(
   apiUrl: string,
   accessToken: string,
   name: string,
-  scope: UserScope,
   fetchImpl: typeof fetch = fetch,
 ): Promise<CreatedKey> {
   const res = await fetchImpl(`${apiUrl}/v1/api-keys`, {
@@ -150,7 +151,7 @@ export async function createUserApiKey(
       authorization: `Bearer ${accessToken}`,
       "user-agent": CLIENT_ID,
     },
-    body: JSON.stringify({ name, scope }),
+    body: JSON.stringify({ name, scope: "read" }),
   });
   if (!res.ok) {
     throw new Error(`Login succeeded but issuing an API key failed (HTTP ${res.status}).`);
@@ -169,7 +170,6 @@ export interface DeviceLoginDeps {
 
 export interface DeviceLoginArgs {
   apiUrl: string;
-  scope: UserScope;
   openInBrowser: boolean;
   deps?: DeviceLoginDeps;
 }
@@ -192,7 +192,7 @@ export async function runDeviceLogin(args: DeviceLoginArgs): Promise<DeviceLogin
   const print = args.deps?.print ?? ((l: string) => console.log(l));
   const keyName = args.deps?.keyName ?? "releases-cli";
 
-  const code = await requestDeviceCode(args.apiUrl, args.scope, fetchImpl);
+  const code = await requestDeviceCode(args.apiUrl, fetchImpl);
 
   print(`\nTo connect the CLI, visit:\n  ${code.verification_uri}`);
   print(`and enter the code:\n  ${code.user_code}\n`);
@@ -217,12 +217,12 @@ export async function runDeviceLogin(args: DeviceLoginArgs): Promise<DeviceLogin
   const sessionUser = await getSessionUser(args.apiUrl, accessToken, fetchImpl);
   if (sessionUser) print(`Authorized as ${sessionUser.name ?? sessionUser.email}.`);
 
-  const created = await createUserApiKey(args.apiUrl, accessToken, keyName, args.scope, fetchImpl);
+  const created = await createUserApiKey(args.apiUrl, accessToken, keyName, fetchImpl);
 
   return {
     token: created.key,
     name: created.name ?? keyName,
-    scopes: [created.scope ?? args.scope],
+    scopes: [created.scope ?? "read"],
     apiUrl: args.apiUrl,
   };
 }

--- a/src/lib/device-auth.ts
+++ b/src/lib/device-auth.ts
@@ -7,6 +7,10 @@
  * requested scope) and hand it back to the caller to store.
  */
 
+// Must match DEVICE_AUTH_CLIENT_ID in @buildinternet/releases-core/api-token — the
+// worker's validateClient allow-list rejects any other client_id (fail closed).
+// Hard-coded until a published core version exposing that constant is adopted; keep
+// the literal in lockstep until then.
 const CLIENT_ID = "releases-cli";
 const GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code";
 
@@ -19,15 +23,6 @@ export interface DeviceCodeResponse {
   verification_uri_complete?: string;
   expires_in: number;
   interval?: number;
-}
-
-/**
- * Cumulative `api`-resource actions matching the server's permission encoding
- * (`workers/api/src/auth/api-key-scope.ts` in the monorepo). Kept as a local copy
- * so the CLI doesn't import worker code; reconcile if the server encoding changes.
- */
-export function scopeToApiPermissions(scope: UserScope): Record<string, string[]> {
-  return scope === "write" ? { api: ["read", "write"] } : { api: ["read"] };
 }
 
 export async function requestDeviceCode(
@@ -128,17 +123,18 @@ export async function getSessionUser(
 
 export interface CreatedKey {
   key: string;
-  name?: string;
-  scopes?: string[];
+  name?: string | null;
+  /** Single ladder label the server granted ("read" | "write"). */
+  scope?: string;
 }
 
 /**
- * Exchange the device-flow session for a durable `relu_` API key. Calls the
- * `@better-auth/api-key` create endpoint with the session as a Bearer token
- * (requires the server `bearer()` plugin). The server caps the scope.
- *
- * Seam: confirm the create path + body against the installed plugin once the
- * monorepo Phase 1 lands. If the endpoint differs, change it here only.
+ * Exchange the device-flow session for a durable `relu_` API key. Hits the API
+ * worker's own `/v1/api-keys` route — the SAME surface the web panel uses, NOT
+ * Better Auth's raw `/api/auth/api-key/create` — so the server injects the owner,
+ * caps the scope to read/write, and encodes the permission ladder in one place. The
+ * device-flow session token rides as a Bearer credential, which the worker's
+ * `requireSession` honors via its `bearer()` plugin.
  */
 export async function createUserApiKey(
   apiUrl: string,
@@ -147,14 +143,14 @@ export async function createUserApiKey(
   scope: UserScope,
   fetchImpl: typeof fetch = fetch,
 ): Promise<CreatedKey> {
-  const res = await fetchImpl(`${apiUrl}/api/auth/api-key/create`, {
+  const res = await fetchImpl(`${apiUrl}/v1/api-keys`, {
     method: "POST",
     headers: {
       "content-type": "application/json",
       authorization: `Bearer ${accessToken}`,
       "user-agent": CLIENT_ID,
     },
-    body: JSON.stringify({ name, permissions: scopeToApiPermissions(scope) }),
+    body: JSON.stringify({ name, scope }),
   });
   if (!res.ok) {
     throw new Error(`Login succeeded but issuing an API key failed (HTTP ${res.status}).`);
@@ -226,7 +222,7 @@ export async function runDeviceLogin(args: DeviceLoginArgs): Promise<DeviceLogin
   return {
     token: created.key,
     name: created.name ?? keyName,
-    scopes: created.scopes ?? scopeToApiPermissions(args.scope).api,
+    scopes: [created.scope ?? args.scope],
     apiUrl: args.apiUrl,
   };
 }

--- a/src/lib/device-auth.ts
+++ b/src/lib/device-auth.ts
@@ -1,0 +1,163 @@
+/**
+ * RFC 8628 device-authorization client for `releases login`. Plain `fetch`
+ * against the API worker's Better Auth handler — no `better-auth` dependency, so
+ * the thin client stays thin. The flow: request a device+user code, have the
+ * human approve it in a browser, poll for a session access token, then exchange
+ * that session for a durable `relu_` API key (created server-side, capped at the
+ * requested scope) and hand it back to the caller to store.
+ */
+
+const CLIENT_ID = "releases-cli";
+const GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code";
+
+export type UserScope = "read" | "write";
+
+export interface DeviceCodeResponse {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  verification_uri_complete?: string;
+  expires_in: number;
+  interval?: number;
+}
+
+/**
+ * Cumulative `api`-resource actions matching the server's permission encoding
+ * (`workers/api/src/auth/api-key-scope.ts` in the monorepo). Kept as a local copy
+ * so the CLI doesn't import worker code; reconcile if the server encoding changes.
+ */
+export function scopeToApiPermissions(scope: UserScope): Record<string, string[]> {
+  return scope === "write" ? { api: ["read", "write"] } : { api: ["read"] };
+}
+
+export async function requestDeviceCode(
+  apiUrl: string,
+  scope: UserScope,
+  fetchImpl: typeof fetch = fetch,
+): Promise<DeviceCodeResponse> {
+  const res = await fetchImpl(`${apiUrl}/api/auth/device/code`, {
+    method: "POST",
+    headers: { "content-type": "application/json", "user-agent": CLIENT_ID },
+    body: JSON.stringify({ client_id: CLIENT_ID, scope }),
+  });
+  if (!res.ok) {
+    throw new Error(`Could not start device login (HTTP ${res.status}).`);
+  }
+  return (await res.json()) as DeviceCodeResponse;
+}
+
+export interface PollOptions {
+  intervalSeconds: number;
+  expiresInSeconds: number;
+  fetchImpl?: typeof fetch;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const defaultSleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+/** Poll the token endpoint until approval, denial, or expiry. Returns the access token. */
+export async function pollForToken(
+  apiUrl: string,
+  deviceCode: string,
+  opts: PollOptions,
+): Promise<string> {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const sleep = opts.sleep ?? defaultSleep;
+  let interval = Math.max(0, opts.intervalSeconds);
+  const deadline = Date.now() + opts.expiresInSeconds * 1000;
+
+  for (;;) {
+    if (Date.now() > deadline) {
+      throw new Error("Device code expired before it was approved. Run `releases login` again.");
+    }
+    await sleep(interval * 1000);
+
+    const res = await fetchImpl(`${apiUrl}/api/auth/device/token`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "user-agent": CLIENT_ID },
+      body: JSON.stringify({
+        grant_type: GRANT_TYPE,
+        device_code: deviceCode,
+        client_id: CLIENT_ID,
+      }),
+    });
+    const data = (await res.json().catch(() => ({}))) as {
+      access_token?: string;
+      error?: string;
+      error_description?: string;
+    };
+
+    if (data.access_token) return data.access_token;
+
+    switch (data.error) {
+      case "authorization_pending":
+        continue;
+      case "slow_down":
+        interval += 5;
+        continue;
+      case "access_denied":
+        throw new Error("Authorization was denied in the browser.");
+      case "expired_token":
+        throw new Error("Device code expired before it was approved. Run `releases login` again.");
+      default:
+        throw new Error(
+          `Device login failed: ${data.error_description ?? data.error ?? "unknown error"}`,
+        );
+    }
+  }
+}
+
+export interface SessionUser {
+  email: string;
+  name?: string;
+}
+
+/** Fetch the user behind a device-flow access token (for the "Logged in as" greeting). */
+export async function getSessionUser(
+  apiUrl: string,
+  accessToken: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<SessionUser | null> {
+  const res = await fetchImpl(`${apiUrl}/api/auth/get-session`, {
+    headers: { authorization: `Bearer ${accessToken}`, "user-agent": CLIENT_ID },
+  });
+  if (!res.ok) return null;
+  const data = (await res.json().catch(() => null)) as { user?: SessionUser } | null;
+  return data?.user ?? null;
+}
+
+export interface CreatedKey {
+  key: string;
+  name?: string;
+  scopes?: string[];
+}
+
+/**
+ * Exchange the device-flow session for a durable `relu_` API key. Calls the
+ * `@better-auth/api-key` create endpoint with the session as a Bearer token
+ * (requires the server `bearer()` plugin). The server caps the scope.
+ *
+ * Seam: confirm the create path + body against the installed plugin once the
+ * monorepo Phase 1 lands. If the endpoint differs, change it here only.
+ */
+export async function createUserApiKey(
+  apiUrl: string,
+  accessToken: string,
+  name: string,
+  scope: UserScope,
+  fetchImpl: typeof fetch = fetch,
+): Promise<CreatedKey> {
+  const res = await fetchImpl(`${apiUrl}/api/auth/api-key/create`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${accessToken}`,
+      "user-agent": CLIENT_ID,
+    },
+    body: JSON.stringify({ name, permissions: scopeToApiPermissions(scope) }),
+  });
+  if (!res.ok) {
+    throw new Error(`Login succeeded but issuing an API key failed (HTTP ${res.status}).`);
+  }
+  return (await res.json()) as CreatedKey;
+}

--- a/src/lib/device-auth.ts
+++ b/src/lib/device-auth.ts
@@ -161,3 +161,72 @@ export async function createUserApiKey(
   }
   return (await res.json()) as CreatedKey;
 }
+
+export interface DeviceLoginDeps {
+  fetchImpl?: typeof fetch;
+  sleep?: (ms: number) => Promise<void>;
+  openBrowser?: (url: string) => boolean;
+  print?: (line: string) => void;
+  /** Name recorded on the minted key (defaults to `releases-cli (<hostname>)`). */
+  keyName?: string;
+}
+
+export interface DeviceLoginArgs {
+  apiUrl: string;
+  scope: UserScope;
+  openInBrowser: boolean;
+  deps?: DeviceLoginDeps;
+}
+
+export interface DeviceLoginResult {
+  token: string;
+  name?: string;
+  scopes?: string[];
+  apiUrl: string;
+}
+
+/**
+ * Orchestrate the full device-login flow and return a credential payload for the
+ * caller to persist. Pure of I/O specifics via injectable deps (fetch, sleep,
+ * browser, print) so it's unit-testable. Does NOT write to disk — the command
+ * layer owns persistence so storage stays in one place.
+ */
+export async function runDeviceLogin(args: DeviceLoginArgs): Promise<DeviceLoginResult> {
+  const fetchImpl = args.deps?.fetchImpl ?? fetch;
+  const print = args.deps?.print ?? ((l: string) => console.log(l));
+  const keyName = args.deps?.keyName ?? "releases-cli";
+
+  const code = await requestDeviceCode(args.apiUrl, args.scope, fetchImpl);
+
+  print(`\nTo connect the CLI, visit:\n  ${code.verification_uri}`);
+  print(`and enter the code:\n  ${code.user_code}\n`);
+
+  const target = code.verification_uri_complete ?? code.verification_uri;
+  if (args.openInBrowser && args.deps?.openBrowser) {
+    const ok = args.deps.openBrowser(target);
+    print(ok ? "Opening your browser..." : `Open this URL manually:\n  ${target}`);
+  } else if (args.openInBrowser) {
+    // No injected opener in this context; the command layer wires the real one.
+    print(`Open this URL to continue:\n  ${target}`);
+  }
+
+  print("Waiting for authorization...");
+  const accessToken = await pollForToken(args.apiUrl, code.device_code, {
+    intervalSeconds: code.interval ?? 5,
+    expiresInSeconds: code.expires_in,
+    fetchImpl,
+    sleep: args.deps?.sleep,
+  });
+
+  const sessionUser = await getSessionUser(args.apiUrl, accessToken, fetchImpl);
+  if (sessionUser) print(`Authorized as ${sessionUser.name ?? sessionUser.email}.`);
+
+  const created = await createUserApiKey(args.apiUrl, accessToken, keyName, args.scope, fetchImpl);
+
+  return {
+    token: created.key,
+    name: created.name ?? keyName,
+    scopes: created.scopes ?? scopeToApiPermissions(args.scope).api,
+    apiUrl: args.apiUrl,
+  };
+}

--- a/src/lib/open-browser.ts
+++ b/src/lib/open-browser.ts
@@ -1,0 +1,27 @@
+import { spawn } from "node:child_process";
+
+/** Resolve the OS-specific command to open a URL in the default browser. */
+export function browserCommand(
+  platform: NodeJS.Platform,
+  url: string,
+): { cmd: string; args: string[] } {
+  if (platform === "darwin") return { cmd: "open", args: [url] };
+  if (platform === "win32") return { cmd: "cmd", args: ["/c", "start", "", url] };
+  return { cmd: "xdg-open", args: [url] };
+}
+
+/**
+ * Best-effort: open `url` in the default browser, detached. Returns false if the
+ * launch throws (headless box, missing opener) so the caller can fall back to
+ * printing the URL for manual opening. Never throws.
+ */
+export function openBrowser(url: string, platform: NodeJS.Platform = process.platform): boolean {
+  try {
+    const { cmd, args } = browserCommand(platform, url);
+    const child = spawn(cmd, args, { stdio: "ignore", detached: true });
+    child.unref();
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/tests/unit/device-auth.test.ts
+++ b/tests/unit/device-auth.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "bun:test";
+import {
+  scopeToApiPermissions,
+  requestDeviceCode,
+  pollForToken,
+} from "../../src/lib/device-auth.js";
+
+const BASE = "https://test.example.com";
+
+describe("scopeToApiPermissions", () => {
+  it("maps read/write to cumulative api actions", () => {
+    expect(scopeToApiPermissions("read")).toEqual({ api: ["read"] });
+    expect(scopeToApiPermissions("write")).toEqual({ api: ["read", "write"] });
+  });
+});
+
+describe("requestDeviceCode", () => {
+  it("POSTs client_id + scope and returns the code payload", async () => {
+    let seen: { url: string; body: unknown } | null = null;
+    const fakeFetch = (async (url: string, init?: RequestInit) => {
+      seen = { url, body: JSON.parse(String(init?.body)) };
+      return new Response(
+        JSON.stringify({
+          device_code: "dev123",
+          user_code: "ABCD1234",
+          verification_uri: "https://releases.sh/device",
+          verification_uri_complete: "https://releases.sh/device?user_code=ABCD1234",
+          expires_in: 900,
+          interval: 5,
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+
+    const res = await requestDeviceCode(BASE, "write", fakeFetch);
+    expect(res.user_code).toBe("ABCD1234");
+    expect(seen!.url).toBe(`${BASE}/api/auth/device/code`);
+    expect(seen!.body).toEqual({ client_id: "releases-cli", scope: "write" });
+  });
+});
+
+describe("pollForToken", () => {
+  it("returns the access_token after an authorization_pending round", async () => {
+    let call = 0;
+    const fakeFetch = (async () => {
+      call += 1;
+      if (call === 1) {
+        return new Response(JSON.stringify({ error: "authorization_pending" }), {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response(JSON.stringify({ access_token: "tok_abc" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    const token = await pollForToken(BASE, "dev123", {
+      intervalSeconds: 0, // no real waiting in tests
+      expiresInSeconds: 60,
+      fetchImpl: fakeFetch,
+      sleep: async () => {},
+    });
+    expect(token).toBe("tok_abc");
+    expect(call).toBe(2);
+  });
+
+  it("throws when the user denies", async () => {
+    const fakeFetch = (async () =>
+      new Response(JSON.stringify({ error: "access_denied" }), {
+        status: 400,
+        headers: { "content-type": "application/json" },
+      })) as unknown as typeof fetch;
+
+    await expect(
+      pollForToken(BASE, "dev123", {
+        intervalSeconds: 0,
+        expiresInSeconds: 60,
+        fetchImpl: fakeFetch,
+        sleep: async () => {},
+      }),
+    ).rejects.toThrow(/denied/i);
+  });
+});

--- a/tests/unit/device-auth.test.ts
+++ b/tests/unit/device-auth.test.ts
@@ -1,19 +1,7 @@
 import { describe, it, expect } from "bun:test";
-import {
-  scopeToApiPermissions,
-  requestDeviceCode,
-  pollForToken,
-  runDeviceLogin,
-} from "../../src/lib/device-auth.js";
+import { requestDeviceCode, pollForToken, runDeviceLogin } from "../../src/lib/device-auth.js";
 
 const BASE = "https://test.example.com";
-
-describe("scopeToApiPermissions", () => {
-  it("maps read/write to cumulative api actions", () => {
-    expect(scopeToApiPermissions("read")).toEqual({ api: ["read"] });
-    expect(scopeToApiPermissions("write")).toEqual({ api: ["read", "write"] });
-  });
-});
 
 describe("requestDeviceCode", () => {
   it("POSTs client_id + scope and returns the code payload", async () => {
@@ -118,14 +106,19 @@ describe("runDeviceLogin", () => {
           headers: { "content-type": "application/json" },
         });
       }
-      if (u.endsWith("/api/auth/api-key/create")) {
+      if (u.endsWith("/v1/api-keys")) {
         return new Response(
           JSON.stringify({
             key: "relu_secretkey",
+            id: "ak_1",
             name: "releases-cli",
-            scopes: ["read", "write"],
+            start: "relu_sec",
+            scope: "write",
+            remaining: null,
+            expiresAt: null,
+            createdAt: "2026-06-05T00:00:00.000Z",
           }),
-          { status: 200, headers: { "content-type": "application/json" } },
+          { status: 201, headers: { "content-type": "application/json" } },
         );
       }
       throw new Error(`unexpected url ${u}`);
@@ -149,7 +142,8 @@ describe("runDeviceLogin", () => {
 
     expect(result.token).toBe("relu_secretkey");
     expect(result.apiUrl).toBe(apiUrl);
-    expect(result.scopes).toEqual(["read", "write"]);
+    // The server returns the granted ladder label; runDeviceLogin stores it as-is.
+    expect(result.scopes).toEqual(["write"]);
     expect(opened).toBe(`${apiUrl}/device?user_code=ABCD1234`);
     // The user code is shown to the human at least once.
     expect(printed.join("\n")).toContain("ABCD1234");

--- a/tests/unit/device-auth.test.ts
+++ b/tests/unit/device-auth.test.ts
@@ -21,10 +21,11 @@ describe("requestDeviceCode", () => {
       );
     }) as unknown as typeof fetch;
 
-    const res = await requestDeviceCode(BASE, "write", fakeFetch);
+    const res = await requestDeviceCode(BASE, fakeFetch);
     expect(res.user_code).toBe("ABCD1234");
     expect(seen!.url).toBe(`${BASE}/api/auth/device/code`);
-    expect(seen!.body).toEqual({ client_id: "releases-cli", scope: "write" });
+    // No OAuth scope: the minted key is read-only server-side, nothing to request.
+    expect(seen!.body).toEqual({ client_id: "releases-cli" });
   });
 });
 
@@ -113,7 +114,7 @@ describe("runDeviceLogin", () => {
             id: "ak_1",
             name: "releases-cli",
             start: "relu_sec",
-            scope: "write",
+            scope: "read",
             remaining: null,
             expiresAt: null,
             createdAt: "2026-06-05T00:00:00.000Z",
@@ -126,7 +127,6 @@ describe("runDeviceLogin", () => {
 
     const result = await runDeviceLogin({
       apiUrl,
-      scope: "write",
       openInBrowser: true,
       deps: {
         fetchImpl: fakeFetch,
@@ -142,8 +142,8 @@ describe("runDeviceLogin", () => {
 
     expect(result.token).toBe("relu_secretkey");
     expect(result.apiUrl).toBe(apiUrl);
-    // The server returns the granted ladder label; runDeviceLogin stores it as-is.
-    expect(result.scopes).toEqual(["write"]);
+    // User keys are read-only; the server returns the granted label, stored as-is.
+    expect(result.scopes).toEqual(["read"]);
     expect(opened).toBe(`${apiUrl}/device?user_code=ABCD1234`);
     // The user code is shown to the human at least once.
     expect(printed.join("\n")).toContain("ABCD1234");

--- a/tests/unit/device-auth.test.ts
+++ b/tests/unit/device-auth.test.ts
@@ -3,6 +3,7 @@ import {
   scopeToApiPermissions,
   requestDeviceCode,
   pollForToken,
+  runDeviceLogin,
 } from "../../src/lib/device-auth.js";
 
 const BASE = "https://test.example.com";
@@ -81,5 +82,76 @@ describe("pollForToken", () => {
         sleep: async () => {},
       }),
     ).rejects.toThrow(/denied/i);
+  });
+});
+
+describe("runDeviceLogin", () => {
+  it("returns a stored-credential payload on success", async () => {
+    const apiUrl = BASE;
+    let opened: string | null = null;
+    const printed: string[] = [];
+
+    const fakeFetch = (async (url: string) => {
+      const u = String(url);
+      if (u.endsWith("/api/auth/device/code")) {
+        return new Response(
+          JSON.stringify({
+            device_code: "dev123",
+            user_code: "ABCD1234",
+            verification_uri: `${apiUrl}/device`,
+            verification_uri_complete: `${apiUrl}/device?user_code=ABCD1234`,
+            expires_in: 900,
+            interval: 0,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      if (u.endsWith("/api/auth/device/token")) {
+        return new Response(JSON.stringify({ access_token: "tok_abc" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (u.endsWith("/api/auth/get-session")) {
+        return new Response(JSON.stringify({ user: { email: "z@example.com", name: "Zach" } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (u.endsWith("/api/auth/api-key/create")) {
+        return new Response(
+          JSON.stringify({
+            key: "relu_secretkey",
+            name: "releases-cli",
+            scopes: ["read", "write"],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      throw new Error(`unexpected url ${u}`);
+    }) as unknown as typeof fetch;
+
+    const result = await runDeviceLogin({
+      apiUrl,
+      scope: "write",
+      openInBrowser: true,
+      deps: {
+        fetchImpl: fakeFetch,
+        sleep: async () => {},
+        openBrowser: (url) => {
+          opened = url;
+          return true;
+        },
+        print: (line) => printed.push(line),
+        keyName: "releases-cli (testhost)",
+      },
+    });
+
+    expect(result.token).toBe("relu_secretkey");
+    expect(result.apiUrl).toBe(apiUrl);
+    expect(result.scopes).toEqual(["read", "write"]);
+    expect(opened).toBe(`${apiUrl}/device?user_code=ABCD1234`);
+    // The user code is shown to the human at least once.
+    expect(printed.join("\n")).toContain("ABCD1234");
   });
 });

--- a/tests/unit/open-browser.test.ts
+++ b/tests/unit/open-browser.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "bun:test";
+import { browserCommand } from "../../src/lib/open-browser.js";
+
+describe("browserCommand", () => {
+  it("uses `open` on macOS", () => {
+    expect(browserCommand("darwin", "https://x")).toEqual({ cmd: "open", args: ["https://x"] });
+  });
+  it("uses cmd/start on Windows", () => {
+    expect(browserCommand("win32", "https://x")).toEqual({
+      cmd: "cmd",
+      args: ["/c", "start", "", "https://x"],
+    });
+  });
+  it("uses xdg-open elsewhere", () => {
+    expect(browserCommand("linux", "https://x")).toEqual({ cmd: "xdg-open", args: ["https://x"] });
+  });
+});


### PR DESCRIPTION
## `releases login` — device-authorization (RFC 8628) CLI login

A no-paste, browser-approved login that mints a durable user-owned **read-only** `relu_` API key. The server + web half is **[buildinternet/releases#1447](https://github.com/buildinternet/releases/pull/1447)** (merged + deployed, inert behind the flag).

> **Merge ordering:** safe to review now. `releases login` will `401` against prod until the `device-authorization-enabled` + `user-api-keys-enabled` Flagship flags are flipped on. Merge after the flags are live.

### What this adds

1. `releases login` requests a device + user code (`POST /api/auth/device/code`), prints the code, and opens the browser to `/device`.
2. It polls (`POST /api/auth/device/token`) until the human approves in the browser.
3. It exchanges the resulting session (carried as a Bearer token) for a read-only `relu_` key, stores it through the existing credential path, and discards the session.

The web self-serve "API Keys" panel remains a first-class way to generate keys; this is purely additive. The paste-based `releases auth login` is untouched.

### Read-only, matching the server ceiling (#1448)

[releases#1448](https://github.com/buildinternet/releases/pull/1448) capped user (`relu_`) keys at **read-only** — the mint route refuses anything above read, and the auth resolver clamps every `relu_` key to read. So `releases login` mints a read key (search + read the catalog, no writes), with **no `--scope` option** — mirroring the web panel, which dropped its read/write selector in the same PR. `createUserApiKey` sends `{ name, scope: "read" }`.

### Key exchange — the real contract

The exchange hits the API worker's own **`POST /v1/api-keys`** route (the same surface the web panel uses), **not** Better Auth's raw `/api/auth/api-key/create`. The server injects the owner from the session and caps/encodes the scope. The device-flow session token rides as `Authorization: Bearer …`, which the worker's `requireSession` honors via its `bearer()` plugin.

### Files

- `src/lib/device-auth.ts` — RFC 8628 client over plain `fetch` (no `better-auth` dep): `requestDeviceCode`, `pollForToken` (handles `authorization_pending` / `slow_down` / `access_denied` / `expired_token` / expiry), `getSessionUser`, `createUserApiKey` (→ `/v1/api-keys`, read-only), and the injectable-deps `runDeviceLogin` orchestrator.
- `src/lib/open-browser.ts` — OS-detecting opener (`open` / `start` / `xdg-open`) with a headless fallback that prints the URL.
- `src/cli/commands/login.ts` — the top-level `login` command (`--no-browser`).
- `src/cli/program.ts` — registers the command.
- `tests/unit/device-auth.test.ts`, `tests/unit/open-browser.test.ts` — unit tests (HTTP + browser layers injected).

### Testing

- `bun test`: **849 pass / 0 fail**. `tsc --noEmit`: clean. `bun run build`: clean; `releases login --help` shows the read-only description and no `--scope`.
- The `client_id` (`releases-cli`) matches the worker's `validateClient` allow-list (`DEVICE_AUTH_CLIENT_ID` in `@buildinternet/releases-core/api-token`); kept as a local literal until the published core version exposing it is adopted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
