### PR TITLE
feat(admin): user role provisioning verbs

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -426,6 +426,48 @@ export async function unsuppressRelease(releaseId: string): Promise<boolean> {
   return result?.unsuppressed ?? false;
 }
 
+// ── User roles (OAuth scope entitlement) ──
+
+/** A user's role row as returned by `/v1/admin/users/role`. `role` NULL → read-only. */
+export interface UserRole {
+  userId: string;
+  email: string;
+  role: string | null;
+}
+
+/** The PATCH response, which also carries the role the user held before the change. */
+export interface SetUserRoleResult extends UserRole {
+  previousRole: string | null;
+}
+
+/** Exactly one of email/userId must be set; the route enforces this too. */
+export type UserIdentifier = { email?: string; userId?: string };
+
+function userRoleQuery(id: UserIdentifier): string {
+  return id.userId
+    ? `userId=${encodeURIComponent(id.userId)}`
+    : `email=${encodeURIComponent(id.email ?? "")}`;
+}
+
+/** Read a user's current role. Returns null when no such user exists (404). */
+export async function getUserRole(id: UserIdentifier): Promise<UserRole | null> {
+  return apiFetch<UserRole | null>(`/v1/admin/users/role?${userRoleQuery(id)}`);
+}
+
+/** Set a user's role (user | curator | admin). Throws on 400/404. */
+export async function setUserRole(id: UserIdentifier, role: string): Promise<SetUserRoleResult> {
+  return apiFetch<SetUserRoleResult>(`/v1/admin/users/role`, {
+    method: "PATCH",
+    body: JSON.stringify({ ...id, role }),
+  });
+}
+
+/** List users holding a curator or admin role. */
+export async function listUserRoles(): Promise<UserRole[]> {
+  const res = await apiFetch<{ users: UserRole[] }>(`/v1/admin/users/roles`);
+  return res?.users ?? [];
+}
+
 // ── Content hash ──
 
 export async function checkContentHash(source: Source, contentHash: string): Promise<boolean> {

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -464,8 +464,16 @@ export async function setUserRole(id: UserIdentifier, role: string): Promise<Set
 
 /** List users holding a curator or admin role. */
 export async function listUserRoles(): Promise<UserRole[]> {
-  const res = await apiFetch<{ users: UserRole[] }>(`/v1/admin/users/roles`);
-  return res?.users ?? [];
+  const res = await apiFetch<{ users: UserRole[] } | null>(`/v1/admin/users/roles`);
+  // An empty list is a 200 `{ users: [] }`; apiFetch only yields null on a 404,
+  // which here means the admin route is missing/undeployed. Surface that instead
+  // of masking it as "no curator/admin users".
+  if (!res) {
+    throw new Error(
+      "listUserRoles: 404/empty from /v1/admin/users/roles — is the admin users route deployed?",
+    );
+  }
+  return res.users ?? [];
 }
 
 // ── Content hash ──

--- a/src/cli/commands/admin/user.ts
+++ b/src/cli/commands/admin/user.ts
@@ -1,0 +1,111 @@
+/**
+ * `releases admin user …` — manage the Better Auth `user.role` column that
+ * governs OAuth scope entitlement (read / curator=write / admin). Thin wrapper
+ * over the root-key-gated `/v1/admin/users/role` routes; the admin gate is
+ * applied by `gateAdminSubtree` in program.ts. See buildinternet/releases#1484.
+ */
+import { Command } from "commander";
+import chalk from "chalk";
+import { logger } from "@releases/lib/logger";
+import { writeJson } from "../../../lib/output.js";
+import {
+  getUserRole,
+  setUserRole,
+  listUserRoles,
+  type UserIdentifier,
+} from "../../../api/client.js";
+import { renderTable } from "../../render/table.js";
+
+/** Settable roles — mirrors the API's ROLE_LADDER (the route is authoritative). */
+const VALID_ROLES = ["user", "curator", "admin"];
+
+interface IdentifierOpts {
+  email?: string;
+  userId?: string;
+}
+
+/** Resolve exactly one of --email / --user-id, or exit 1 with a clear message. */
+function resolveIdentifier(opts: IdentifierOpts): UserIdentifier {
+  const hasEmail = typeof opts.email === "string" && opts.email.length > 0;
+  const hasUserId = typeof opts.userId === "string" && opts.userId.length > 0;
+  if (hasEmail === hasUserId) {
+    logger.error("Provide exactly one of --email or --user-id.");
+    process.exit(1);
+  }
+  return hasEmail ? { email: opts.email } : { userId: opts.userId };
+}
+
+export function registerUserCommand(program: Command) {
+  const user = program.command("user").description("Manage user roles (OAuth scope entitlement)");
+
+  user
+    .command("set-role")
+    .description("Set a user's role (user | curator | admin); revoke = set to user")
+    .option("--email <email>", "Target user email")
+    .option("--user-id <id>", "Target user id")
+    .requiredOption("--role <role>", "Role to assign: user | curator | admin")
+    .option("--json", "Output JSON")
+    .action(async (opts: IdentifierOpts & { role: string; json?: boolean }) => {
+      if (!VALID_ROLES.includes(opts.role)) {
+        logger.error(`Invalid role "${opts.role}". Allowed: ${VALID_ROLES.join(", ")}.`);
+        process.exit(1);
+      }
+      const id = resolveIdentifier(opts);
+      const result = await setUserRole(id, opts.role);
+      if (opts.json) {
+        await writeJson(result);
+        return;
+      }
+      logger.info(
+        `${result.email}: ${result.previousRole ?? "(none)"} ${chalk.dim("→")} ${chalk.green(
+          result.role,
+        )}`,
+      );
+    });
+
+  user
+    .command("get-role")
+    .description("Show a user's current role")
+    .option("--email <email>", "Target user email")
+    .option("--user-id <id>", "Target user id")
+    .option("--json", "Output JSON")
+    .action(async (opts: IdentifierOpts & { json?: boolean }) => {
+      const id = resolveIdentifier(opts);
+      const result = await getUserRole(id);
+      if (!result) {
+        logger.error("User not found.");
+        process.exit(1);
+      }
+      if (opts.json) {
+        await writeJson(result);
+        return;
+      }
+      logger.info(`${result.email}: ${result.role ?? chalk.dim("(none → read-only)")}`);
+    });
+
+  user
+    .command("list-roles")
+    .description("List users holding a curator or admin role")
+    .option("--json", "Output JSON")
+    .action(async (opts: { json?: boolean }) => {
+      const users = await listUserRoles();
+      if (opts.json) {
+        await writeJson({ users });
+        return;
+      }
+      if (users.length === 0) {
+        logger.info("No curator/admin users.");
+        return;
+      }
+      console.log(
+        renderTable({
+          head: [
+            { label: "Email", noTruncate: true },
+            { label: "Role" },
+            { label: "User ID", noTruncate: true },
+          ],
+          rows: users.map((u) => [u.email, u.role ?? chalk.dim("—"), u.userId]),
+        }),
+      );
+    });
+}

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -40,6 +40,7 @@ import { registerEvaluateCommand } from "./commands/admin/evaluate.js";
 import { registerPlaybookCommand } from "./commands/admin/playbook.js";
 import { registerOverviewCommands } from "./commands/admin/overview.js";
 import { registerWorkCommands } from "./commands/admin/work.js";
+import { registerUserCommand } from "./commands/admin/user.js";
 import { registerTelemetryCommand } from "./commands/telemetry.js";
 import { registerFeedbackCommand, registerFeedbackAdminCommand } from "./commands/feedback.js";
 import { registerSubmitCommand, registerRecommendationAdminCommand } from "./commands/recommend.js";
@@ -282,6 +283,7 @@ registerOrgCommand(admin);
 registerProductCommand(admin);
 registerCollectionCommand(admin);
 registerReleaseCommand(admin);
+registerUserCommand(admin);
 
 const discoveryAdmin = admin
   .command("discovery")

--- a/tests/unit/user-roles.test.ts
+++ b/tests/unit/user-roles.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
+
+// Drive the real client via env (a top-level mock.module leaks across files —
+// see api-client.test.ts). Match request paths by suffix, not full URL, so the
+// process-wide getApiUrl() memoization can't poison assertions.
+const prevEnv: { url?: string; key?: string } = {};
+beforeAll(() => {
+  prevEnv.url = process.env.RELEASES_API_URL;
+  prevEnv.key = process.env.RELEASES_API_KEY;
+  process.env.RELEASES_API_URL = "https://test.example.com";
+  process.env.RELEASES_API_KEY = "test-key";
+});
+afterAll(() => {
+  if (prevEnv.url === undefined) delete process.env.RELEASES_API_URL;
+  else process.env.RELEASES_API_URL = prevEnv.url;
+  if (prevEnv.key === undefined) delete process.env.RELEASES_API_KEY;
+  else process.env.RELEASES_API_KEY = prevEnv.key;
+});
+
+const client = await import("../../src/api/client.js");
+
+describe("user-role client wire contract", () => {
+  let originalFetch: typeof globalThis.fetch;
+  let capturedUrl = "";
+  let capturedMethod = "";
+  let capturedBody: Record<string, unknown> | null = null;
+  let responder: () => Response;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    capturedUrl = "";
+    capturedMethod = "";
+    capturedBody = null;
+    responder = () =>
+      new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    globalThis.fetch = (async (url: string, init?: RequestInit) => {
+      capturedUrl = url;
+      capturedMethod = init?.method ?? "GET";
+      capturedBody = init?.body ? JSON.parse(String(init.body)) : null;
+      return responder();
+    }) as unknown as typeof globalThis.fetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("setUserRole PATCHes the role route with identifier + role", async () => {
+    responder = () =>
+      new Response(
+        JSON.stringify({ userId: "u_1", email: "a@b.com", previousRole: null, role: "curator" }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    const res = await client.setUserRole({ email: "a@b.com" }, "curator");
+    expect(capturedMethod).toBe("PATCH");
+    expect(capturedUrl.endsWith("/v1/admin/users/role")).toBe(true);
+    expect(capturedBody).toEqual({ email: "a@b.com", role: "curator" });
+    expect(res).toMatchObject({ previousRole: null, role: "curator" });
+  });
+
+  it("getUserRole GETs by email and returns null on 404", async () => {
+    responder = () =>
+      new Response(JSON.stringify({ userId: "u_2", email: "c@d.com", role: "admin" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    const found = await client.getUserRole({ email: "c@d.com" });
+    expect(capturedMethod).toBe("GET");
+    expect(capturedUrl).toContain("/v1/admin/users/role?email=c%40d.com");
+    expect(found).toMatchObject({ role: "admin" });
+
+    responder = () =>
+      new Response(JSON.stringify({ error: "user_not_found" }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
+    const missing = await client.getUserRole({ userId: "nope" });
+    expect(capturedUrl).toContain("/v1/admin/users/role?userId=nope");
+    expect(missing).toBeNull();
+  });
+
+  it("listUserRoles unwraps the users array", async () => {
+    responder = () =>
+      new Response(
+        JSON.stringify({ users: [{ userId: "u_1", email: "a@b.com", role: "admin" }] }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    const users = await client.listUserRoles();
+    expect(capturedUrl.endsWith("/v1/admin/users/roles")).toBe(true);
+    expect(users).toHaveLength(1);
+    expect(users[0]).toMatchObject({ email: "a@b.com", role: "admin" });
+  });
+});

--- a/tests/unit/user-roles.test.ts
+++ b/tests/unit/user-roles.test.ts
@@ -92,4 +92,13 @@ describe("user-role client wire contract", () => {
     expect(users).toHaveLength(1);
     expect(users[0]).toMatchObject({ email: "a@b.com", role: "admin" });
   });
+
+  it("listUserRoles throws on a 404 (route missing) instead of returning []", async () => {
+    responder = () =>
+      new Response(JSON.stringify({ error: "not_found" }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
+    await expect(client.listUserRoles()).rejects.toThrow(/admin users route|404/i);
+  });
 });


### PR DESCRIPTION
Adds `releases admin user set-role | get-role | list-roles`, wrapping the root-key-gated role-provisioning routes added in buildinternet/releases#1484 (PR buildinternet/releases#1485). These manage the Better Auth `user.role` column — the OAuth scope entitlement source of truth (`user`→read, `curator`→read+write, `admin`→read+write+admin) — without a redeploy.

## Verbs

- `admin user set-role --email <e> | --user-id <id> --role <user|curator|admin>` — sets a role; prints `email: <prev> → <new>`. Revoke = set to `user`. Client-side role validation + exactly-one-identifier guard before the call.
- `admin user get-role --email|--user-id` — prints the current role (or `(none → read-only)`).
- `admin user list-roles` — table of curator/admin users.

All three accept `--json`. Registered under the `admin` subtree, so the existing admin auth gate (root key) applies.

## Tests

`tests/unit/user-roles.test.ts` asserts the client wire contract (PATCH path + body, GET-by-email/userId query + 404→null, `/roles` unwrap) via a mocked `fetch`, matching paths by suffix to avoid the `getApiUrl()` memoization gotcha. Full suite: 868 pass; tsc + lint + prettier clean.

> Depends on the API route landing (buildinternet/releases#1485). Live `get-role`/`set-role` against prod work once that deploys.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User role management API: query roles by email or user ID, update roles, and list curator/admin users.
  * Admin CLI: new commands to get, set, and list user roles with validation and table or JSON output.
  * API behavior: fetching a missing user returns null; listing roles now surfaces errors for missing endpoints.

* **Tests**
  * Added/expanded unit tests covering requests, responses, and 404 handling for role operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->