### PR TITLE
fix(changeset): use @buildinternet/releases package name

### DIFF
--- a/.changeset/admin-webhook-cli.md
+++ b/.changeset/admin-webhook-cli.md
@@ -1,5 +1,5 @@
 ---
-"releases-cli": minor
+"@buildinternet/releases": minor
 ---
 
 Add `releases admin webhook` commands for managing outbound webhook subscriptions: `add`, `list`, `show`, `edit`, `remove`, `test`, `rotate-secret`, and `deliveries`. These wrap the existing root-key-gated `/v1/webhooks` API routes so Phase-A operators can manage subscriptions without raw API calls.

--- a/.changeset/canonical-mcp-tool-names.md
+++ b/.changeset/canonical-mcp-tool-names.md
@@ -1,5 +1,5 @@
 ---
-"releases-cli": minor
+"@buildinternet/releases": minor
 ---
 
 Rename the local stdio MCP server's tools (`releases admin mcp serve`) to mirror the canonical names served by the hosted server at `mcp.releases.sh`: `search_releases` → `search` (now returns the full unified result — orgs, catalog, and releases — with an optional `type` section filter), `list_sources` + `list_products` → `list_catalog` (org-scoped via `GET /v1/orgs/:slug/catalog`; global path folds products + standalone sources), and `get_product` → `get_catalog_entry` (dispatches product vs. source on the identifier prefix). `get_source` / `get_source_changelog` are unchanged.


### PR DESCRIPTION
## Problem

The `Version or Publish` job on `main` is failing at `changeset version`:

```
error Found changeset admin-webhook-cli for package releases-cli which is not in the workspace
```

Two changesets that recently merged to `main` — `admin-webhook-cli.md` (#292) and `canonical-mcp-tool-names.md` (#293) — declared the bump against `"releases-cli"`, the **root** package. Changesets only manages workspace members (`npm/*`, `packages/*`); the publishable package is `@buildinternet/releases`. So `changeset version` throws and the release job bails.

## Fix

Point both changesets at `@buildinternet/releases` (the name every prior merged changeset uses). Verified locally with `bunx changeset status` — resolves cleanly, bumps `@buildinternet/releases` + the fixed-group packages at minor, no error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)