### PR TITLE
chore: add missing changeset for `releases login` (#282)

### DIFF
--- a/.changeset/login-device-auth.md
+++ b/.changeset/login-device-auth.md
@@ -1,0 +1,7 @@
+---
+"@buildinternet/releases": minor
+---
+
+feat(cli): `releases login` — device authorization (RFC 8628) (#282)
+
+Add a top-level `releases login` command that authenticates the CLI via the OAuth 2.0 Device Authorization Grant (RFC 8628): it requests a device/user code, opens the verification URL in the browser (with a headless copy-paste fallback), polls for approval, then exchanges the device session for a durable read-only `relu_` API key minted via `POST /v1/api-keys` and stores it through the existing credential path. Backfills the changeset omitted when #282 merged.


### PR DESCRIPTION
## What

Backfills the changeset that was omitted when **#282** (`releases login` — device authorization, RFC 8628) merged.

## Why

Auditing recent CLI work surfaced that #282 merged without a changeset. Since the last `chore: version packages` (#277), two feature PRs landed:

- **#280** (org avatar) — ✅ included a changeset
- **#282** (`releases login`) — ❌ no changeset

Without this, the login feature's minor bump and its changelog entry would be silently dropped from the next release. There's no reason it was excluded — it's a user-facing feature on par with the other recent PRs. This adds a `minor` changeset (consistent with the others), targeting `@buildinternet/releases`, which cascades to all 8 fixed packages.

No code changes — changeset only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `releases login` command for CLI authentication using OAuth 2.0 Device Authorization Grant, enabling users to generate and store secure API keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->