### PR TITLE
fix: error when source fetch combines an identifier with --org

### DIFF
--- a/.changeset/fetch-org-identifier-conflict.md
+++ b/.changeset/fetch-org-identifier-conflict.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": patch
+---
+
+`releases admin source fetch` no longer silently drops a source identifier when combined with `--org` (#307). Previously `source fetch <identifier> --org <org>` ignored the identifier and dispatched a managed-agent session over every active source in the org; it now errors out on the conflict, matching `releases latest`'s `--product`/`--org` rejection. Passing both the positional identifier and `--source` is also rejected instead of silently preferring the positional. The `--org` fan-out additionally skips push-only `agent` sources — they have no fetch adapter, so dispatching a session over one was a wasted no-op — and reports how many were skipped.

--- a/skills/releases-cli/references/admin.md
+++ b/skills/releases-cli/references/admin.md
@@ -145,6 +145,7 @@ Notes:
 
 - Default cap is 200 releases per source (GitHub paginates at ~10K). `--max <n>` or `--all` to override.
 - Remote mode **requires** a filter or slug. Bare `releases admin source fetch` with no args is blocked to prevent accidental bulk work.
+- A source identifier can't be combined with `--org` — pass one source (`src_…`, `org/slug`, or `--source`) or use `--org` alone to fetch the whole org; the CLI errors on the conflict. `--org` skips push-only `agent` sources (they have no fetch adapter).
 - Remote concurrency defaults to 3, capped at 5. Duplicate source fetches are detected and blocked.
 - Smart fetch backoff: sources returning no changes back off exponentially (1h → 48h); error backoff caps at 72h.
 
@@ -225,7 +226,7 @@ releases admin org update vercel --category developer-tools
 releases admin org link vercel --platform github --handle vercel
 releases admin org tag add vercel react serverless
 releases admin org alias add anthropic claude.ai claude.com
-releases admin source fetch --org vercel                  # fetch all of an org's active sources
+releases admin source fetch --org vercel                  # fetch all of an org's active sources (skips push-only agent sources)
 releases admin org delete vercel                          # reversible tombstone soft-delete
 releases admin org delete vercel --hard --yes             # permanent purge + FK cascade
 ```

--- a/skills/releases-cli/references/admin.md
+++ b/skills/releases-cli/references/admin.md
@@ -130,20 +130,21 @@ Slug renames require `--confirm-slug-change` because they break existing web lin
 ### Fetch
 
 ```bash
-releases admin source fetch next-js              # one source
-releases admin source fetch --since 2025-01-01 --max 50
-releases admin source fetch --max 500            # override the 200/source default
-releases admin source fetch --all                # no date/count limits
+releases admin source fetch next-js              # one source (slug, src_… id, or org/slug)
+releases admin source fetch --org acme           # all of an org's active sources
 releases admin source fetch --stale 24           # only stale sources, with backoff
 releases admin source fetch --retry-errors       # retry sources whose last fetch failed
 releases admin source fetch --changed            # sources with upstream changes detected
-releases admin source fetch --unfetched --concurrency 5
-releases admin source fetch next-js --skip-changelog   # skip CHANGELOG.md refresh
+releases admin source fetch --unfetched          # never-fetched sources
+releases admin source fetch next-js --wait       # block until the dispatched session finishes
+releases admin source fetch next-js --dry-run    # probe without writing or billing
+releases admin source fetch next-js --local      # stage a local-ingest handoff (no managed agent)
 ```
 
 Notes:
 
-- Default cap is 200 releases per source (GitHub paginates at ~10K). `--max <n>` or `--all` to override.
+- The server caps each fetch at 200 releases per source (GitHub paginates at ~10K); there is no CLI override flag.
+- A fetch that inserts new releases also triggers a server-side fill pass over the source's missing AI titles/summaries (up to 100 rows) when the org has `auto_generate_content` enabled — no flag, no second step.
 - Remote mode **requires** a filter or slug. Bare `releases admin source fetch` with no args is blocked to prevent accidental bulk work.
 - A source identifier can't be combined with `--org` — pass one source (`src_…`, `org/slug`, or `--source`) or use `--org` alone to fetch the whole org; the CLI errors on the conflict. `--org` skips push-only `agent` sources (they have no fetch adapter).
 - Remote concurrency defaults to 3, capped at 5. Duplicate source fetches are detected and blocked.

--- a/src/cli/commands/fetch.ts
+++ b/src/cli/commands/fetch.ts
@@ -59,7 +59,7 @@ export function registerFetchCommand(program: Command) {
     .option("--retry-errors", "Only fetch sources whose last fetch was an error")
     .option(
       "--org <org>",
-      "Fetch all active sources for an organization (org_…, slug, domain, name, or handle)",
+      "Fetch all active sources for an organization (org_…, slug, domain, name, or handle); skips push-only agent sources and can't be combined with a source identifier",
     )
     .option(
       "--wait [seconds]",

--- a/src/cli/commands/fetch.ts
+++ b/src/cli/commands/fetch.ts
@@ -107,6 +107,13 @@ Examples:
       ) => {
         const identifier = slugArg ?? opts.source;
 
+        // The positional argument and --source are two spellings of the same
+        // thing — refuse both rather than silently preferring the positional.
+        if (slugArg && opts.source) {
+          logger.error("Pass one source — either the [identifier] argument or --source, not both.");
+          process.exit(1);
+        }
+
         // --local short-circuits the remote managed-agent path entirely: it stages
         // the local-ingest handoff (preflight + URL discovery + brief) and never
         // POSTs to /v1/workflows/update. Single-source only — the batch filters
@@ -128,6 +135,17 @@ Examples:
           logger.warn("--force only applies with --local; ignoring it for the remote fetch path.");
         }
 
+        // A single source identifier and --org are mutually exclusive — the
+        // org fan-out used to win silently, dropping the identifier and
+        // dispatching a managed-agent session over every active source in the
+        // org (#307). Mirrors `latest`'s --product/--org rejection.
+        if (identifier && opts.org) {
+          logger.error(
+            "A source identifier can't be combined with --org. Pass one source (src_…, org/slug, or --source), or use --org alone to fetch the whole org.",
+          );
+          process.exit(1);
+        }
+
         // Resolve --wait up front so a malformed value fails before we kick off a remote workflow.
         let waitSeconds: number | null = null;
         if (opts.wait !== undefined) {
@@ -146,15 +164,15 @@ Examples:
           const org = await findOrg(opts.org);
           if (!org) return orgNotFound(opts.org);
           orgId = org.id;
-          const activeSources = (await getSourcesByOrg(org.id)).filter(
-            (s) => !s.isHidden && s.fetchPriority !== "paused",
-          );
-          if (activeSources.length === 0) {
+          const { fetchable, skippedAgents } = selectOrgFetchSources(await getSourcesByOrg(org.id));
+          if (skippedAgents > 0)
+            logger.info(`Skipping ${skippedAgents} push-only agent source(s) (no fetch adapter)`);
+          if (fetchable.length === 0) {
             if (opts.json) await writeJsonLine({ sessionId: null, message: "No active sources" });
             else logger.info(`No active sources for ${org.name}.`);
             return;
           }
-          entries = activeSources.map((s) => ({ id: s.id, slug: s.slug }));
+          entries = fetchable.map((s) => ({ id: s.id, slug: s.slug }));
           label = `all sources for ${org.slug} (${entries.length})`;
         } else if (identifier) {
           const src = await findSource(identifier);
@@ -360,6 +378,21 @@ async function runDryRunProbe(identifier: string, opts: { json?: boolean }): Pro
   // Feed/GitHub/scrape-with-feed dry-run.
   const found = result.releasesFound ?? 0;
   logger.info(chalk.green(`${src.slug}: parsed ${found} candidate release(s) (no writes).`));
+}
+
+/**
+ * Select the org sources the `--org` fan-out should fetch: visible, unpaused,
+ * and not push-only. `agent` sources have no fetch adapter — releases are
+ * POSTed to them, never pulled — so dispatching a managed-agent session over
+ * one is a wasted no-op (#307). Hidden/paused sources were always excluded and
+ * don't count toward `skippedAgents`.
+ */
+export function selectOrgFetchSources<
+  T extends { isHidden?: boolean | null; fetchPriority?: string | null; type: string },
+>(sources: T[]): { fetchable: T[]; skippedAgents: number } {
+  const active = sources.filter((s) => !s.isHidden && s.fetchPriority !== "paused");
+  const fetchable = active.filter((s) => s.type !== "agent");
+  return { fetchable, skippedAgents: active.length - fetchable.length };
 }
 
 /** Strict integer parse — `parseInt("60abc")` returns 60, which would silently misuse `--wait 60s`. */

--- a/tests/cli/source-fetch-org-conflict.test.ts
+++ b/tests/cli/source-fetch-org-conflict.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "bun:test";
+import { runCli } from "../utils.js";
+import { selectOrgFetchSources } from "../../src/cli/commands/fetch.js";
+
+/**
+ * #307 — `source fetch <identifier> --org <org>` used to silently drop the
+ * positional identifier and fan out a managed-agent session over every active
+ * source in the org. The conflict must error out before any API call, in the
+ * same style as `latest`'s "--product can't be combined with a [source]
+ * argument or --org." rejection.
+ */
+describe("source fetch identifier/--org conflict (#307)", () => {
+  it("rejects a positional identifier combined with --org", () => {
+    const { exitCode, stderr } = runCli([
+      "admin",
+      "source",
+      "fetch",
+      "releases-cli",
+      "--org",
+      "releases-sh",
+    ]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("can't be combined with --org");
+  });
+
+  it("rejects --source combined with --org", () => {
+    const { exitCode, stderr } = runCli([
+      "admin",
+      "source",
+      "fetch",
+      "--source",
+      "releases-cli",
+      "--org",
+      "releases-sh",
+    ]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("can't be combined with --org");
+  });
+
+  it("rejects a positional identifier combined with --source", () => {
+    const { exitCode, stderr } = runCli([
+      "admin",
+      "source",
+      "fetch",
+      "releases-cli",
+      "--source",
+      "other-source",
+    ]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("not both");
+  });
+
+  it("keeps the --local-specific conflict message for --local + --org", () => {
+    const { exitCode, stderr } = runCli([
+      "admin",
+      "source",
+      "fetch",
+      "my-source",
+      "--local",
+      "--org",
+      "acme",
+    ]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("--local");
+    expect(stderr).toContain("--org");
+  });
+});
+
+/**
+ * #307 bonus — the `--org` fan-out must skip push-only `agent` sources (no
+ * fetch adapter; releases are POSTed to them, never pulled), alongside the
+ * existing hidden/paused exclusions.
+ */
+const src = (over: Partial<Parameters<typeof selectOrgFetchSources>[0][number]>) => ({
+  isHidden: false,
+  fetchPriority: "normal",
+  type: "scrape",
+  ...over,
+});
+
+describe("selectOrgFetchSources", () => {
+  it("excludes hidden and paused sources without counting them as agent skips", () => {
+    const { fetchable, skippedAgents } = selectOrgFetchSources([
+      src({}),
+      src({ isHidden: true }),
+      src({ fetchPriority: "paused" }),
+    ]);
+    expect(fetchable).toHaveLength(1);
+    expect(skippedAgents).toBe(0);
+  });
+
+  it("skips push-only agent sources and reports the count", () => {
+    const { fetchable, skippedAgents } = selectOrgFetchSources([
+      src({ type: "github" }),
+      src({ type: "agent" }),
+      src({ type: "feed" }),
+    ]);
+    expect(fetchable.map((s) => s.type)).toEqual(["github", "feed"]);
+    expect(skippedAgents).toBe(1);
+  });
+
+  it("does not count a hidden or paused agent source twice", () => {
+    const { fetchable, skippedAgents } = selectOrgFetchSources([
+      src({ type: "agent", isHidden: true }),
+      src({ type: "agent", fetchPriority: "paused" }),
+    ]);
+    expect(fetchable).toHaveLength(0);
+    expect(skippedAgents).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #307

## Problem

`releases admin source fetch <identifier> --org <org>` silently dropped the positional source identifier: the `--org` branch of the resolution chain runs first, so the command fanned out a managed-agent session over every active source in the org with no hint that the arguments conflicted. `releases latest` already rejects the analogous combination ("--product can't be combined with a [source] argument or --org.").

## Fix

- A source identifier (positional or `--source`) combined with `--org` now errors out before any API call, in the same `logger.error` + `exit(1)` style as `latest`:
  > A source identifier can't be combined with --org. Pass one source (src_…, org/slug, or --source), or use --org alone to fetch the whole org.
- Passing both the positional identifier and `--source` is rejected the same way instead of silently preferring the positional.
- The `--local`/`--dry-run` paths keep their existing, more specific `requireSingleSourceFlag` messages (checked first, unchanged).

## Bonus (from the issue)

The `--org` fan-out now skips push-only `agent` sources (e.g. `product-changelog`) — they have no fetch adapter (releases are POSTed to them, never pulled), so dispatching a managed-agent session over one was a wasted no-op. The skip is reported: `Skipping N push-only agent source(s) (no fetch adapter)`. Logic lives in an exported pure helper (`selectOrgFetchSources`) so it's unit-testable, following the `parseWaitSeconds` pattern; hidden/paused sources are excluded as before and don't count toward the skip total.

## Tests

`tests/cli/source-fetch-org-conflict.test.ts`:
- positional + `--org` errors
- `--source` + `--org` errors
- positional + `--source` errors
- `--local` + `--org` keeps the `--local`-specific message
- `selectOrgFetchSources` unit coverage (hidden/paused exclusion, agent skip + count, no double-counting)

`bun test` (910 pass), `bun run typecheck`, `bun run lint`, and `bun run format:check` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `releases admin source fetch` command now properly validates conflicting arguments, erroring when a source identifier is combined with `--org` or `--source`.
  * When using `--org`, push-only agent sources are now skipped and the count is reported.

* **Documentation**
  * Updated CLI documentation to clarify conflict handling and filtering behavior for the `releases admin source fetch --org` command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->