### PR TITLE
chore: add missing changeset for admin user role verbs (#288)

### DIFF
--- a/.changeset/admin-user-roles.md
+++ b/.changeset/admin-user-roles.md
@@ -1,0 +1,7 @@
+---
+"@buildinternet/releases": minor
+---
+
+feat(admin): `releases admin user set-role | get-role | list-roles` (#288)
+
+Add CLI verbs to manage user roles — the OAuth scope-entitlement source of truth (`user`→read, `curator`→read+write, `admin`→read+write+admin) — wrapping the root-key-gated `/v1/admin/users/role` routes from buildinternet/releases#1485. `set-role` shows `previousRole → role`; `get-role` reads one user; `list-roles` lists curator/admin users. Backfills the changeset omitted when #288 merged.


### PR DESCRIPTION
PR #288 merged without a changeset, so the `admin user set-role/get-role/list-roles` verbs would be dropped from the next `version packages` release. Backfill a `minor` changeset for `@buildinternet/releases` (matches the `releases login` precedent in #285).