### PR TITLE
feat: add 'releases keys' verbs (create/list/revoke)

### DIFF
--- a/.changeset/keys-verbs.md
+++ b/.changeset/keys-verbs.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": minor
+---
+
+Add `releases keys` verbs (create/list/revoke) for self-serve, read-only user API keys. Authenticated via the device-flow session token persisted at login, with transparent re-auth on expiry.

--- a/README.md
+++ b/README.md
@@ -204,6 +204,19 @@ releases login --no-browser # print the URL + code to open yourself (headless / 
 
 This uses the OAuth 2.0 Device Authorization Grant (RFC 8628): the CLI shows a short code, you approve it at [releases.sh/device](https://releases.sh/device) in a signed-in browser, and a **read-only** key is minted and saved to `~/.releases/credentials`. Sign up / sign in to the web app first if you haven't. A read-only key is all that's self-serve today; write/admin keys are closed beta (see above).
 
+### Managing keys
+
+List, create, and revoke your personal API keys without leaving the terminal:
+
+```bash
+releases keys list                                  # your keys (id, scope, prefix, created, expiry)
+releases keys create --name "ci-bot"                # mints a read-only key, shown once
+releases keys create --name "ci-bot" --expires-in-days 90
+releases keys revoke <id>                            # delete a key (confirm, or pass --yes)
+```
+
+Keys created here are **read-only** (write/admin are not self-serve). The created key string is shown exactly once — store it then. These commands reuse the session from `releases login`, re-prompting the browser approval only when it has expired; the session is bound to the API environment it was issued against, so switching `RELEASES_API_URL` re-authenticates rather than reusing a key from another environment.
+
 ### Storing a token directly
 
 If you've been issued a token (for example a write/admin key during the closed beta), store it without the browser flow using the `auth` namespace, so you don't need `RELEASES_API_KEY` in your shell every time:

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "releases-cli",
       "dependencies": {
-        "@buildinternet/releases-api-types": "^0.30.0",
+        "@buildinternet/releases-api-types": "^0.31.0",
         "@buildinternet/releases-core": "^0.23.0",
         "@buildinternet/releases-lib": "workspace:*",
         "@buildinternet/releases-skills": "workspace:*",
@@ -27,7 +27,7 @@
     },
     "npm/releases": {
       "name": "@buildinternet/releases",
-      "version": "0.56.0",
+      "version": "0.57.0",
       "bin": {
         "releases": "bin/releases",
       },
@@ -41,31 +41,31 @@
     },
     "npm/releases-darwin-arm64": {
       "name": "@buildinternet/releases-darwin-arm64",
-      "version": "0.56.0",
+      "version": "0.57.0",
     },
     "npm/releases-darwin-x64": {
       "name": "@buildinternet/releases-darwin-x64",
-      "version": "0.56.0",
+      "version": "0.57.0",
     },
     "npm/releases-linux-arm64": {
       "name": "@buildinternet/releases-linux-arm64",
-      "version": "0.56.0",
+      "version": "0.57.0",
     },
     "npm/releases-linux-x64": {
       "name": "@buildinternet/releases-linux-x64",
-      "version": "0.56.0",
+      "version": "0.57.0",
     },
     "npm/releases-windows-x64": {
       "name": "@buildinternet/releases-windows-x64",
-      "version": "0.56.0",
+      "version": "0.57.0",
     },
     "packages/lib": {
       "name": "@buildinternet/releases-lib",
-      "version": "0.56.0",
+      "version": "0.57.0",
     },
     "packages/skills": {
       "name": "@buildinternet/releases-skills",
-      "version": "0.56.0",
+      "version": "0.57.0",
     },
   },
   "packages": {
@@ -73,7 +73,7 @@
 
     "@buildinternet/releases": ["@buildinternet/releases@workspace:npm/releases"],
 
-    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.30.0", "", { "dependencies": { "@buildinternet/releases-core": "^0.23.0", "zod": "^4.4.3" } }, "sha512-aYaixgkuSpV93lz5x5sswqYnqHd7guJVK2Eulc/dS/cEY4HmEFqtTuRt/WwgzNGBMBeF4X5soflu0ravsfo4Hw=="],
+    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.31.0", "", { "dependencies": { "@buildinternet/releases-core": "^0.23.0", "zod": "^4.4.3" } }, "sha512-u2Psp+uXHVq87/rfx/1/zYe7RiWrlSM4VWkXLanXdkzpccDit1SoBg6Ib7AymoRGL7khroc4kY3rAiSKCAlNjA=="],
 
     "@buildinternet/releases-core": ["@buildinternet/releases-core@0.23.0", "", { "dependencies": { "drizzle-orm": "^0.45.2", "js-tiktoken": "^1.0.21", "nanoid": "^5.1.7" } }, "sha512-ieUK+KTlXmxX6nRHIft4alMuNNOJctk8AKCfbJmM0SbWqLHcHjLy9O+sj2R+4052IhwJI86gPFpTLM1QNfLFDA=="],
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "homepage": "https://releases.sh",
   "dependencies": {
-    "@buildinternet/releases-api-types": "^0.30.0",
+    "@buildinternet/releases-api-types": "^0.31.0",
     "@buildinternet/releases-core": "^0.23.0",
     "@buildinternet/releases-lib": "workspace:*",
     "@buildinternet/releases-skills": "workspace:*",

--- a/src/cli/commands/keys.ts
+++ b/src/cli/commands/keys.ts
@@ -1,4 +1,4 @@
-import { Command } from "commander";
+import { Command, InvalidArgumentError } from "commander";
 import chalk from "chalk";
 import type {
   UserApiKey,
@@ -12,6 +12,20 @@ import { renderTable } from "../render/table.js";
 import { promptConfirm, defaultPromptReader } from "../../lib/confirm.js";
 
 const UA = "releases-cli";
+
+/**
+ * Strict parser for `--expires-in-days`. `parseInt("abc")` yields NaN (which
+ * would serialize to `null`) and `parseInt("3d")` silently yields 3 — so parse
+ * with `Number`, require a whole number in 1–365, and reject anything else with
+ * a commander argument error rather than letting a bad value reach the server.
+ */
+export function parseExpiresInDays(raw: string): number {
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 1 || n > 365) {
+    throw new InvalidArgumentError("must be an integer between 1 and 365.");
+  }
+  return n;
+}
 
 export interface KeysRequestDeps {
   getToken: (apiUrl: string) => Promise<string>;
@@ -73,12 +87,17 @@ export function registerKeysCommand(program: Command): void {
     .command("create")
     .description("Create a read-only API key (revealed once)")
     .requiredOption("--name <name>", "Label for the key")
-    .option("--expires-in-days <n>", "Expiry in days (1-365)", (v) => parseInt(v, 10))
+    .option("--expires-in-days <n>", "Expiry in days (1-365)", parseExpiresInDays)
     .option("--json", "Output as JSON")
     .action(async (opts: { name: string; expiresInDays?: number; json?: boolean }) => {
       const apiUrl = getApiUrl();
       const body: Record<string, unknown> = { name: opts.name, scope: "read" };
-      if (opts.expiresInDays !== undefined) body.expiresInDays = opts.expiresInDays;
+      // parseExpiresInDays guarantees a valid integer or commander exits before
+      // this runs; the Number.isInteger guard is belt-and-suspenders so a NaN/null
+      // can never be serialized into the request body.
+      if (opts.expiresInDays !== undefined && Number.isInteger(opts.expiresInDays)) {
+        body.expiresInDays = opts.expiresInDays;
+      }
       const res = await keysRequest(
         apiUrl,
         "/v1/api-keys",

--- a/src/cli/commands/keys.ts
+++ b/src/cli/commands/keys.ts
@@ -1,0 +1,189 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import type {
+  UserApiKey,
+  CreatedUserApiKey,
+  ListUserApiKeysResponse,
+} from "@buildinternet/releases-api-types";
+import { getApiUrl } from "../../lib/mode.js";
+import { getSessionToken, clearSessionToken } from "../../lib/session.js";
+import { writeJson } from "../../lib/output.js";
+import { renderTable } from "../render/table.js";
+import { promptConfirm, defaultPromptReader } from "../../lib/confirm.js";
+
+const UA = "releases-cli";
+
+export interface KeysRequestDeps {
+  getToken: (apiUrl: string) => Promise<string>;
+  onReauth: (apiUrl: string) => Promise<string>;
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Session-authed request to the /v1/api-keys management surface. Sends the
+ * stored session token as a Bearer credential; on a 401 it re-auths ONCE
+ * (forcing the device flow) and retries, then surfaces whatever comes back.
+ */
+export async function keysRequest(
+  apiUrl: string,
+  path: string,
+  init: RequestInit,
+  deps: KeysRequestDeps,
+): Promise<Response> {
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const send = (t: string) =>
+    fetchImpl(`${apiUrl}${path}`, {
+      ...init,
+      headers: { ...init.headers, authorization: `Bearer ${t}`, "user-agent": UA },
+    });
+
+  let res = await send(await deps.getToken(apiUrl));
+  if (res.status === 401) {
+    res = await send(await deps.onReauth(apiUrl));
+  }
+  return res;
+}
+
+/** Production deps: stored token, and a re-auth that clears the stale one first. */
+function liveDeps(): KeysRequestDeps {
+  return {
+    getToken: (apiUrl) => getSessionToken(apiUrl),
+    onReauth: async (apiUrl) => {
+      clearSessionToken();
+      return getSessionToken(apiUrl);
+    },
+  };
+}
+
+async function errMessage(res: Response, fallback: string): Promise<string> {
+  try {
+    const body = (await res.json()) as { message?: string };
+    return body.message || fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+export function registerKeysCommand(program: Command): void {
+  const keys = program
+    .command("keys")
+    .description("Manage your user API keys (read-only relu_ keys)");
+
+  keys
+    .command("create")
+    .description("Create a read-only API key (revealed once)")
+    .requiredOption("--name <name>", "Label for the key")
+    .option("--expires-in-days <n>", "Expiry in days (1-365)", (v) => parseInt(v, 10))
+    .option("--json", "Output as JSON")
+    .action(async (opts: { name: string; expiresInDays?: number; json?: boolean }) => {
+      const apiUrl = getApiUrl();
+      const body: Record<string, unknown> = { name: opts.name, scope: "read" };
+      if (opts.expiresInDays !== undefined) body.expiresInDays = opts.expiresInDays;
+      const res = await keysRequest(
+        apiUrl,
+        "/v1/api-keys",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(body),
+        },
+        liveDeps(),
+      );
+      if (!res.ok) {
+        console.error(
+          chalk.red(await errMessage(res, `Failed to create key (HTTP ${res.status})`)),
+        );
+        process.exit(1);
+      }
+      const created = (await res.json()) as CreatedUserApiKey;
+      if (opts.json) {
+        await writeJson(created);
+        return;
+      }
+      console.log(
+        chalk.green("API key created (read-only). Store it now — it won't be shown again:"),
+      );
+      console.log(`\n  ${chalk.bold(created.key)}\n`);
+      console.log(chalk.dim(`  id: ${created.id}  scope: ${created.scope}`));
+    });
+
+  keys
+    .command("list")
+    .description("List your API keys")
+    .option("--json", "Output as JSON")
+    .action(async (opts: { json?: boolean }) => {
+      const apiUrl = getApiUrl();
+      const res = await keysRequest(apiUrl, "/v1/api-keys", { method: "GET" }, liveDeps());
+      if (!res.ok) {
+        console.error(chalk.red(await errMessage(res, `Failed to list keys (HTTP ${res.status})`)));
+        process.exit(1);
+      }
+      const data = (await res.json()) as ListUserApiKeysResponse;
+      if (opts.json) {
+        await writeJson(data);
+        return;
+      }
+      if (data.apiKeys.length === 0) {
+        console.log(
+          chalk.yellow("No API keys. Create one with `releases keys create --name <name>`."),
+        );
+        return;
+      }
+      console.log(
+        renderTable({
+          head: [
+            { label: "ID", noTruncate: true },
+            { label: "Name" },
+            { label: "Scope", noTruncate: true },
+            { label: "Prefix", noTruncate: true },
+            { label: "Created", noTruncate: true },
+            { label: "Expires", noTruncate: true },
+          ],
+          rows: data.apiKeys.map((k: UserApiKey) => [
+            k.id,
+            k.name ?? chalk.dim("—"),
+            k.scope ?? chalk.dim("—"),
+            k.start ?? chalk.dim("—"),
+            k.createdAt.slice(0, 10),
+            k.expiresAt ? k.expiresAt.slice(0, 10) : chalk.dim("never"),
+          ]),
+        }),
+      );
+    });
+
+  keys
+    .command("revoke <id>")
+    .description("Revoke (delete) an API key by id")
+    .option("--yes", "Skip the confirmation prompt")
+    .action(async (id: string, opts: { yes?: boolean }) => {
+      if (!opts.yes) {
+        const ok = await promptConfirm(
+          `Type the key id to confirm revoke (${id}): `,
+          id,
+          defaultPromptReader,
+        );
+        if (!ok) {
+          console.error(chalk.red("Aborted."));
+          process.exit(1);
+        }
+      }
+      const apiUrl = getApiUrl();
+      const res = await keysRequest(
+        apiUrl,
+        `/v1/api-keys/${encodeURIComponent(id)}`,
+        { method: "DELETE" },
+        liveDeps(),
+      );
+      if (res.status === 404) {
+        console.error(chalk.red("No such key (or not owned by you)."));
+        process.exit(1);
+      }
+      if (!res.ok) {
+        console.error(
+          chalk.red(await errMessage(res, `Failed to revoke key (HTTP ${res.status})`)),
+        );
+        process.exit(1);
+      }
+      console.log(chalk.green(`Revoked ${id}.`));
+    });
+}

--- a/src/cli/commands/login.ts
+++ b/src/cli/commands/login.ts
@@ -29,6 +29,7 @@ export function registerLoginCommand(program: Command): void {
 
         const cred: StoredCredential = {
           token: result.token,
+          sessionToken: result.sessionToken,
           name: result.name,
           scopes: result.scopes,
           apiUrl: result.apiUrl,

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -55,6 +55,7 @@ import { isAuthenticated } from "../lib/mode.js";
 import { preflightScopeWarning } from "../lib/preflight.js";
 import { registerAuthCommand } from "./commands/auth.js";
 import { registerLoginCommand } from "./commands/login.js";
+import { registerKeysCommand } from "./commands/keys.js";
 import { VERSION } from "./version.js";
 import { writeJson } from "../lib/output.js";
 
@@ -235,6 +236,7 @@ registerSubmitCommand(program);
 registerWhoamiCommand(program);
 registerAuthCommand(program);
 registerLoginCommand(program);
+registerKeysCommand(program);
 registerAgentContextCommand(program);
 registerCompletionCommand(program);
 registerSkillsCommand(program);

--- a/src/lib/credentials.ts
+++ b/src/lib/credentials.ts
@@ -12,6 +12,13 @@ import { getDataDir } from "@releases/lib/config";
 
 export interface StoredCredential {
   token: string;
+  /**
+   * Device-flow session token, used ONLY for the session-gated /v1/api-keys
+   * management endpoints (the `releases keys` verbs). Broader than `token` — it
+   * can manage the account — so it shares the same 0600 file and is cleared by
+   * `auth logout` / `clearCredential()`.
+   */
+  sessionToken?: string;
   name?: string;
   scopes?: string[];
   /** API URL the token was verified against (prod/staging tokens don't cross DBs). */
@@ -35,6 +42,12 @@ export function readCredential(): StoredCredential | null {
     if (typeof parsed.apiUrl !== "string" || !parsed.apiUrl) return null;
     if (typeof parsed.savedAt !== "string" || !parsed.savedAt) return null;
     if (parsed.name !== undefined && typeof parsed.name !== "string") return null;
+    if (
+      parsed.sessionToken !== undefined &&
+      (typeof parsed.sessionToken !== "string" || !parsed.sessionToken)
+    ) {
+      return null;
+    }
     // `scopes` is optional, but if present it must be a string array — a malformed
     // value (e.g. a hand-edited string) would crash callers that iterate or
     // `.join` it (auth status, the admin scope pre-flight).

--- a/src/lib/device-auth.ts
+++ b/src/lib/device-auth.ts
@@ -66,8 +66,10 @@ export async function pollForToken(
     if (Date.now() > deadline) {
       throw new Error("Device code expired before it was approved. Run `releases login` again.");
     }
+    // oxlint-disable-next-line no-await-in-loop -- sequential device-flow poll (RFC 8628): wait the server interval before each request
     await sleep(interval * 1000);
 
+    // oxlint-disable-next-line no-await-in-loop -- sequential device-flow poll (RFC 8628): one outstanding poll request at a time
     const res = await fetchImpl(`${apiUrl}/api/auth/device/token`, {
       method: "POST",
       headers: { "content-type": "application/json", "user-agent": CLIENT_ID },
@@ -77,6 +79,7 @@ export async function pollForToken(
         client_id: CLIENT_ID,
       }),
     });
+    // oxlint-disable-next-line no-await-in-loop -- sequential device-flow poll (RFC 8628): parse this poll's response before the next iteration
     const data = (await res.json().catch(() => ({}))) as {
       access_token?: string;
       error?: string;

--- a/src/lib/device-auth.ts
+++ b/src/lib/device-auth.ts
@@ -176,21 +176,25 @@ export interface DeviceLoginArgs {
 
 export interface DeviceLoginResult {
   token: string;
+  sessionToken: string;
   name?: string;
   scopes?: string[];
   apiUrl: string;
 }
 
+export interface DeviceAuthResult {
+  sessionToken: string;
+  user: SessionUser | null;
+}
+
 /**
- * Orchestrate the full device-login flow and return a credential payload for the
- * caller to persist. Pure of I/O specifics via injectable deps (fetch, sleep,
- * browser, print) so it's unit-testable. Does NOT write to disk — the command
- * layer owns persistence so storage stays in one place.
+ * Run the RFC 8628 device flow and return the session token only — mints NO key.
+ * Used by `releases keys` to (re)establish a session for the management endpoints
+ * without polluting the user's key list.
  */
-export async function runDeviceLogin(args: DeviceLoginArgs): Promise<DeviceLoginResult> {
+export async function runDeviceAuth(args: DeviceLoginArgs): Promise<DeviceAuthResult> {
   const fetchImpl = args.deps?.fetchImpl ?? fetch;
   const print = args.deps?.print ?? ((l: string) => console.log(l));
-  const keyName = args.deps?.keyName ?? "releases-cli";
 
   const code = await requestDeviceCode(args.apiUrl, fetchImpl);
 
@@ -207,20 +211,35 @@ export async function runDeviceLogin(args: DeviceLoginArgs): Promise<DeviceLogin
   }
 
   print("Waiting for authorization...");
-  const accessToken = await pollForToken(args.apiUrl, code.device_code, {
+  const sessionToken = await pollForToken(args.apiUrl, code.device_code, {
     intervalSeconds: code.interval ?? 5,
     expiresInSeconds: code.expires_in,
     fetchImpl,
     sleep: args.deps?.sleep,
   });
 
-  const sessionUser = await getSessionUser(args.apiUrl, accessToken, fetchImpl);
-  if (sessionUser) print(`Authorized as ${sessionUser.name ?? sessionUser.email}.`);
+  const user = await getSessionUser(args.apiUrl, sessionToken, fetchImpl);
+  if (user) print(`Authorized as ${user.name ?? user.email}.`);
 
-  const created = await createUserApiKey(args.apiUrl, accessToken, keyName, fetchImpl);
+  return { sessionToken, user };
+}
+
+/**
+ * Orchestrate the full device-login flow and return a credential payload for the
+ * caller to persist. Pure of I/O specifics via injectable deps (fetch, sleep,
+ * browser, print) so it's unit-testable. Does NOT write to disk — the command
+ * layer owns persistence so storage stays in one place.
+ */
+export async function runDeviceLogin(args: DeviceLoginArgs): Promise<DeviceLoginResult> {
+  const fetchImpl = args.deps?.fetchImpl ?? fetch;
+  const keyName = args.deps?.keyName ?? "releases-cli";
+
+  const { sessionToken } = await runDeviceAuth(args);
+  const created = await createUserApiKey(args.apiUrl, sessionToken, keyName, fetchImpl);
 
   return {
     token: created.key,
+    sessionToken,
     name: created.name ?? keyName,
     scopes: [created.scope ?? "read"],
     apiUrl: args.apiUrl,

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -42,16 +42,24 @@ function defaultDeviceLogin(apiUrl: string) {
  */
 export async function getSessionToken(apiUrl: string, deps: SessionDeps = {}): Promise<string> {
   const existing = readCredential();
-  if (existing?.sessionToken) return existing.sessionToken;
+  // A stored token is bound to the API URL it was verified against (prod/staging
+  // tokens don't cross DBs), so only reuse or refresh a credential established
+  // against THIS environment. A different (or missing) apiUrl is a non-match — we
+  // fall through to a full login that re-binds the credential to the active URL,
+  // never reusing a foreign session or writing a session onto a foreign credential.
+  const sameEnv = existing?.apiUrl === apiUrl;
 
-  if (existing?.token) {
-    // A durable relu_ key already exists — refresh the session only, mint nothing.
+  if (sameEnv && existing?.sessionToken) return existing.sessionToken;
+
+  if (sameEnv && existing?.token) {
+    // A durable relu_ key for this env already exists — refresh the session only, mint nothing.
     const sessionToken = await (deps.deviceAuth ?? defaultDeviceAuth)(apiUrl);
     writeCredential({ ...existing, sessionToken, savedAt: new Date().toISOString() });
     return sessionToken;
   }
 
-  // No stored credential — full login so a valid credential (key + session) lands.
+  // No usable same-env credential — full login so a valid credential (key + session),
+  // bound to this apiUrl, lands.
   const res = await (deps.deviceLogin ?? defaultDeviceLogin)(apiUrl);
   writeCredential({
     token: res.token,

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,0 +1,73 @@
+import { hostname } from "node:os";
+import { readCredential, writeCredential } from "./credentials.js";
+import { runDeviceAuth, runDeviceLogin } from "./device-auth.js";
+import { openBrowser } from "./open-browser.js";
+
+/**
+ * Injectable device-flow entry points (production uses the real RFC 8628 flow;
+ * tests inject deterministic stand-ins).
+ * - `deviceAuth` establishes a session token WITHOUT minting a key — used when a
+ *   durable relu_ key already exists and only the session needs refreshing.
+ * - `deviceLogin` mints a read key AND establishes a session — used the first
+ *   time, when there is no stored credential to attach a session to (a credential
+ *   must always carry a non-empty `token`, so we cannot persist a session alone).
+ */
+export interface SessionDeps {
+  deviceAuth?: (apiUrl: string) => Promise<string>;
+  deviceLogin?: (
+    apiUrl: string,
+  ) => Promise<{ token: string; sessionToken: string; name?: string; scopes?: string[] }>;
+}
+
+function defaultDeviceAuth(apiUrl: string): Promise<string> {
+  return runDeviceAuth({
+    apiUrl,
+    openInBrowser: true,
+    deps: { openBrowser, print: (l) => console.log(l) },
+  }).then((r) => r.sessionToken);
+}
+
+function defaultDeviceLogin(apiUrl: string) {
+  return runDeviceLogin({
+    apiUrl,
+    openInBrowser: true,
+    deps: { openBrowser, keyName: `releases-cli (${hostname()})`, print: (l) => console.log(l) },
+  });
+}
+
+/**
+ * Return a session token for the /v1/api-keys management endpoints. Uses the
+ * stored token if present; otherwise (re)establishes one via the device flow and
+ * persists it onto a valid credential (one that always has a non-empty relu_ key).
+ */
+export async function getSessionToken(apiUrl: string, deps: SessionDeps = {}): Promise<string> {
+  const existing = readCredential();
+  if (existing?.sessionToken) return existing.sessionToken;
+
+  if (existing?.token) {
+    // A durable relu_ key already exists — refresh the session only, mint nothing.
+    const sessionToken = await (deps.deviceAuth ?? defaultDeviceAuth)(apiUrl);
+    writeCredential({ ...existing, sessionToken, savedAt: new Date().toISOString() });
+    return sessionToken;
+  }
+
+  // No stored credential — full login so a valid credential (key + session) lands.
+  const res = await (deps.deviceLogin ?? defaultDeviceLogin)(apiUrl);
+  writeCredential({
+    token: res.token,
+    sessionToken: res.sessionToken,
+    name: res.name,
+    scopes: res.scopes,
+    apiUrl,
+    savedAt: new Date().toISOString(),
+  });
+  return res.sessionToken;
+}
+
+/** Clear only the stored session token (e.g. after a 401), keeping the relu_ key. */
+export function clearSessionToken(): void {
+  const existing = readCredential();
+  if (!existing) return;
+  const { sessionToken: _drop, ...rest } = existing;
+  writeCredential({ ...rest, savedAt: new Date().toISOString() });
+}

--- a/tests/unit/credentials.test.ts
+++ b/tests/unit/credentials.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterAll } from "bun:test";
-import { mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -67,5 +67,40 @@ describe("credentials", () => {
     expect(clearCredential()).toBe(true);
     expect(readCredential()).toBeNull();
     expect(clearCredential()).toBe(false);
+  });
+
+  it("round-trips an optional sessionToken", () => {
+    writeCredential({
+      token: "relu_abc",
+      sessionToken: "sess_xyz",
+      apiUrl: "https://api.releases.sh",
+      savedAt: "2026-06-06T00:00:00.000Z",
+    });
+    expect(readCredential()?.sessionToken).toBe("sess_xyz");
+    clearCredential();
+  });
+
+  it("accepts a credential with no sessionToken (back-compat)", () => {
+    writeCredential({
+      token: "relu_abc",
+      apiUrl: "https://api.releases.sh",
+      savedAt: "2026-06-06T00:00:00.000Z",
+    });
+    expect(readCredential()?.sessionToken).toBeUndefined();
+    clearCredential();
+  });
+
+  it("rejects a credential whose sessionToken is a non-string", () => {
+    writeCredential({
+      token: "relu_abc",
+      apiUrl: "https://api.releases.sh",
+      savedAt: "2026-06-06T00:00:00.000Z",
+    });
+    const path = join(dir, "credentials");
+    const obj = JSON.parse(readFileSync(path, "utf8"));
+    obj.sessionToken = 123;
+    writeFileSync(path, JSON.stringify(obj));
+    expect(readCredential()).toBeNull();
+    clearCredential();
   });
 });

--- a/tests/unit/device-auth.test.ts
+++ b/tests/unit/device-auth.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "bun:test";
-import { requestDeviceCode, pollForToken, runDeviceLogin } from "../../src/lib/device-auth.js";
+import {
+  requestDeviceCode,
+  pollForToken,
+  runDeviceLogin,
+  runDeviceAuth,
+} from "../../src/lib/device-auth.js";
 
 const BASE = "https://test.example.com";
 
@@ -147,5 +152,88 @@ describe("runDeviceLogin", () => {
     expect(opened).toBe(`${apiUrl}/device?user_code=ABCD1234`);
     // The user code is shown to the human at least once.
     expect(printed.join("\n")).toContain("ABCD1234");
+  });
+});
+
+describe("runDeviceAuth", () => {
+  it("returns the session token and mints no key", async () => {
+    const calls: string[] = [];
+    const fakeFetch = (async (url: string) => {
+      const u = String(url);
+      calls.push(u);
+      if (u.endsWith("/device/code"))
+        return new Response(
+          JSON.stringify({
+            device_code: "d",
+            user_code: "U",
+            verification_uri: "https://x/device",
+            expires_in: 900,
+            interval: 0,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      if (u.endsWith("/device/token"))
+        return new Response(JSON.stringify({ access_token: "sess_tok" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      if (u.endsWith("/get-session"))
+        return new Response(JSON.stringify({ user: { email: "a@b.co", name: "A" } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      throw new Error(`unexpected ${u}`);
+    }) as unknown as typeof fetch;
+
+    const res = await runDeviceAuth({
+      apiUrl: "https://test.example.com",
+      openInBrowser: false,
+      deps: { fetchImpl: fakeFetch, sleep: async () => {}, print: () => {} },
+    });
+    expect(res.sessionToken).toBe("sess_tok");
+    expect(calls.some((u) => u.endsWith("/v1/api-keys"))).toBe(false);
+  });
+});
+
+describe("runDeviceLogin returns sessionToken", () => {
+  it("includes the session token alongside the minted key", async () => {
+    const fakeFetch = (async (url: string) => {
+      const u = String(url);
+      if (u.endsWith("/device/code"))
+        return new Response(
+          JSON.stringify({
+            device_code: "d",
+            user_code: "U",
+            verification_uri: "https://x/device",
+            expires_in: 900,
+            interval: 0,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      if (u.endsWith("/device/token"))
+        return new Response(JSON.stringify({ access_token: "sess_tok" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      if (u.endsWith("/get-session"))
+        return new Response(JSON.stringify({ user: { email: "a@b.co" } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      if (u.endsWith("/v1/api-keys"))
+        return new Response(JSON.stringify({ key: "relu_new", name: "n", scope: "read" }), {
+          status: 201,
+          headers: { "content-type": "application/json" },
+        });
+      throw new Error(`unexpected ${u}`);
+    }) as unknown as typeof fetch;
+
+    const res = await runDeviceLogin({
+      apiUrl: "https://test.example.com",
+      openInBrowser: false,
+      deps: { fetchImpl: fakeFetch, sleep: async () => {}, print: () => {} },
+    });
+    expect(res.token).toBe("relu_new");
+    expect(res.sessionToken).toBe("sess_tok");
   });
 });

--- a/tests/unit/keys.test.ts
+++ b/tests/unit/keys.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "bun:test";
+import { keysRequest } from "../../src/cli/commands/keys.js";
+
+const BASE = "https://test.example.com";
+
+describe("keysRequest", () => {
+  it("sends the session token as a Bearer credential", async () => {
+    let seenAuth = "";
+    const fetchImpl = (async (_url: string, init?: RequestInit) => {
+      seenAuth = String((init?.headers as Record<string, string>)?.authorization ?? "");
+      return new Response(JSON.stringify({ apiKeys: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    await keysRequest(
+      BASE,
+      "/v1/api-keys",
+      { method: "GET" },
+      {
+        getToken: async () => "sess_tok",
+        onReauth: async () => "sess_tok2",
+        fetchImpl,
+      },
+    );
+    expect(seenAuth).toBe("Bearer sess_tok");
+  });
+
+  it("re-auths and retries once on 401", async () => {
+    let call = 0;
+    const fetchImpl = (async () => {
+      call += 1;
+      if (call === 1)
+        return new Response(JSON.stringify({ error: "unauthorized" }), {
+          status: 401,
+          headers: { "content-type": "application/json" },
+        });
+      return new Response(JSON.stringify({ apiKeys: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    let reauthed = false;
+    const res = await keysRequest(
+      BASE,
+      "/v1/api-keys",
+      { method: "GET" },
+      {
+        getToken: async () => "sess_old",
+        onReauth: async () => {
+          reauthed = true;
+          return "sess_new";
+        },
+        fetchImpl,
+      },
+    );
+    expect(reauthed).toBe(true);
+    expect(call).toBe(2);
+    expect(res.status).toBe(200);
+  });
+
+  it("does not retry more than once (second 401 surfaces)", async () => {
+    let call = 0;
+    const fetchImpl = (async () => {
+      call += 1;
+      return new Response("{}", { status: 401, headers: { "content-type": "application/json" } });
+    }) as unknown as typeof fetch;
+    const res = await keysRequest(
+      BASE,
+      "/v1/api-keys",
+      { method: "GET" },
+      {
+        getToken: async () => "a",
+        onReauth: async () => "b",
+        fetchImpl,
+      },
+    );
+    expect(call).toBe(2);
+    expect(res.status).toBe(401);
+  });
+});

--- a/tests/unit/keys.test.ts
+++ b/tests/unit/keys.test.ts
@@ -1,7 +1,29 @@
 import { describe, it, expect } from "bun:test";
-import { keysRequest } from "../../src/cli/commands/keys.js";
+import { InvalidArgumentError } from "commander";
+import { keysRequest, parseExpiresInDays } from "../../src/cli/commands/keys.js";
 
 const BASE = "https://test.example.com";
+
+describe("parseExpiresInDays", () => {
+  it("parses a valid integer in range", () => {
+    expect(parseExpiresInDays("30")).toBe(30);
+    expect(parseExpiresInDays("1")).toBe(1);
+    expect(parseExpiresInDays("365")).toBe(365);
+  });
+
+  it("rejects non-numeric input (never returns NaN)", () => {
+    expect(() => parseExpiresInDays("abc")).toThrow(InvalidArgumentError);
+    expect(() => parseExpiresInDays("30d")).toThrow(InvalidArgumentError);
+    expect(() => parseExpiresInDays("")).toThrow(InvalidArgumentError);
+  });
+
+  it("rejects non-integers and out-of-range values", () => {
+    expect(() => parseExpiresInDays("3.5")).toThrow(InvalidArgumentError);
+    expect(() => parseExpiresInDays("0")).toThrow(InvalidArgumentError);
+    expect(() => parseExpiresInDays("366")).toThrow(InvalidArgumentError);
+    expect(() => parseExpiresInDays("-5")).toThrow(InvalidArgumentError);
+  });
+});
 
 describe("keysRequest", () => {
   it("sends the session token as a Bearer credential", async () => {

--- a/tests/unit/session.test.ts
+++ b/tests/unit/session.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, afterEach, afterAll } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const dir = mkdtempSync(join(tmpdir(), "rel-sess-"));
+process.env.RELEASED_DATA_DIR = dir;
+
+const { readCredential, writeCredential, clearCredential } =
+  await import("../../src/lib/credentials.js");
+const { getSessionToken, clearSessionToken } = await import("../../src/lib/session.js");
+
+afterEach(() => clearCredential());
+afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+describe("getSessionToken", () => {
+  it("returns the stored session token without re-auth", async () => {
+    writeCredential({
+      token: "relu_x",
+      sessionToken: "sess_stored",
+      apiUrl: "https://test.example.com",
+      savedAt: "2026-06-06T00:00:00.000Z",
+    });
+    let called = false;
+    const t = await getSessionToken("https://test.example.com", {
+      deviceAuth: async () => {
+        called = true;
+        return "sess_new";
+      },
+      deviceLogin: async () => {
+        called = true;
+        return { token: "relu_new", sessionToken: "sess_new", scopes: ["read"] };
+      },
+    });
+    expect(t).toBe("sess_stored");
+    expect(called).toBe(false);
+  });
+
+  it("refreshes the session WITHOUT minting when a relu_ token already exists", async () => {
+    writeCredential({
+      token: "relu_existing",
+      apiUrl: "https://test.example.com",
+      savedAt: "2026-06-06T00:00:00.000Z",
+    });
+    let minted = false;
+    const t = await getSessionToken("https://test.example.com", {
+      deviceAuth: async () => "sess_refreshed",
+      deviceLogin: async () => {
+        minted = true;
+        return { token: "relu_new", sessionToken: "x", scopes: ["read"] };
+      },
+    });
+    expect(t).toBe("sess_refreshed");
+    expect(minted).toBe(false);
+    const cred = readCredential();
+    expect(cred?.sessionToken).toBe("sess_refreshed");
+    expect(cred?.token).toBe("relu_existing"); // durable key untouched
+  });
+
+  it("does a full login (mints key + session) when no credential exists", async () => {
+    clearCredential();
+    const t = await getSessionToken("https://test.example.com", {
+      deviceAuth: async () => {
+        throw new Error("should not be called");
+      },
+      deviceLogin: async () => ({
+        token: "relu_minted",
+        sessionToken: "sess_full",
+        name: "n",
+        scopes: ["read"],
+      }),
+    });
+    expect(t).toBe("sess_full");
+    const cred = readCredential();
+    expect(cred?.token).toBe("relu_minted"); // valid non-empty token persisted
+    expect(cred?.sessionToken).toBe("sess_full");
+  });
+});
+
+describe("clearSessionToken", () => {
+  it("drops only the session token, keeping the relu_ key", () => {
+    writeCredential({
+      token: "relu_keep",
+      sessionToken: "sess_drop",
+      apiUrl: "https://test.example.com",
+      savedAt: "2026-06-06T00:00:00.000Z",
+    });
+    clearSessionToken();
+    const cred = readCredential();
+    expect(cred?.token).toBe("relu_keep");
+    expect(cred?.sessionToken).toBeUndefined();
+  });
+});

--- a/tests/unit/session.test.ts
+++ b/tests/unit/session.test.ts
@@ -75,6 +75,35 @@ describe("getSessionToken", () => {
     expect(cred?.token).toBe("relu_minted"); // valid non-empty token persisted
     expect(cred?.sessionToken).toBe("sess_full");
   });
+
+  it("does NOT reuse a session bound to a different environment", async () => {
+    // Credential established against prod; the active URL is staging.
+    writeCredential({
+      token: "relu_prod",
+      sessionToken: "sess_prod",
+      apiUrl: "https://api.releases.sh",
+      savedAt: "2026-06-06T00:00:00.000Z",
+    });
+    let refreshed = false;
+    const t = await getSessionToken("https://api-staging.releases.sh", {
+      deviceAuth: async () => {
+        refreshed = true;
+        return "sess_should_not_refresh_foreign";
+      },
+      deviceLogin: async () => ({
+        token: "relu_staging",
+        sessionToken: "sess_staging",
+        scopes: ["read"],
+      }),
+    });
+    // Foreign session is not returned; a full login rebinds to the active env.
+    expect(t).toBe("sess_staging");
+    expect(refreshed).toBe(false); // never refreshes onto a foreign-env credential
+    const cred = readCredential();
+    expect(cred?.apiUrl).toBe("https://api-staging.releases.sh");
+    expect(cred?.token).toBe("relu_staging");
+    expect(cred?.sessionToken).toBe("sess_staging");
+  });
 });
 
 describe("clearSessionToken", () => {


### PR DESCRIPTION
Phase 4 part 2 of buildinternet/releases#1445. Adds `releases keys create/list/revoke` for self-serve user API keys.

## What

- **Credential model:** persists the device-flow **session token** (`StoredCredential.sessionToken`), distinct from the durable read-only `relu_` key in `token`. `readCredential` validates it.
- **Device-auth:** extracts a session-only `runDeviceAuth` (mints **no** key) from `runDeviceLogin`; `login` now stores the session alongside the minted key.
- **Session helper:** `getSessionToken` reuses the stored session, refreshes it via `runDeviceAuth` (no mint) when a `relu_` key already exists, and only does a full login (mint + session) when there's no credential at all — so a valid, non-empty-`token` credential is always persisted. `keysRequest` re-auths + retries **once** on 401.
- **Verbs:** `keys create` is **read-only** (sends `scope: "read"`, no `--scope` flag — server caps user keys at read, buildinternet/releases#1448); `keys list` (table + `--json`); `keys revoke <id>` (confirm / `--yes`).
- Types consumed from the published `@buildinternet/releases-api-types@^0.31.0` (buildinternet/releases#1464, merged + published).

## Validation

- `npx tsc --noEmit`: clean (types resolve against the published 0.31.0).
- `bun test`: 861/861 pass.

## Remaining (post-merge)

Manual prod smoke once published: `login → keys list → keys create --name probe → keys list → keys revoke <id> → keys list`. Confirm a bare `relu_` key cannot reach the management endpoints (only the session can).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `releases keys` CLI to create, list, and revoke read-only user API keys (interactive and JSON modes).
  * Session-token based auth for key operations with automatic re-auth on expiry; login persists session tokens for reuse.
* **Documentation**
  * README updated with “Managing keys” usage and behavior notes.
* **Tests**
  * Added/expanded unit tests covering keys, session, device auth, and credentials.
* **Chores**
  * Bumped API types dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->