### PR TITLE
feat(admin): `releases admin oauth client …` verbs

### DIFF
--- a/.changeset/admin-oauth-clients.md
+++ b/.changeset/admin-oauth-clients.md
@@ -1,0 +1,7 @@
+---
+"@buildinternet/releases": minor
+---
+
+feat(admin): `releases admin oauth client …` verbs
+
+Add CLI verbs to register and manage "Sign in with Releases" OAuth clients, wrapping the root-key-gated `/v1/admin/oauth/clients` routes from buildinternet/releases#1482. `create` (with `--redirect-uri`/`--scope` repeatable, `--trusted`, `--public`/PKCE, `--no-pkce`) prints the `reloc_` secret once; `list`/`get` are secret-free; `disable`/`enable` toggle the reversible kill switch; `trust`/`untrust` toggle consent-screen skipping; `rotate-secret` issues a new secret once; `delete` is a hard removal.

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -476,6 +476,102 @@ export async function listUserRoles(): Promise<UserRole[]> {
   return res.users ?? [];
 }
 
+// ── OAuth clients ("Sign in with Releases") ──
+
+/** Secret-free public view of an OAuth client, as returned by every read path. */
+export interface OAuthClient {
+  clientId: string;
+  name: string | null;
+  redirectUris: string[];
+  scopes: string[];
+  /** Maps to skip_consent — a trusted client bypasses the consent screen. */
+  trusted: boolean;
+  disabled: boolean;
+  /** A public (PKCE) client has no secret (`tokenEndpointAuthMethod: "none"`). */
+  public: boolean;
+  type: string | null;
+  tokenEndpointAuthMethod: string | null;
+  createdAt?: unknown;
+  updatedAt?: unknown;
+}
+
+/** Fields accepted by `POST /v1/admin/oauth/clients`. */
+export interface CreateOAuthClientInput {
+  name?: string;
+  redirectUris: string[];
+  scopes: string[];
+  trusted?: boolean;
+  /** `none` ⇒ secretless public/PKCE client. */
+  tokenEndpointAuthMethod?: "none" | "client_secret_basic" | "client_secret_post";
+  type?: "web" | "native" | "user-agent-based";
+  grantTypes?: string[];
+  requirePKCE?: boolean;
+  clientUri?: string;
+  logoUri?: string;
+}
+
+/** Create response — carries the `reloc_` secret exactly once (null for public clients). */
+export interface CreateOAuthClientResult extends OAuthClient {
+  clientSecret: string | null;
+}
+
+/** Register a new OAuth client. The `clientSecret` is shown once and never again. */
+export async function createOAuthClient(
+  input: CreateOAuthClientInput,
+): Promise<CreateOAuthClientResult> {
+  return apiFetch<CreateOAuthClientResult>(`/v1/admin/oauth/clients`, {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
+}
+
+/** List all registered OAuth clients (secret-free). */
+export async function listOAuthClients(): Promise<OAuthClient[]> {
+  const res = await apiFetch<{ clients: OAuthClient[] } | null>(`/v1/admin/oauth/clients`);
+  if (!res) {
+    throw new Error(
+      "listOAuthClients: 404 from /v1/admin/oauth/clients — is the admin oauth route deployed?",
+    );
+  }
+  return res.clients ?? [];
+}
+
+/** Read one OAuth client by id. Returns null when no such client exists (404). */
+export async function getOAuthClient(clientId: string): Promise<OAuthClient | null> {
+  return apiFetch<OAuthClient | null>(`/v1/admin/oauth/clients/${encodeURIComponent(clientId)}`);
+}
+
+/** Atomically update the `disabled` and/or `trusted` flag on a client. */
+export async function updateOAuthClient(
+  clientId: string,
+  fields: { disabled?: boolean; trusted?: boolean },
+): Promise<OAuthClient> {
+  return apiFetch<OAuthClient>(`/v1/admin/oauth/clients/${encodeURIComponent(clientId)}`, {
+    method: "PATCH",
+    body: JSON.stringify(fields),
+  });
+}
+
+/** Rotate a confidential client's secret; returns the new `reloc_` secret once. */
+export async function rotateOAuthClientSecret(
+  clientId: string,
+): Promise<{ clientId: string; clientSecret: string }> {
+  return apiFetch<{ clientId: string; clientSecret: string }>(
+    `/v1/admin/oauth/clients/${encodeURIComponent(clientId)}/rotate-secret`,
+    { method: "POST" },
+  );
+}
+
+/** Delete a client (a hard removal — disable instead if you want a reversible kill switch). */
+export async function deleteOAuthClient(
+  clientId: string,
+): Promise<{ clientId: string; deleted: boolean }> {
+  return apiFetch<{ clientId: string; deleted: boolean }>(
+    `/v1/admin/oauth/clients/${encodeURIComponent(clientId)}`,
+    { method: "DELETE" },
+  );
+}
+
 // ── Content hash ──
 
 export async function checkContentHash(source: Source, contentHash: string): Promise<boolean> {

--- a/src/cli/commands/admin/oauth.ts
+++ b/src/cli/commands/admin/oauth.ts
@@ -1,0 +1,221 @@
+/**
+ * `releases admin oauth client …` — manage "Sign in with Releases" OAuth
+ * clients. Thin wrapper over the root-key-gated `/v1/admin/oauth/clients`
+ * routes (buildinternet/releases#1482); the admin gate is applied by
+ * `gateAdminSubtree` in program.ts. Mirrors the `admin user` verb shape.
+ */
+import { Command } from "commander";
+import chalk from "chalk";
+import { logger } from "@releases/lib/logger";
+import { writeJson } from "../../../lib/output.js";
+import {
+  createOAuthClient,
+  listOAuthClients,
+  getOAuthClient,
+  updateOAuthClient,
+  rotateOAuthClientSecret,
+  deleteOAuthClient,
+  type OAuthClient,
+} from "../../../api/client.js";
+import { renderTable } from "../../render/table.js";
+
+/** Commander collector for repeatable options (`--redirect-uri a --redirect-uri b`). */
+function collect(value: string, previous: string[]): string[] {
+  return previous.concat([value]);
+}
+
+/** One-line human summary of a client's flags. */
+function flagSummary(client: OAuthClient): string {
+  const flags: string[] = [];
+  flags.push(client.public ? chalk.cyan("public/PKCE") : "confidential");
+  if (client.trusted) flags.push(chalk.yellow("trusted"));
+  if (client.disabled) flags.push(chalk.red("disabled"));
+  return flags.join(" · ");
+}
+
+function printClient(client: OAuthClient): void {
+  logger.info(`${chalk.bold(client.clientId)}  ${client.name ?? chalk.dim("(unnamed)")}`);
+  logger.info(`  ${flagSummary(client)}`);
+  logger.info(`  redirect: ${client.redirectUris.join(", ") || chalk.dim("(none)")}`);
+  logger.info(`  scopes:   ${client.scopes.join(" ") || chalk.dim("(none)")}`);
+}
+
+export function registerOauthCommand(program: Command) {
+  const oauth = program
+    .command("oauth")
+    .description('Manage "Sign in with Releases" OAuth clients');
+  const client = oauth.command("client").description("Register and manage OAuth clients");
+
+  client
+    .command("create")
+    .description("Register a new OAuth client (secret shown once)")
+    .requiredOption(
+      "--redirect-uri <uri>",
+      "Allowed redirect URI (repeatable)",
+      collect,
+      [] as string[],
+    )
+    .requiredOption("--scope <scope>", "Granted scope (repeatable)", collect, [] as string[])
+    .option("--name <name>", "Human-readable client name")
+    .option("--trusted", "Skip the consent screen (trusted first-party client)")
+    .option("--public", "Public/PKCE client with no secret (tokenEndpointAuthMethod=none)")
+    .option(
+      "--grant-type <type>",
+      "Grant type (repeatable; default authorization_code)",
+      collect,
+      [] as string[],
+    )
+    .option("--no-pkce", "Do not require PKCE (default: required)")
+    .option("--client-uri <url>", "Client homepage URL")
+    .option("--logo-uri <url>", "Client logo URL")
+    .option("--json", "Output JSON")
+    .action(
+      async (opts: {
+        redirectUri: string[];
+        scope: string[];
+        name?: string;
+        trusted?: boolean;
+        public?: boolean;
+        grantType: string[];
+        pkce: boolean;
+        clientUri?: string;
+        logoUri?: string;
+        json?: boolean;
+      }) => {
+        const result = await createOAuthClient({
+          name: opts.name,
+          redirectUris: opts.redirectUri,
+          scopes: opts.scope,
+          trusted: opts.trusted,
+          tokenEndpointAuthMethod: opts.public ? "none" : undefined,
+          grantTypes: opts.grantType.length > 0 ? opts.grantType : undefined,
+          requirePKCE: opts.pkce,
+          clientUri: opts.clientUri,
+          logoUri: opts.logoUri,
+        });
+        if (opts.json) {
+          await writeJson(result);
+          return;
+        }
+        printClient(result);
+        if (result.clientSecret) {
+          logger.info("");
+          logger.info(chalk.bold("Client secret (shown once — store it now):"));
+          logger.info(`  ${chalk.green(result.clientSecret)}`);
+        } else {
+          logger.info(`  ${chalk.dim("public client — no secret")}`);
+        }
+      },
+    );
+
+  client
+    .command("list")
+    .description("List all registered OAuth clients")
+    .option("--json", "Output JSON")
+    .action(async (opts: { json?: boolean }) => {
+      const clients = await listOAuthClients();
+      if (opts.json) {
+        await writeJson({ clients });
+        return;
+      }
+      if (clients.length === 0) {
+        logger.info("No OAuth clients registered.");
+        return;
+      }
+      console.log(
+        renderTable({
+          head: [
+            { label: "Client ID", noTruncate: true },
+            { label: "Name" },
+            { label: "Type" },
+            { label: "Flags" },
+          ],
+          rows: clients.map((c) => [
+            c.clientId,
+            c.name ?? chalk.dim("—"),
+            c.public ? "public" : "confidential",
+            [c.trusted ? "trusted" : "", c.disabled ? "disabled" : ""].filter(Boolean).join(",") ||
+              chalk.dim("—"),
+          ]),
+        }),
+      );
+    });
+
+  client
+    .command("get <clientId>")
+    .description("Show one OAuth client")
+    .option("--json", "Output JSON")
+    .action(async (clientId: string, opts: { json?: boolean }) => {
+      const found = await getOAuthClient(clientId);
+      if (!found) {
+        logger.error("Client not found.");
+        process.exit(1);
+      }
+      if (opts.json) {
+        await writeJson(found);
+        return;
+      }
+      printClient(found);
+    });
+
+  client
+    .command("disable <clientId>")
+    .description("Disable a client (reversible kill switch)")
+    .option("--json", "Output JSON")
+    .action(async (clientId: string, opts: { json?: boolean }) => {
+      const updated = await updateOAuthClient(clientId, { disabled: true });
+      if (opts.json) return writeJson(updated);
+      logger.info(`${updated.clientId}: ${chalk.red("disabled")}`);
+    });
+
+  client
+    .command("enable <clientId>")
+    .description("Re-enable a disabled client")
+    .option("--json", "Output JSON")
+    .action(async (clientId: string, opts: { json?: boolean }) => {
+      const updated = await updateOAuthClient(clientId, { disabled: false });
+      if (opts.json) return writeJson(updated);
+      logger.info(`${updated.clientId}: ${chalk.green("enabled")}`);
+    });
+
+  client
+    .command("trust <clientId>")
+    .description("Mark a client trusted (skips the consent screen)")
+    .option("--json", "Output JSON")
+    .action(async (clientId: string, opts: { json?: boolean }) => {
+      const updated = await updateOAuthClient(clientId, { trusted: true });
+      if (opts.json) return writeJson(updated);
+      logger.info(`${updated.clientId}: ${chalk.yellow("trusted")}`);
+    });
+
+  client
+    .command("untrust <clientId>")
+    .description("Remove trusted status (consent screen required again)")
+    .option("--json", "Output JSON")
+    .action(async (clientId: string, opts: { json?: boolean }) => {
+      const updated = await updateOAuthClient(clientId, { trusted: false });
+      if (opts.json) return writeJson(updated);
+      logger.info(`${updated.clientId}: ${chalk.dim("untrusted")}`);
+    });
+
+  client
+    .command("rotate-secret <clientId>")
+    .description("Rotate a confidential client's secret (new secret shown once)")
+    .option("--json", "Output JSON")
+    .action(async (clientId: string, opts: { json?: boolean }) => {
+      const result = await rotateOAuthClientSecret(clientId);
+      if (opts.json) return writeJson(result);
+      logger.info(chalk.bold("New client secret (shown once — store it now):"));
+      logger.info(`  ${chalk.green(result.clientSecret)}`);
+    });
+
+  client
+    .command("delete <clientId>")
+    .description("Delete a client (hard removal; use disable for a reversible switch)")
+    .option("--json", "Output JSON")
+    .action(async (clientId: string, opts: { json?: boolean }) => {
+      const result = await deleteOAuthClient(clientId);
+      if (opts.json) return writeJson(result);
+      logger.info(`${result.clientId}: ${chalk.red("deleted")}`);
+    });
+}

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -41,6 +41,7 @@ import { registerPlaybookCommand } from "./commands/admin/playbook.js";
 import { registerOverviewCommands } from "./commands/admin/overview.js";
 import { registerWorkCommands } from "./commands/admin/work.js";
 import { registerUserCommand } from "./commands/admin/user.js";
+import { registerOauthCommand } from "./commands/admin/oauth.js";
 import { registerTelemetryCommand } from "./commands/telemetry.js";
 import { registerFeedbackCommand, registerFeedbackAdminCommand } from "./commands/feedback.js";
 import { registerSubmitCommand, registerRecommendationAdminCommand } from "./commands/recommend.js";
@@ -284,6 +285,7 @@ registerProductCommand(admin);
 registerCollectionCommand(admin);
 registerReleaseCommand(admin);
 registerUserCommand(admin);
+registerOauthCommand(admin);
 
 const discoveryAdmin = admin
   .command("discovery")

--- a/tests/unit/oauth-clients.test.ts
+++ b/tests/unit/oauth-clients.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
+
+// Drive the real client via env (a top-level mock.module leaks across files —
+// see api-client.test.ts). Match request paths by suffix, not full URL, so the
+// process-wide getApiUrl() memoization can't poison assertions.
+const prevEnv: { url?: string; key?: string } = {};
+beforeAll(() => {
+  prevEnv.url = process.env.RELEASES_API_URL;
+  prevEnv.key = process.env.RELEASES_API_KEY;
+  process.env.RELEASES_API_URL = "https://test.example.com";
+  process.env.RELEASES_API_KEY = "test-key";
+});
+afterAll(() => {
+  if (prevEnv.url === undefined) delete process.env.RELEASES_API_URL;
+  else process.env.RELEASES_API_URL = prevEnv.url;
+  if (prevEnv.key === undefined) delete process.env.RELEASES_API_KEY;
+  else process.env.RELEASES_API_KEY = prevEnv.key;
+});
+
+const client = await import("../../src/api/client.js");
+
+describe("oauth-client client wire contract", () => {
+  let originalFetch: typeof globalThis.fetch;
+  let capturedUrl = "";
+  let capturedMethod = "";
+  let capturedBody: Record<string, unknown> | null = null;
+  let responder: () => Response;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    capturedUrl = "";
+    capturedMethod = "";
+    capturedBody = null;
+    responder = () =>
+      new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    globalThis.fetch = (async (url: string, init?: RequestInit) => {
+      capturedUrl = url;
+      capturedMethod = init?.method ?? "GET";
+      capturedBody = init?.body ? JSON.parse(String(init.body)) : null;
+      return responder();
+    }) as unknown as typeof globalThis.fetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("createOAuthClient POSTs the create route with the full input", async () => {
+    responder = () =>
+      new Response(
+        JSON.stringify({
+          clientId: "abc",
+          name: "My App",
+          redirectUris: ["https://app/cb"],
+          scopes: ["read"],
+          trusted: true,
+          disabled: false,
+          public: false,
+          type: "web",
+          tokenEndpointAuthMethod: "client_secret_basic",
+          clientSecret: "reloc_secret",
+        }),
+        { status: 201, headers: { "Content-Type": "application/json" } },
+      );
+    const res = await client.createOAuthClient({
+      name: "My App",
+      redirectUris: ["https://app/cb"],
+      scopes: ["read"],
+      trusted: true,
+    });
+    expect(capturedMethod).toBe("POST");
+    expect(capturedUrl.endsWith("/v1/admin/oauth/clients")).toBe(true);
+    expect(capturedBody).toEqual({
+      name: "My App",
+      redirectUris: ["https://app/cb"],
+      scopes: ["read"],
+      trusted: true,
+    });
+    expect(res.clientSecret).toBe("reloc_secret");
+  });
+
+  it("createOAuthClient passes tokenEndpointAuthMethod=none for public clients", async () => {
+    responder = () =>
+      new Response(JSON.stringify({ clientId: "p", public: true, clientSecret: null }), {
+        status: 201,
+        headers: { "Content-Type": "application/json" },
+      });
+    await client.createOAuthClient({
+      redirectUris: ["myapp://cb"],
+      scopes: ["read"],
+      tokenEndpointAuthMethod: "none",
+    });
+    expect(capturedBody).toMatchObject({ tokenEndpointAuthMethod: "none" });
+  });
+
+  it("listOAuthClients GETs the clients route and unwraps { clients }", async () => {
+    responder = () =>
+      new Response(JSON.stringify({ clients: [{ clientId: "a" }, { clientId: "b" }] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    const res = await client.listOAuthClients();
+    expect(capturedMethod).toBe("GET");
+    expect(capturedUrl.endsWith("/v1/admin/oauth/clients")).toBe(true);
+    expect(res).toHaveLength(2);
+  });
+
+  it("getOAuthClient GETs the per-client route and returns null on 404", async () => {
+    responder = () => new Response("", { status: 404 });
+    const res = await client.getOAuthClient("xyz");
+    expect(capturedMethod).toBe("GET");
+    expect(capturedUrl.endsWith("/v1/admin/oauth/clients/xyz")).toBe(true);
+    expect(res).toBeNull();
+  });
+
+  it("updateOAuthClient PATCHes only the flags provided", async () => {
+    responder = () =>
+      new Response(JSON.stringify({ clientId: "c1", disabled: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    await client.updateOAuthClient("c1", { disabled: true });
+    expect(capturedMethod).toBe("PATCH");
+    expect(capturedUrl.endsWith("/v1/admin/oauth/clients/c1")).toBe(true);
+    expect(capturedBody).toEqual({ disabled: true });
+  });
+
+  it("rotateOAuthClientSecret POSTs the rotate-secret route", async () => {
+    responder = () =>
+      new Response(JSON.stringify({ clientId: "c1", clientSecret: "reloc_new" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    const res = await client.rotateOAuthClientSecret("c1");
+    expect(capturedMethod).toBe("POST");
+    expect(capturedUrl.endsWith("/v1/admin/oauth/clients/c1/rotate-secret")).toBe(true);
+    expect(res.clientSecret).toBe("reloc_new");
+  });
+
+  it("deleteOAuthClient DELETEs the per-client route", async () => {
+    responder = () =>
+      new Response(JSON.stringify({ clientId: "c1", deleted: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    const res = await client.deleteOAuthClient("c1");
+    expect(capturedMethod).toBe("DELETE");
+    expect(capturedUrl.endsWith("/v1/admin/oauth/clients/c1")).toBe(true);
+    expect(res.deleted).toBe(true);
+  });
+});


### PR DESCRIPTION
Adds CLI verbs to register and manage "Sign in with Releases" OAuth clients — the operator front door for the client-provisioning routes that shipped in buildinternet/releases#1482 (#1486). Until now those routes were reachable only via raw root-key REST.

Mirrors the `releases admin user` verb shape (#288): thin wrappers over the root-key-gated `/v1/admin/oauth/clients` route family, gated by the existing `gateAdminSubtree`.

### Verbs (`releases admin oauth client …`)

- **`create`** — `--redirect-uri`/`--scope` repeatable, `--name`, `--trusted` (skip consent), `--public` (PKCE, `tokenEndpointAuthMethod=none`), `--no-pkce`, `--grant-type`, `--client-uri`, `--logo-uri`. Prints the `reloc_` secret **once** (null for public clients).
- **`list`** / **`get <clientId>`** — secret-free reads (table / detail).
- **`disable`** / **`enable <clientId>`** — reversible kill switch (PATCH `disabled`).
- **`trust`** / **`untrust <clientId>`** — toggle consent-screen skipping (PATCH `trusted`).
- **`rotate-secret <clientId>`** — new `reloc_` secret shown once (400 for a public client, surfaced by the route).
- **`delete <clientId>`** — hard removal.

### Implementation

- Client helpers in `src/api/client.ts` (`createOAuthClient`, `listOAuthClients`, `getOAuthClient`, `updateOAuthClient`, `rotateOAuthClientSecret`, `deleteOAuthClient`) — same `apiFetch` + 404→null conventions as the user-role helpers.
- New `src/cli/commands/admin/oauth.ts`, registered under `admin`.
- Wire-contract tests (`tests/unit/oauth-clients.test.ts`) assert method + path-suffix + body for every verb, using the suffix-match pattern that avoids the `getApiUrl()` memoization trap.
- Changeset included (minor).

### Verification

- `npx tsc --noEmit` clean; `bun run lint` clean (only pre-existing warnings); `bun run format` clean.
- `bun test` — 876 pass / 0 fail (7 new).
- `admin oauth client --help` renders all verbs through the admin gate.

Follow-up to #1482; the other follow-up (staging smoke of a full authorization_code + PKCE flow) is separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)