### PR TITLE
chore: add .worktreeinclude for Claude Code worktree env copy

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,5 @@
+# Files copied from the main checkout into Claude Code worktrees on creation.
+# Uses .gitignore syntax; only matching files that are ALSO gitignored are
+# copied, so tracked files are never duplicated.
+# https://code.claude.com/docs/en/worktrees#copy-gitignored-files-into-worktrees
+.env


### PR DESCRIPTION
## What

Adds a root `.worktreeinclude` so [Claude Code worktrees](https://code.claude.com/docs/en/worktrees#copy-gitignored-files-into-worktrees) auto-copy `.env` from the main checkout on creation.

```
.env
```

`.worktreeinclude` uses `.gitignore` syntax; Claude copies any file that **both** matches a pattern **and** is gitignored, so tracked files (`.env.example`) are never duplicated. It fires for `--worktree`, `EnterWorktree`, subagent isolation, and desktop parallel sessions — no setup script needed.

Mirrors the same convention added to the [monorepo](https://github.com/buildinternet/releases/pull/1569).

🤖 Generated with [Claude Code](https://claude.com/claude-code)