### PR TITLE
feat(follows): follow / unfollow / following / feed verbs (#1520)

### DIFF
--- a/.changeset/follows-verbs.md
+++ b/.changeset/follows-verbs.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": minor
+---
+
+Add personalized follows + feed verbs: `releases follow <org|product>`, `releases unfollow <org|product>`, `releases following` (list), and `releases feed` (your personalized release timeline). They act on the signed-in user's account via the API's `/v1/me/*` routes — sign in with `releases login` (or set `RELEASES_API_KEY`) first. `follow`/`unfollow` accept an org slug, an `org/product` coordinate, or an `org_…`/`prod_…` id; `feed` reuses the same renderer as `releases tail` and is page-paginated (`--page` / `--limit`, `--json`). Requires `@buildinternet/releases-api-types` ≥ 0.32.0 for the follows wire types.

--- a/README.md
+++ b/README.md
@@ -90,6 +90,22 @@ The release reader commands (`get`, `search`, `tail`/`latest`) return a **slim**
 
 Tabular reader commands fit themselves to the terminal width when stdout is a TTY (column truncation with `…`) and switch to bare TSV when piped — no headers, no color, no truncation — so `releases org list | cut -f2` works without parsing ANSI. `COLUMNS=<n>` overrides the detected width. For complete, parseable output prefer `--json`. The `search` / `tail`/`latest` human view is a single aligned row per release (identity · description · relative age · dimmed `rel_…`); `search` adds a cleaned, markdown-stripped excerpt under each hit.
 
+### Following & personalized feed
+
+Follow organizations and products to build a personalized release feed. These act on your own account, so they need a signed-in CLI — run `releases login` first (or set `RELEASES_API_KEY`).
+
+```bash
+releases follow vercel              # an org slug…
+releases follow vercel/next-js      # …an org/product coordinate…
+releases follow prod_abc123         # …or a typed ID
+releases following                  # list what you follow
+releases feed                       # your personalized release timeline
+releases feed --limit 50 --page 2   # paginate (also --json)
+releases unfollow vercel
+```
+
+Following an organization includes all of its products. `feed` renders like `tail` (one aligned row per release, `--json` for machine output) and is page-paginated.
+
 ### Feedback
 
 Tell the maintainers about a bug, an idea, or anything else. No API key or account required:

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "releases-cli",
       "dependencies": {
-        "@buildinternet/releases-api-types": "^0.31.0",
+        "@buildinternet/releases-api-types": "^0.32.0",
         "@buildinternet/releases-core": "^0.23.0",
         "@buildinternet/releases-lib": "workspace:*",
         "@buildinternet/releases-skills": "workspace:*",
@@ -27,7 +27,7 @@
     },
     "npm/releases": {
       "name": "@buildinternet/releases",
-      "version": "0.57.0",
+      "version": "0.60.0",
       "bin": {
         "releases": "bin/releases",
       },
@@ -41,31 +41,31 @@
     },
     "npm/releases-darwin-arm64": {
       "name": "@buildinternet/releases-darwin-arm64",
-      "version": "0.57.0",
+      "version": "0.60.0",
     },
     "npm/releases-darwin-x64": {
       "name": "@buildinternet/releases-darwin-x64",
-      "version": "0.57.0",
+      "version": "0.60.0",
     },
     "npm/releases-linux-arm64": {
       "name": "@buildinternet/releases-linux-arm64",
-      "version": "0.57.0",
+      "version": "0.60.0",
     },
     "npm/releases-linux-x64": {
       "name": "@buildinternet/releases-linux-x64",
-      "version": "0.57.0",
+      "version": "0.60.0",
     },
     "npm/releases-windows-x64": {
       "name": "@buildinternet/releases-windows-x64",
-      "version": "0.57.0",
+      "version": "0.60.0",
     },
     "packages/lib": {
       "name": "@buildinternet/releases-lib",
-      "version": "0.57.0",
+      "version": "0.60.0",
     },
     "packages/skills": {
       "name": "@buildinternet/releases-skills",
-      "version": "0.57.0",
+      "version": "0.60.0",
     },
   },
   "packages": {
@@ -73,7 +73,7 @@
 
     "@buildinternet/releases": ["@buildinternet/releases@workspace:npm/releases"],
 
-    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.31.0", "", { "dependencies": { "@buildinternet/releases-core": "^0.23.0", "zod": "^4.4.3" } }, "sha512-u2Psp+uXHVq87/rfx/1/zYe7RiWrlSM4VWkXLanXdkzpccDit1SoBg6Ib7AymoRGL7khroc4kY3rAiSKCAlNjA=="],
+    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.32.0", "", { "dependencies": { "@buildinternet/releases-core": "^0.23.0", "zod": "^4.4.3" } }, "sha512-YG4jaobtRvq5/gvYojyWlL9cCW98WkonST9jdxHQSurpIA/ds6W7k1mszqXdhRH+dM2eXufIEh1lP3AU75VUxw=="],
 
     "@buildinternet/releases-core": ["@buildinternet/releases-core@0.23.0", "", { "dependencies": { "drizzle-orm": "^0.45.2", "js-tiktoken": "^1.0.21", "nanoid": "^5.1.7" } }, "sha512-ieUK+KTlXmxX6nRHIft4alMuNNOJctk8AKCfbJmM0SbWqLHcHjLy9O+sj2R+4052IhwJI86gPFpTLM1QNfLFDA=="],
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "homepage": "https://releases.sh",
   "dependencies": {
-    "@buildinternet/releases-api-types": "^0.31.0",
+    "@buildinternet/releases-api-types": "^0.32.0",
     "@buildinternet/releases-core": "^0.23.0",
     "@buildinternet/releases-lib": "workspace:*",
     "@buildinternet/releases-skills": "workspace:*",

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -57,6 +57,10 @@ import type {
   ReplaceCollectionMembersRequest,
   AddCollectionMemberRequest,
   SetOrgAvatarResponse,
+  Follow,
+  FollowTarget,
+  FollowsListResponse,
+  FollowMutationResponse,
 } from "@buildinternet/releases-api-types";
 export type {
   DomainLookupResponse,
@@ -428,6 +432,112 @@ export async function unsuppressRelease(releaseId: string): Promise<boolean> {
     method: "POST",
   });
   return result?.unsuppressed ?? false;
+}
+
+// ── User follows + personalized feed (`/v1/me/*`) ──
+//
+// These act on the signed-in user's own account. `apiFetch` forwards the stored
+// credential (a `relu_` user key from `releases login`, or `RELEASES_API_KEY`);
+// the API's `/v1/me/*` gate accepts that Bearer user principal. Callers should
+// check `isAuthenticated()` first so an unauthenticated user gets a "run
+// `releases login`" hint instead of a raw 401.
+
+/** A follow target resolved from a human identifier (slug / coordinate / id). */
+export interface ResolvedFollowTarget {
+  targetType: FollowTarget;
+  targetId: string;
+  /** Human label (name or slug) for confirmation messages. */
+  label: string;
+}
+
+const orgFollowTarget = (o: Organization): ResolvedFollowTarget => ({
+  targetType: "org",
+  targetId: o.id,
+  label: o.name ?? o.slug,
+});
+const productFollowTarget = (p: Product): ResolvedFollowTarget => ({
+  targetType: "product",
+  targetId: p.id,
+  label: p.name ?? p.slug,
+});
+
+/**
+ * Resolve a user-supplied identifier to a follow target. `org_…` / `prod_…` typed
+ * ids and `org/slug` coordinates resolve unambiguously; a bare term is tried as
+ * an org first (the common `releases follow vercel` case), then as a product.
+ * Returns null when nothing resolves.
+ */
+export async function resolveFollowTarget(
+  identifier: string,
+): Promise<ResolvedFollowTarget | null> {
+  const id = identifier.trim();
+  if (id.startsWith("org_")) {
+    const org = await findOrg(id);
+    return org ? orgFollowTarget(org) : null;
+  }
+  if (id.startsWith("prod_") || id.includes("/")) {
+    // Typed product id, or an `org/slug` coordinate → product.
+    const product = await findProduct(id);
+    return product ? productFollowTarget(product) : null;
+  }
+  // Bare term: prefer an org match, fall back to a product.
+  const org = await findOrg(id);
+  if (org) return orgFollowTarget(org);
+  const product = await findProduct(id);
+  return product ? productFollowTarget(product) : null;
+}
+
+/** List the signed-in user's follows, enriched + newest-first. */
+export async function listMyFollows(): Promise<Follow[]> {
+  const res = await apiFetch<FollowsListResponse | null>(`/v1/me/follows`);
+  return res?.follows ?? [];
+}
+
+/** Add a follow (idempotent — re-following is a 200 no-op vs a 201 fresh add). */
+export async function addFollow(
+  targetType: FollowTarget,
+  targetId: string,
+): Promise<FollowMutationResponse> {
+  return apiFetch<FollowMutationResponse>(`/v1/me/follows`, {
+    method: "POST",
+    body: JSON.stringify({ targetType, targetId }),
+  });
+}
+
+/** Remove a follow (idempotent — removing a non-follow is a no-op). */
+export async function removeFollow(
+  targetType: FollowTarget,
+  targetId: string,
+): Promise<FollowMutationResponse> {
+  return apiFetch<FollowMutationResponse>(
+    `/v1/me/follows/${targetType}/${encodeURIComponent(targetId)}`,
+    { method: "DELETE" },
+  );
+}
+
+/**
+ * The signed-in user's personalized release feed (org follow = its products
+ * too). Same per-item wire shape as `/v1/releases/latest`, so it reuses
+ * `toLatestRelease` and renders through the shared `renderReleaseRows` path that
+ * `tail` uses. Page/offset paginated; returns `hasMore` from the list envelope.
+ */
+export async function getMyFeed(opts?: {
+  page?: number;
+  limit?: number;
+}): Promise<{ releases: LatestRelease[]; hasMore: boolean }> {
+  const qs = new URLSearchParams();
+  if (opts?.page) qs.set("page", String(opts.page));
+  if (opts?.limit) qs.set("limit", String(opts.limit));
+  const suffix = qs.toString() ? `?${qs.toString()}` : "";
+  const data = await apiFetch<{
+    items: LatestReleaseWire[];
+    pagination?: { hasMore?: boolean };
+  } | null>(`/v1/me/feed${suffix}`);
+  if (!data) throw new Error("Personalized feed unavailable (unexpected 404 on /v1/me/feed).");
+  return {
+    releases: data.items.map(toLatestRelease),
+    hasMore: data.pagination?.hasMore ?? false,
+  };
 }
 
 // ── User roles (OAuth scope entitlement) ──

--- a/src/cli/commands/follows.ts
+++ b/src/cli/commands/follows.ts
@@ -1,0 +1,161 @@
+import { Command, InvalidArgumentError } from "commander";
+import chalk from "chalk";
+import type { Follow } from "@buildinternet/releases-api-types";
+import { isAuthenticated } from "../../lib/mode.js";
+import {
+  resolveFollowTarget,
+  listMyFollows,
+  addFollow,
+  removeFollow,
+  getMyFeed,
+} from "../../api/client.js";
+import { writeJson } from "../../lib/output.js";
+import { renderTable } from "../render/table.js";
+import { renderReleaseRows } from "../render/releases-table.js";
+
+/**
+ * Personalized follows + feed verbs (releases-cli#1520). These act on the
+ * signed-in user's own account, so they require an authenticated CLI — the
+ * stored `relu_` key from `releases login` (or `RELEASES_API_KEY`) rides along
+ * via `apiFetch`, and the API's `/v1/me/*` gate accepts that Bearer user
+ * principal. `follow`/`unfollow` resolve a human identifier (slug, `org/slug`
+ * coordinate, or `org_`/`prod_` id) to a target; `following` lists them; `feed`
+ * renders the personalized timeline using the same path as `releases tail`.
+ */
+
+/** Bail with a sign-in hint when no credential is configured. */
+function requireAuth(): void {
+  if (!isAuthenticated()) {
+    console.error(
+      chalk.red("Not signed in. Run `releases login` first (or set RELEASES_API_KEY)."),
+    );
+    process.exit(1);
+  }
+}
+
+/** Strict 1-based positive-integer parser for `--page` / `--limit`. */
+function parsePositiveInt(label: string, max: number) {
+  return (raw: string): number => {
+    const n = Number(raw);
+    if (!Number.isInteger(n) || n < 1 || n > max) {
+      throw new InvalidArgumentError(`${label} must be an integer between 1 and ${max}.`);
+    }
+    return n;
+  };
+}
+
+function targetNotFound(entity: string): never {
+  console.error(
+    chalk.red(
+      `Couldn't resolve '${entity}' to an organization or product.\n` +
+        "Pass an org slug, an `org/product` coordinate, or an `org_…` / `prod_…` id " +
+        "(find them with `releases search` or `releases list`).",
+    ),
+  );
+  process.exit(1);
+}
+
+export function registerFollowsCommands(program: Command): void {
+  program
+    .command("follow <entity>")
+    .description("Follow an organization or product (shows up in `releases feed`)")
+    .option("--json", "Output as JSON")
+    .action(async (entity: string, opts: { json?: boolean }) => {
+      requireAuth();
+      const target = await resolveFollowTarget(entity);
+      if (!target) targetNotFound(entity);
+      const res = await addFollow(target.targetType, target.targetId);
+      if (opts.json) {
+        await writeJson({ ...res, target });
+        return;
+      }
+      console.log(chalk.green(`Following ${target.label} (${target.targetType}).`));
+    });
+
+  program
+    .command("unfollow <entity>")
+    .description("Stop following an organization or product")
+    .option("--json", "Output as JSON")
+    .action(async (entity: string, opts: { json?: boolean }) => {
+      requireAuth();
+      const target = await resolveFollowTarget(entity);
+      if (!target) targetNotFound(entity);
+      const res = await removeFollow(target.targetType, target.targetId);
+      if (opts.json) {
+        await writeJson({ ...res, target });
+        return;
+      }
+      console.log(chalk.green(`Unfollowed ${target.label} (${target.targetType}).`));
+    });
+
+  program
+    .command("following")
+    .description("List the organizations and products you follow")
+    .option("--json", "Output as JSON")
+    .action(async (opts: { json?: boolean }) => {
+      requireAuth();
+      const follows = await listMyFollows();
+      if (opts.json) {
+        await writeJson({ follows });
+        return;
+      }
+      if (follows.length === 0) {
+        console.log(
+          chalk.yellow("You're not following anything yet. Use `releases follow <org|product>`."),
+        );
+        return;
+      }
+      console.log(
+        renderTable({
+          head: [
+            { label: "Name" },
+            { label: "Type", noTruncate: true },
+            { label: "Coordinate", noTruncate: true },
+            { label: "ID", noTruncate: true },
+          ],
+          rows: follows.map((f: Follow) => [
+            f.name,
+            f.targetType,
+            f.targetType === "product" && f.orgSlug ? `${f.orgSlug}/${f.slug}` : f.slug,
+            f.targetId,
+          ]),
+        }),
+      );
+    });
+
+  program
+    .command("feed")
+    .description("Your personalized release feed (from the orgs + products you follow)")
+    .option("--page <n>", "1-based page number (default 1)", parsePositiveInt("--page", 100_000))
+    .option(
+      "--limit <n>",
+      "Releases per page, 1–100 (default 30)",
+      parsePositiveInt("--limit", 100),
+    )
+    .option("--json", "Output as JSON")
+    .action(async (opts: { page?: number; limit?: number; json?: boolean }) => {
+      requireAuth();
+      const { releases, hasMore } = await getMyFeed({ page: opts.page, limit: opts.limit });
+      if (opts.json) {
+        await writeJson({ releases, pagination: { hasMore } });
+        return;
+      }
+      if (releases.length === 0) {
+        console.log(
+          chalk.yellow(
+            "No releases yet from the organizations and products you follow. " +
+              "Follow more with `releases follow <org|product>`.",
+          ),
+        );
+        return;
+      }
+      console.log(renderReleaseRows(releases, { mode: "feed" }));
+      if (hasMore) {
+        console.log(
+          chalk.dim(
+            `\nMore available — pass \`--page ${(opts.page ?? 1) + 1}\` for the next page.`,
+          ),
+        );
+      }
+    });
+}

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -59,6 +59,7 @@ import { preflightScopeWarning } from "../lib/preflight.js";
 import { registerAuthCommand } from "./commands/auth.js";
 import { registerLoginCommand } from "./commands/login.js";
 import { registerKeysCommand } from "./commands/keys.js";
+import { registerFollowsCommands } from "./commands/follows.js";
 import { VERSION } from "./version.js";
 import { writeJson } from "../lib/output.js";
 
@@ -240,6 +241,7 @@ registerWhoamiCommand(program);
 registerAuthCommand(program);
 registerLoginCommand(program);
 registerKeysCommand(program);
+registerFollowsCommands(program);
 registerAgentContextCommand(program);
 registerCompletionCommand(program);
 registerSkillsCommand(program);

--- a/tests/unit/follows.test.ts
+++ b/tests/unit/follows.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
+
+// Drive the real client via env (a top-level mock.module leaks across files —
+// see api-client.test.ts). Match request paths by suffix, not full URL, so the
+// process-wide getApiUrl() memoization can't poison assertions.
+const prevEnv: { url?: string; key?: string } = {};
+beforeAll(() => {
+  prevEnv.url = process.env.RELEASES_API_URL;
+  prevEnv.key = process.env.RELEASES_API_KEY;
+  process.env.RELEASES_API_URL = "https://test.example.com";
+  process.env.RELEASES_API_KEY = "test-key";
+});
+afterAll(() => {
+  if (prevEnv.url === undefined) delete process.env.RELEASES_API_URL;
+  else process.env.RELEASES_API_URL = prevEnv.url;
+  if (prevEnv.key === undefined) delete process.env.RELEASES_API_KEY;
+  else process.env.RELEASES_API_KEY = prevEnv.key;
+});
+
+const client = await import("../../src/api/client.js");
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+// Minimal org/product detail bodies (only id/slug/name are read by the resolver).
+const orgBody = (id: string, slug: string, name: string) => ({ id, slug, name });
+const productBody = (id: string, slug: string, name: string) => ({ id, slug, name });
+
+describe("follows client wire contract", () => {
+  let originalFetch: typeof globalThis.fetch;
+  let calls: Array<{ url: string; method: string; body: unknown }> = [];
+  // Per-call responder — reads the just-captured URL so multi-fetch flows
+  // (resolveFollowTarget) can return different shapes per path.
+  let responder: (url: string) => Response;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    calls = [];
+    responder = () => json({});
+    globalThis.fetch = (async (url: string, init?: RequestInit) => {
+      const u = String(url);
+      calls.push({
+        url: u,
+        method: init?.method ?? "GET",
+        body: init?.body ? JSON.parse(String(init.body)) : null,
+      });
+      return responder(u);
+    }) as unknown as typeof globalThis.fetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("addFollow POSTs /v1/me/follows with the target body", async () => {
+    responder = () => json({ success: true, following: true }, 201);
+    const res = await client.addFollow("org", "org_a");
+    expect(calls[0]!.method).toBe("POST");
+    expect(calls[0]!.url.endsWith("/v1/me/follows")).toBe(true);
+    expect(calls[0]!.body).toEqual({ targetType: "org", targetId: "org_a" });
+    expect(res).toEqual({ success: true, following: true });
+  });
+
+  it("removeFollow DELETEs /v1/me/follows/:type/:id", async () => {
+    responder = () => json({ success: true, following: false });
+    await client.removeFollow("product", "prod_w");
+    expect(calls[0]!.method).toBe("DELETE");
+    expect(calls[0]!.url.endsWith("/v1/me/follows/product/prod_w")).toBe(true);
+  });
+
+  it("listMyFollows GETs /v1/me/follows and unwraps the array", async () => {
+    responder = () =>
+      json({
+        follows: [
+          {
+            targetType: "org",
+            targetId: "org_a",
+            name: "Acme",
+            slug: "acme",
+            orgSlug: null,
+            createdAt: "2026-06-01T00:00:00Z",
+          },
+        ],
+      });
+    const follows = await client.listMyFollows();
+    expect(calls[0]!.method).toBe("GET");
+    expect(calls[0]!.url.endsWith("/v1/me/follows")).toBe(true);
+    expect(follows).toHaveLength(1);
+    expect(follows[0]).toMatchObject({ targetId: "org_a", name: "Acme" });
+  });
+
+  it("listMyFollows returns [] when the route 404s", async () => {
+    responder = () => json({ error: "not_found" }, 404);
+    expect(await client.listMyFollows()).toEqual([]);
+  });
+
+  it("getMyFeed forwards pagination and maps items to renderable rows", async () => {
+    responder = () =>
+      json({
+        items: [
+          {
+            id: "rel_1",
+            version: "1.2.0",
+            title: "v1.2.0",
+            summary: "Dark mode",
+            titleGenerated: null,
+            titleShort: "Dark mode",
+            publishedAt: "2026-06-01T00:00:00Z",
+            media: [],
+            source: { slug: "acme-blog", name: "Acme Blog", type: "feed" },
+            product: { slug: "widget", name: "Widget" },
+          },
+        ],
+        pagination: { hasMore: true },
+      });
+    const { releases, hasMore } = await client.getMyFeed({ page: 2, limit: 10 });
+    expect(calls[0]!.method).toBe("GET");
+    expect(calls[0]!.url).toContain("/v1/me/feed?");
+    expect(calls[0]!.url).toContain("page=2");
+    expect(calls[0]!.url).toContain("limit=10");
+    expect(hasMore).toBe(true);
+    expect(releases).toHaveLength(1);
+    // toLatestRelease flattens source → sourceName/sourceSlug for the renderer.
+    expect(releases[0]).toMatchObject({
+      id: "rel_1",
+      sourceName: "Acme Blog",
+      sourceSlug: "acme-blog",
+    });
+  });
+});
+
+describe("resolveFollowTarget", () => {
+  let originalFetch: typeof globalThis.fetch;
+  let responder: (url: string) => Response;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    responder = () => new Response(JSON.stringify({}), { status: 404 });
+    globalThis.fetch = (async (url: string) =>
+      responder(String(url))) as unknown as typeof globalThis.fetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("resolves an org_ id via the org route", async () => {
+    responder = (u) =>
+      u.includes("/v1/orgs/") ? json(orgBody("org_a", "acme", "Acme")) : json({}, 404);
+    const t = await client.resolveFollowTarget("org_a");
+    expect(t).toEqual({ targetType: "org", targetId: "org_a", label: "Acme" });
+  });
+
+  it("resolves a prod_ id via the product route", async () => {
+    responder = (u) =>
+      u.includes("/v1/products/prod_w")
+        ? json(productBody("prod_w", "widget", "Widget"))
+        : json({}, 404);
+    const t = await client.resolveFollowTarget("prod_w");
+    expect(t).toEqual({ targetType: "product", targetId: "prod_w", label: "Widget" });
+  });
+
+  it("resolves an org/slug coordinate to a product", async () => {
+    responder = (u) =>
+      u.includes("/v1/orgs/acme/products/widget")
+        ? json(productBody("prod_w", "widget", "Widget"))
+        : json({}, 404);
+    const t = await client.resolveFollowTarget("acme/widget");
+    expect(t).toEqual({ targetType: "product", targetId: "prod_w", label: "Widget" });
+  });
+
+  it("prefers an org for a bare term that matches an org", async () => {
+    responder = (u) =>
+      u.includes("/v1/orgs/vercel") ? json(orgBody("org_v", "vercel", "Vercel")) : json({}, 404);
+    const t = await client.resolveFollowTarget("vercel");
+    expect(t).toEqual({ targetType: "org", targetId: "org_v", label: "Vercel" });
+  });
+
+  it("returns null when nothing resolves", async () => {
+    // org route 404s; product slug-lookup 404s → null.
+    responder = () => new Response(JSON.stringify({ error: "not_found" }), { status: 404 });
+    expect(await client.resolveFollowTarget("nope-nothing")).toBeNull();
+  });
+});


### PR DESCRIPTION
The CLI half of releases#1520 (user follows + personalized feed). The API's `/v1/me/*` Bearer-user auth and the published `@buildinternet/releases-api-types@0.32.0` (the follows wire types) landed in the monorepo (releases#1525); this adds the four user-facing verbs.

## Commands

```bash
releases follow vercel              # org slug…
releases follow vercel/next-js      # …org/product coordinate…
releases follow prod_abc123         # …or a typed ID
releases following                  # list what you follow (table / --json)
releases feed                       # personalized release timeline
releases feed --limit 50 --page 2   # paginated (--json supported)
releases unfollow vercel
```

All four act on the **signed-in user's own account** — the stored `relu_` key from `releases login` (or `RELEASES_API_KEY`) rides along via `apiFetch`, which the `/v1/me/*` gate now accepts as a Bearer user principal. Unauthenticated → a "run `releases login`" hint, not a raw 401.

## How it works

- **`follow` / `unfollow`** resolve a human identifier to a target with `resolveFollowTarget`: `org_…` → org, `prod_…` / `org/slug` coordinate → product, and a **bare term prefers an org** (the common `releases follow vercel` case) before falling back to a product. Then POST / DELETE `/v1/me/follows`.
- **`following`** renders a table (name · type · coordinate · id) from `GET /v1/me/follows`.
- **`feed`** maps `GET /v1/me/feed` items through the **same `toLatestRelease` path as `releases tail`**, so the output and `--json` shape match the existing release reader. Page/offset paginated (`--page` / `--limit`); prints a "pass `--page N`" hint when more remain.

## Client + types

New functions in `src/api/client.ts`: `listMyFollows`, `addFollow`, `removeFollow`, `getMyFeed`, `resolveFollowTarget`. Bumps `@buildinternet/releases-api-types` `^0.31.0` → `^0.32.0`.

## Tests / checks

`tests/unit/follows.test.ts` — 10 wire-contract tests (the four endpoints + the five resolver cases), mirroring `user-roles.test.ts` (env-driven real client, suffix-matched paths to dodge the `getApiUrl` memoization). `typecheck`, `lint`, `format:check` all clean; adjacent client/command suites still green. README section + changeset added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)