### PR TITLE
feat(admin): add `releases admin webhook` CRUD commands

### DIFF
--- a/.changeset/admin-webhook-cli.md
+++ b/.changeset/admin-webhook-cli.md
@@ -1,0 +1,7 @@
+---
+"releases-cli": minor
+---
+
+Add `releases admin webhook` commands for managing outbound webhook subscriptions: `add`, `list`, `show`, `edit`, `remove`, `test`, `rotate-secret`, and `deliveries`. These wrap the existing root-key-gated `/v1/webhooks` API routes so Phase-A operators can manage subscriptions without raw API calls.
+
+The subscriber-facing `webhook verify` (local signature check, no auth) moves from `admin webhook verify` to top-level `webhook verify`.

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -141,6 +141,9 @@ export async function apiFetch<T>(path: string, opts?: RequestInit): Promise<T> 
     recordMutation({ method, path, ok: true, status: res.status });
   }
 
+  // 204 No Content (e.g. DELETE) has an empty body; res.json() would throw.
+  if (res.status === 204) return undefined as T;
+
   return res.json();
 }
 
@@ -570,6 +573,142 @@ export async function deleteOAuthClient(
     `/v1/admin/oauth/clients/${encodeURIComponent(clientId)}`,
     { method: "DELETE" },
   );
+}
+
+// ── Webhook subscriptions ──
+
+/**
+ * A webhook subscription as returned by the read paths. Defined locally rather
+ * than re-exported from `@buildinternet/releases-api-types` because the wire
+ * shape is worker-internal (admin-only) and not part of the published types.
+ */
+export interface WebhookSubscription {
+  id: string;
+  orgId: string;
+  url: string;
+  sourceId: string | null;
+  enabled: boolean;
+  description: string | null;
+  secretVersion: number;
+  createdAt: string;
+  lastSuccessAt: string | null;
+  lastErrorAt: string | null;
+  lastErrorMsg: string | null;
+  consecutiveFailures: number;
+  disabledReason: string | null;
+}
+
+/** Create + rotate-secret carry the derived signing key exactly once. */
+export interface WebhookSubscriptionWithKey extends WebhookSubscription {
+  signingKey: string;
+}
+
+/** Fields accepted by `POST /v1/webhooks`. `orgId`/`sourceId` are resolved ids, not slugs. */
+export interface CreateWebhookSubscriptionInput {
+  orgId: string;
+  url: string;
+  sourceId?: string | null;
+  description?: string | null;
+}
+
+/** One Analytics Engine delivery-attempt row from `GET /v1/webhooks/:id/deliveries`. */
+export interface WebhookDeliveryRow {
+  timestamp?: string;
+  event_id?: string;
+  error_message?: string | null;
+  error_code?: string | null;
+  outcome?: string;
+  http_status?: number;
+  latency_ms?: number;
+  attempt?: number;
+}
+
+/** Register a webhook subscription. The `signingKey` is shown once and never again. */
+export async function createWebhookSubscription(
+  input: CreateWebhookSubscriptionInput,
+): Promise<WebhookSubscriptionWithKey> {
+  return apiFetch<WebhookSubscriptionWithKey>(`/v1/webhooks`, {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
+}
+
+/** List an org's webhook subscriptions. Requires an org id (no cross-org route exists). */
+export async function listWebhookSubscriptions(
+  orgId: string,
+  opts?: { enabled?: boolean },
+): Promise<WebhookSubscription[]> {
+  const params = new URLSearchParams({ org: orgId });
+  if (opts?.enabled !== undefined) params.set("enabled", String(opts.enabled));
+  const res = await apiFetch<{ subscriptions: WebhookSubscription[] } | null>(
+    `/v1/webhooks?${params.toString()}`,
+  );
+  if (!res) {
+    throw new Error(
+      "listWebhookSubscriptions: 404 from /v1/webhooks — is the webhooks route deployed?",
+    );
+  }
+  return res.subscriptions ?? [];
+}
+
+/** Read one subscription by id. Returns null when no such subscription exists (404). */
+export async function getWebhookSubscription(id: string): Promise<WebhookSubscription | null> {
+  return apiFetch<WebhookSubscription | null>(`/v1/webhooks/${encodeURIComponent(id)}`);
+}
+
+/** Update url / description / enabled on a subscription. Does NOT rotate the signing key. */
+export async function updateWebhookSubscription(
+  id: string,
+  fields: { url?: string; description?: string | null; enabled?: boolean },
+): Promise<WebhookSubscription> {
+  return apiFetch<WebhookSubscription>(`/v1/webhooks/${encodeURIComponent(id)}`, {
+    method: "PATCH",
+    body: JSON.stringify(fields),
+  });
+}
+
+/** Hard-delete a subscription (delivery history is Analytics-Engine-only, untouched). */
+export async function deleteWebhookSubscription(id: string): Promise<void> {
+  await apiFetch<void>(`/v1/webhooks/${encodeURIComponent(id)}`, { method: "DELETE" });
+}
+
+/** Bump the secret version, invalidating the old key. Returns the new key once. */
+export async function rotateWebhookSecret(
+  id: string,
+): Promise<{ secretVersion: number; signingKey: string }> {
+  return apiFetch<{ secretVersion: number; signingKey: string }>(
+    `/v1/webhooks/${encodeURIComponent(id)}/rotate-secret`,
+    { method: "POST" },
+  );
+}
+
+/** Enqueue a synthetic `release.created` event to the subscription's URL. */
+export async function testWebhookSubscription(
+  id: string,
+): Promise<{ enqueued: boolean; eventId: string }> {
+  return apiFetch<{ enqueued: boolean; eventId: string }>(
+    `/v1/webhooks/${encodeURIComponent(id)}/test`,
+    { method: "POST" },
+  );
+}
+
+/**
+ * Fetch recent delivery attempts from Analytics Engine. The route supports
+ * `failed` + `limit`; `--since` filtering is applied client-side by the command
+ * (the AE-backed route has no time-range param yet).
+ */
+export async function getWebhookDeliveries(
+  id: string,
+  opts?: { failed?: boolean; limit?: number },
+): Promise<WebhookDeliveryRow[]> {
+  const params = new URLSearchParams();
+  if (opts?.failed) params.set("failed", "true");
+  if (opts?.limit !== undefined) params.set("limit", String(opts.limit));
+  const qs = params.toString();
+  const res = await apiFetch<{ data?: WebhookDeliveryRow[] } | null>(
+    `/v1/webhooks/${encodeURIComponent(id)}/deliveries${qs ? `?${qs}` : ""}`,
+  );
+  return res?.data ?? [];
 }
 
 // ── Content hash ──

--- a/src/cli/commands/admin/webhook.ts
+++ b/src/cli/commands/admin/webhook.ts
@@ -46,6 +46,13 @@ function statusLabel(sub: WebhookSubscription): string {
   return sub.enabled ? chalk.green("enabled") : chalk.red("disabled");
 }
 
+/** Parse + clamp `--limit` to the API's accepted range so no garbage reaches the URL. */
+function parseLimit(value: string): number {
+  const n = parseInt(value, 10);
+  if (Number.isNaN(n) || n === 0) return 20;
+  return Math.min(100, Math.max(1, n));
+}
+
 function printSubscription(sub: WebhookSubscription): void {
   logger.info(`${chalk.bold(sub.id)}  ${statusLabel(sub)}`);
   logger.info(`  url:     ${sub.url}`);
@@ -280,7 +287,7 @@ export function registerWebhookAdminCommand(program: Command) {
     .description("Show recent delivery attempts from Analytics Engine")
     .option("--failed", "Only failed attempts (retry / perm_fail / dlq / auto_disabled)")
     .option("--since <iso>", "Only attempts at or after this ISO timestamp (filtered client-side)")
-    .option("--limit <n>", "Max attempts to fetch (default 20, max 100)", (v) => parseInt(v, 10))
+    .option("--limit <n>", "Max attempts to fetch (default 20, max 100)", parseLimit)
     .option("--json", "Output JSON")
     .action(
       async (

--- a/src/cli/commands/admin/webhook.ts
+++ b/src/cli/commands/admin/webhook.ts
@@ -1,0 +1,318 @@
+/**
+ * `releases admin webhook …` — manage outbound webhook subscriptions. Thin
+ * wrapper over the root-key-gated `/v1/webhooks` routes (buildinternet/releases#343,
+ * #1505); the admin gate is applied by `gateAdminSubtree` in program.ts. Mirrors
+ * the `admin oauth client` verb shape.
+ *
+ * The subscriber-facing `releases webhook verify` (local signature check) lives
+ * separately at top level in `../webhook.ts` — it needs no auth.
+ */
+import { Command } from "commander";
+import chalk from "chalk";
+import { logger } from "@releases/lib/logger";
+import { writeJson } from "../../../lib/output.js";
+import {
+  createWebhookSubscription,
+  listWebhookSubscriptions,
+  getWebhookSubscription,
+  updateWebhookSubscription,
+  deleteWebhookSubscription,
+  rotateWebhookSecret,
+  testWebhookSubscription,
+  getWebhookDeliveries,
+  findOrg,
+  findSource,
+  type WebhookSubscription,
+  type WebhookDeliveryRow,
+} from "../../../api/client.js";
+import { renderTable } from "../../render/table.js";
+import { orgNotFound, sourceNotFound } from "../../suggest.js";
+
+/** Resolve an org slug (or id) to its id, or exit 1 with did-you-mean suggestions. */
+async function resolveOrgId(slug: string): Promise<string> {
+  const org = await findOrg(slug);
+  if (!org) return orgNotFound(slug);
+  return org.id;
+}
+
+/** Resolve a source slug (or src_ id) to its id, or exit 1 (AmbiguousSourceError propagates). */
+async function resolveSourceId(identifier: string): Promise<string> {
+  const src = await findSource(identifier);
+  if (!src) return sourceNotFound(identifier);
+  return src.id;
+}
+
+function statusLabel(sub: WebhookSubscription): string {
+  return sub.enabled ? chalk.green("enabled") : chalk.red("disabled");
+}
+
+function printSubscription(sub: WebhookSubscription): void {
+  logger.info(`${chalk.bold(sub.id)}  ${statusLabel(sub)}`);
+  logger.info(`  url:     ${sub.url}`);
+  logger.info(`  org:     ${sub.orgId}`);
+  logger.info(`  source:  ${sub.sourceId ?? chalk.dim("(all org sources)")}`);
+  if (sub.description) logger.info(`  desc:    ${sub.description}`);
+  logger.info(`  secret:  v${sub.secretVersion}${chalk.dim(`  · created ${sub.createdAt}`)}`);
+  logger.info(
+    `  last ok: ${sub.lastSuccessAt ?? chalk.dim("—")}   failures: ${sub.consecutiveFailures}`,
+  );
+  if (sub.lastErrorAt) {
+    logger.info(`  last err: ${sub.lastErrorAt} ${chalk.dim(sub.lastErrorMsg ?? "")}`);
+  }
+  if (!sub.enabled && sub.disabledReason) {
+    logger.info(`  ${chalk.red(`disabled: ${sub.disabledReason}`)}`);
+  }
+}
+
+/** True when a thrown error is the API's "deliveries not configured" signal (501). */
+function isDeliveriesUnavailable(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return /\(501\)|deliveries_unavailable|CF_API_TOKEN/.test(msg);
+}
+
+function renderDeliveries(rows: WebhookDeliveryRow[]): string {
+  return renderTable({
+    head: [
+      { label: "Time", noTruncate: true },
+      { label: "Outcome" },
+      { label: "HTTP" },
+      { label: "Latency" },
+      { label: "Attempt" },
+      { label: "Error" },
+    ],
+    rows: rows.map((r) => [
+      r.timestamp ?? chalk.dim("—"),
+      r.outcome ?? chalk.dim("—"),
+      r.http_status != null ? String(r.http_status) : chalk.dim("—"),
+      r.latency_ms != null ? `${r.latency_ms}ms` : chalk.dim("—"),
+      r.attempt != null ? String(r.attempt) : chalk.dim("—"),
+      r.error_message ?? chalk.dim("—"),
+    ]),
+  });
+}
+
+export function registerWebhookAdminCommand(program: Command) {
+  const webhook = program.command("webhook").description("Manage outbound webhook subscriptions");
+
+  webhook
+    .command("add")
+    .description("Create a webhook subscription (signing key shown once)")
+    .requiredOption("--org <slug>", "Owning org slug or id")
+    .requiredOption("--url <url>", "HTTPS delivery URL")
+    .option("--source <slug>", "Limit to one source (slug or src_ id); default = all org sources")
+    .option("--description <text>", "Human-readable label")
+    .option("--json", "Output JSON")
+    .action(
+      async (opts: {
+        org: string;
+        url: string;
+        source?: string;
+        description?: string;
+        json?: boolean;
+      }) => {
+        const orgId = await resolveOrgId(opts.org);
+        const sourceId = opts.source ? await resolveSourceId(opts.source) : undefined;
+        const result = await createWebhookSubscription({
+          orgId,
+          url: opts.url,
+          sourceId,
+          description: opts.description,
+        });
+        if (opts.json) return writeJson(result);
+        printSubscription(result);
+        logger.info("");
+        logger.info(chalk.bold("Signing key (shown once — store it now):"));
+        logger.info(`  ${chalk.green(result.signingKey)}`);
+        logger.info(
+          chalk.dim("  Re-derive only via `webhook rotate-secret` (invalidates the old key)."),
+        );
+      },
+    );
+
+  webhook
+    .command("list")
+    .description("List an org's webhook subscriptions")
+    .requiredOption("--org <slug>", "Org slug or id (cross-org listing is not supported)")
+    .option("--enabled", "Only enabled subscriptions")
+    .option("--disabled", "Only disabled subscriptions")
+    .option("--json", "Output JSON")
+    .action(
+      async (opts: { org: string; enabled?: boolean; disabled?: boolean; json?: boolean }) => {
+        if (opts.enabled && opts.disabled) {
+          logger.error("Pass at most one of --enabled / --disabled.");
+          process.exit(1);
+        }
+        const orgId = await resolveOrgId(opts.org);
+        let filter: { enabled?: boolean } | undefined;
+        if (opts.enabled) filter = { enabled: true };
+        else if (opts.disabled) filter = { enabled: false };
+        const subscriptions = await listWebhookSubscriptions(orgId, filter);
+        if (opts.json) return writeJson({ subscriptions });
+        if (subscriptions.length === 0) {
+          logger.info("No webhook subscriptions.");
+          return;
+        }
+        console.log(
+          renderTable({
+            head: [
+              { label: "ID", noTruncate: true },
+              { label: "URL", noTruncate: true },
+              { label: "Source" },
+              { label: "Status" },
+              { label: "Fails" },
+            ],
+            rows: subscriptions.map((s) => [
+              s.id,
+              s.url,
+              s.sourceId ?? chalk.dim("all"),
+              s.enabled ? "enabled" : "disabled",
+              String(s.consecutiveFailures),
+            ]),
+          }),
+        );
+      },
+    );
+
+  webhook
+    .command("show <id>")
+    .description("Show one subscription plus its last 10 delivery attempts")
+    .option("--json", "Output JSON")
+    .action(async (id: string, opts: { json?: boolean }) => {
+      const sub = await getWebhookSubscription(id);
+      if (!sub) {
+        logger.error("Subscription not found.");
+        process.exit(1);
+      }
+      let deliveries: WebhookDeliveryRow[] = [];
+      let deliveriesUnavailable = false;
+      try {
+        deliveries = await getWebhookDeliveries(id, { limit: 10 });
+      } catch (err) {
+        if (isDeliveriesUnavailable(err)) deliveriesUnavailable = true;
+        else throw err;
+      }
+      if (opts.json) return writeJson({ ...sub, deliveries });
+      printSubscription(sub);
+      logger.info("");
+      if (deliveriesUnavailable) {
+        logger.info(chalk.dim("Delivery history unavailable (Analytics Engine not configured)."));
+      } else if (deliveries.length === 0) {
+        logger.info(chalk.dim("No delivery attempts recorded."));
+      } else {
+        logger.info(chalk.bold("Recent deliveries:"));
+        console.log(renderDeliveries(deliveries));
+      }
+    });
+
+  webhook
+    .command("edit <id>")
+    .description("Update a subscription's url / description / enabled state")
+    .option("--url <url>", "New HTTPS delivery URL (does not rotate the signing key)")
+    .option("--description <text>", "New description")
+    .option("--enable", "Enable the subscription (resets the failure counter)")
+    .option("--disable", "Disable the subscription")
+    .option("--json", "Output JSON")
+    .action(
+      async (
+        id: string,
+        opts: {
+          url?: string;
+          description?: string;
+          enable?: boolean;
+          disable?: boolean;
+          json?: boolean;
+        },
+      ) => {
+        if (opts.enable && opts.disable) {
+          logger.error("Pass at most one of --enable / --disable.");
+          process.exit(1);
+        }
+        const fields: { url?: string; description?: string; enabled?: boolean } = {};
+        if (opts.url !== undefined) fields.url = opts.url;
+        if (opts.description !== undefined) fields.description = opts.description;
+        if (opts.enable) fields.enabled = true;
+        if (opts.disable) fields.enabled = false;
+        if (Object.keys(fields).length === 0) {
+          logger.error("Nothing to change. Pass --url, --description, --enable, or --disable.");
+          process.exit(1);
+        }
+        const updated = await updateWebhookSubscription(id, fields);
+        if (opts.json) return writeJson(updated);
+        printSubscription(updated);
+      },
+    );
+
+  webhook
+    .command("remove <id>")
+    .description("Hard-delete a subscription")
+    .option("--json", "Output JSON")
+    .action(async (id: string, opts: { json?: boolean }) => {
+      await deleteWebhookSubscription(id);
+      if (opts.json) return writeJson({ id, deleted: true });
+      logger.info(`${id}: ${chalk.red("deleted")}`);
+    });
+
+  webhook
+    .command("test <id>")
+    .description("Enqueue a synthetic release.created event to the subscription URL")
+    .option("--json", "Output JSON")
+    .action(async (id: string, opts: { json?: boolean }) => {
+      const result = await testWebhookSubscription(id);
+      if (opts.json) return writeJson(result);
+      logger.info(`${chalk.green("enqueued")} test event ${chalk.dim(result.eventId)} → ${id}`);
+    });
+
+  webhook
+    .command("rotate-secret <id>")
+    .description("Rotate the signing key (new key shown once; old key invalidated)")
+    .option("--json", "Output JSON")
+    .action(async (id: string, opts: { json?: boolean }) => {
+      const result = await rotateWebhookSecret(id);
+      if (opts.json) return writeJson(result);
+      logger.info(
+        chalk.bold(`New signing key (v${result.secretVersion}, shown once — store it now):`),
+      );
+      logger.info(`  ${chalk.green(result.signingKey)}`);
+    });
+
+  webhook
+    .command("deliveries <id>")
+    .description("Show recent delivery attempts from Analytics Engine")
+    .option("--failed", "Only failed attempts (retry / perm_fail / dlq / auto_disabled)")
+    .option("--since <iso>", "Only attempts at or after this ISO timestamp (filtered client-side)")
+    .option("--limit <n>", "Max attempts to fetch (default 20, max 100)", (v) => parseInt(v, 10))
+    .option("--json", "Output JSON")
+    .action(
+      async (
+        id: string,
+        opts: { failed?: boolean; since?: string; limit?: number; json?: boolean },
+      ) => {
+        let rows: WebhookDeliveryRow[];
+        try {
+          rows = await getWebhookDeliveries(id, { failed: opts.failed, limit: opts.limit });
+        } catch (err) {
+          if (isDeliveriesUnavailable(err)) {
+            logger.error(
+              "Delivery history unavailable — the API has no Analytics Engine query configured.",
+            );
+            process.exit(1);
+          }
+          throw err;
+        }
+        if (opts.since) {
+          const cutoff = Date.parse(opts.since);
+          if (Number.isNaN(cutoff)) {
+            logger.error(`Invalid --since timestamp: ${opts.since}`);
+            process.exit(1);
+          }
+          rows = rows.filter((r) => r.timestamp != null && Date.parse(r.timestamp) >= cutoff);
+        }
+        if (opts.json) return writeJson({ deliveries: rows });
+        if (rows.length === 0) {
+          logger.info("No delivery attempts.");
+          return;
+        }
+        console.log(renderDeliveries(rows));
+      },
+    );
+}

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -48,6 +48,7 @@ import { registerSubmitCommand, registerRecommendationAdminCommand } from "./com
 import { registerServeCommand } from "./commands/serve.js";
 import { registerWhoamiCommand } from "./commands/whoami.js";
 import { registerWebhookCommand } from "./commands/webhook.js";
+import { registerWebhookAdminCommand } from "./commands/admin/webhook.js";
 import { registerAgentContextCommand } from "./commands/agent-context.js";
 import { registerCompletionCommand } from "./commands/completion.js";
 import { completionNotice } from "./completion/hint.js";
@@ -242,6 +243,9 @@ registerKeysCommand(program);
 registerAgentContextCommand(program);
 registerCompletionCommand(program);
 registerSkillsCommand(program);
+// Subscriber-facing `webhook verify` — local signature check, no auth. The
+// admin webhook CRUD lives under `admin` (registerWebhookAdminCommand).
+registerWebhookCommand(program);
 
 const admin = program
   .command("admin")
@@ -309,7 +313,7 @@ registerWorkCommands(admin);
 const mcpAdmin = admin.command("mcp").description("MCP server management");
 registerServeCommand(mcpAdmin);
 
-registerWebhookCommand(admin);
+registerWebhookAdminCommand(admin);
 registerFeedbackAdminCommand(admin);
 registerRecommendationAdminCommand(admin);
 

--- a/tests/unit/webhook-admin.test.ts
+++ b/tests/unit/webhook-admin.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
+
+// Drive the real client via env (a top-level mock.module leaks across files —
+// see api-client.test.ts). Match request paths by suffix, not full URL, so the
+// process-wide getApiUrl() memoization can't poison assertions.
+const prevEnv: { url?: string; key?: string } = {};
+beforeAll(() => {
+  prevEnv.url = process.env.RELEASES_API_URL;
+  prevEnv.key = process.env.RELEASES_API_KEY;
+  process.env.RELEASES_API_URL = "https://test.example.com";
+  process.env.RELEASES_API_KEY = "test-key";
+});
+afterAll(() => {
+  if (prevEnv.url === undefined) delete process.env.RELEASES_API_URL;
+  else process.env.RELEASES_API_URL = prevEnv.url;
+  if (prevEnv.key === undefined) delete process.env.RELEASES_API_KEY;
+  else process.env.RELEASES_API_KEY = prevEnv.key;
+});
+
+const client = await import("../../src/api/client.js");
+
+describe("webhook-subscription client wire contract", () => {
+  let originalFetch: typeof globalThis.fetch;
+  let capturedUrl = "";
+  let capturedMethod = "";
+  let capturedBody: Record<string, unknown> | null = null;
+  let responder: () => Response;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    capturedUrl = "";
+    capturedMethod = "";
+    capturedBody = null;
+    responder = () =>
+      new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    globalThis.fetch = (async (url: string, init?: RequestInit) => {
+      capturedUrl = url;
+      capturedMethod = init?.method ?? "GET";
+      capturedBody = init?.body ? JSON.parse(String(init.body)) : null;
+      return responder();
+    }) as unknown as typeof globalThis.fetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("createWebhookSubscription POSTs /v1/webhooks with the input and returns the signing key", async () => {
+    responder = () =>
+      new Response(
+        JSON.stringify({
+          id: "whk_abc",
+          orgId: "org_1",
+          url: "https://x/cb",
+          sourceId: null,
+          enabled: true,
+          secretVersion: 1,
+          signingKey: "deadbeef",
+        }),
+        { status: 201, headers: { "Content-Type": "application/json" } },
+      );
+    const res = await client.createWebhookSubscription({
+      orgId: "org_1",
+      url: "https://x/cb",
+      description: "test sub",
+    });
+    expect(capturedMethod).toBe("POST");
+    expect(capturedUrl.endsWith("/v1/webhooks")).toBe(true);
+    expect(capturedBody).toEqual({ orgId: "org_1", url: "https://x/cb", description: "test sub" });
+    expect(res.signingKey).toBe("deadbeef");
+  });
+
+  it("listWebhookSubscriptions GETs /v1/webhooks?org= and unwraps { subscriptions }", async () => {
+    responder = () =>
+      new Response(JSON.stringify({ subscriptions: [{ id: "whk_a" }, { id: "whk_b" }] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    const res = await client.listWebhookSubscriptions("org_1");
+    expect(capturedMethod).toBe("GET");
+    expect(capturedUrl).toContain("/v1/webhooks?");
+    expect(capturedUrl).toContain("org=org_1");
+    expect(res).toHaveLength(2);
+  });
+
+  it("listWebhookSubscriptions passes enabled=true when filtered", async () => {
+    responder = () =>
+      new Response(JSON.stringify({ subscriptions: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    await client.listWebhookSubscriptions("org_1", { enabled: true });
+    expect(capturedUrl).toContain("enabled=true");
+  });
+
+  it("getWebhookSubscription GETs the per-id route and returns null on 404", async () => {
+    responder = () => new Response("", { status: 404 });
+    const res = await client.getWebhookSubscription("whk_x");
+    expect(capturedMethod).toBe("GET");
+    expect(capturedUrl.endsWith("/v1/webhooks/whk_x")).toBe(true);
+    expect(res).toBeNull();
+  });
+
+  it("updateWebhookSubscription PATCHes only the fields provided", async () => {
+    responder = () =>
+      new Response(JSON.stringify({ id: "whk_1", url: "https://new/cb" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    await client.updateWebhookSubscription("whk_1", { url: "https://new/cb" });
+    expect(capturedMethod).toBe("PATCH");
+    expect(capturedUrl.endsWith("/v1/webhooks/whk_1")).toBe(true);
+    expect(capturedBody).toEqual({ url: "https://new/cb" });
+  });
+
+  it("deleteWebhookSubscription DELETEs the per-id route and tolerates a 204 body", async () => {
+    responder = () => new Response(null, { status: 204 });
+    await client.deleteWebhookSubscription("whk_1");
+    expect(capturedMethod).toBe("DELETE");
+    expect(capturedUrl.endsWith("/v1/webhooks/whk_1")).toBe(true);
+  });
+
+  it("rotateWebhookSecret POSTs the rotate-secret route and returns the new key", async () => {
+    responder = () =>
+      new Response(JSON.stringify({ secretVersion: 2, signingKey: "newkey" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    const res = await client.rotateWebhookSecret("whk_1");
+    expect(capturedMethod).toBe("POST");
+    expect(capturedUrl.endsWith("/v1/webhooks/whk_1/rotate-secret")).toBe(true);
+    expect(res.secretVersion).toBe(2);
+    expect(res.signingKey).toBe("newkey");
+  });
+
+  it("testWebhookSubscription POSTs the test route", async () => {
+    responder = () =>
+      new Response(JSON.stringify({ enqueued: true, eventId: "rel_evt_1" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    const res = await client.testWebhookSubscription("whk_1");
+    expect(capturedMethod).toBe("POST");
+    expect(capturedUrl.endsWith("/v1/webhooks/whk_1/test")).toBe(true);
+    expect(res.enqueued).toBe(true);
+  });
+
+  it("getWebhookDeliveries GETs the deliveries route and unwraps AE { data }", async () => {
+    responder = () =>
+      new Response(
+        JSON.stringify({ data: [{ event_id: "e1", outcome: "success", http_status: 200 }] }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    const res = await client.getWebhookDeliveries("whk_1", { failed: true, limit: 5 });
+    expect(capturedMethod).toBe("GET");
+    expect(capturedUrl).toContain("/v1/webhooks/whk_1/deliveries?");
+    expect(capturedUrl).toContain("failed=true");
+    expect(capturedUrl).toContain("limit=5");
+    expect(res).toHaveLength(1);
+    expect(res[0].outcome).toBe("success");
+  });
+});


### PR DESCRIPTION
Implements **buildinternet/releases#1505** — the admin CLI surface for managing outbound webhook subscriptions. CLI-only; wraps the root-key-gated `/v1/webhooks` API routes that already exist (no API work).

## Commands

`releases admin webhook …`:

| Command | Purpose |
| --- | --- |
| `add --org <slug> --url <url> [--source <slug>] [--description <text>]` | Create a subscription; prints the signing key once |
| `list --org <slug> [--enabled\|--disabled]` | List an org's subscriptions |
| `show <id>` | Subscription detail + last 10 delivery attempts |
| `edit <id> [--url] [--description] [--enable\|--disable]` | Mutate a subscription (URL change does not rotate the key) |
| `remove <id>` | Hard-delete |
| `test <id>` | Enqueue a synthetic `release.created` event |
| `rotate-secret <id>` | Bump secret version; new key shown once |
| `deliveries <id> [--failed] [--since <iso>] [--limit N]` | Recent delivery attempts from Analytics Engine |

All support `--json`.

## Notable changes

- **`webhook verify` moved to top level.** It was registered under `admin` (program.ts:312), so the local-only, no-network signature-check utility required the operator root key. It's now `releases webhook verify` (ungated), matching the original design intent; `admin webhook verify` no longer exists.
- **`apiFetch` 204 guard.** Webhook DELETE returns `204 No Content`; `res.json()` would throw on the empty body. Added a shared `if (res.status === 204) return undefined` beside the existing `404 → null` guard — benefits any future No-Content route.

## API-reality deviations from the issue's wishlist

- `list` **requires** `--org` — there is no cross-org list route in the API.
- `deliveries --since` filters **client-side** — the AE-backed route supports only `failed` + `limit`. Documented in both the client JSDoc and the `--since` help text.

## Tests / verification

- 9 new wire-contract tests (`tests/unit/webhook-admin.test.ts`), TDD red→green.
- Full suite **885 pass / 0 fail**; `tsc --noEmit` clean; `oxlint` clean; prettier clean.
- Smoke-tested `--help`: all 8 subcommands present under `admin webhook`; `verify` now top-level.
- Ran `/simplify` (reuse + simplification + efficiency + altitude): adopted the shared `orgNotFound`/`sourceNotFound` suggestion helpers and matched `oauth.ts`'s one-line JSON-output form.

Changeset included (minor).

> Note: cross-repo, so this won't auto-close buildinternet/releases#1505 on merge — close it manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive webhook subscription management commands for administrators, including creation, listing, detailed viewing, editing, deletion, testing, secret rotation, and delivery history inspection
  * Repositioned webhook verification command to top-level for improved accessibility

* **Bug Fixes**
  * Fixed handling of HTTP 204 No Content responses to prevent JSON parsing errors

* **Tests**
  * Added comprehensive unit test coverage for webhook subscription operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->