### PR TITLE
feat(admin): `source show` inspect verb + fix `source update --json` slug-ambiguity (#294, #295)

### DIFF
--- a/.changeset/source-show-and-by-id-update.md
+++ b/.changeset/source-show-and-by-id-update.md
@@ -1,0 +1,7 @@
+---
+"@buildinternet/releases": patch
+---
+
+Add `releases admin source show <src_…|org/slug|slug>` (alias `get`) to inspect a single source's config — type, fetch method, priority/paused state, last-fetch, and the metadata flags operators care about (render/crawl, feed URL, parse instructions, etc.). `--json` returns the source with parsed metadata instead of the raw JSON-in-JSON string. Previously the only way to read a source's config was to dump the whole org and filter the `sources` array by hand (#295).
+
+Fix `source update <src_…> --json`: the JSON-refresh step re-resolved the source by its bare slug, so updating a source whose slug collides across orgs (e.g. `release-notes`) threw `AmbiguousSourceError` _after_ the update had already applied — even though the source was addressed by an unambiguous `src_…` id. The refresh now resolves through the typed id (#294).

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -13,14 +13,7 @@ import {
   type ListResponse,
 } from "@buildinternet/releases-core/cli-contracts";
 import { isValidKind, KIND_VALUES, type Kind } from "@buildinternet/releases-core/kinds";
-
-function getFetchMethod(type: string, meta: Record<string, unknown> | null): string {
-  if (type === "github") return "github";
-  if (type === "feed") return "feed";
-  if (meta?.feedUrl) return "feed";
-  if (meta?.noFeedFound) return "ai";
-  return "-";
-}
+import { getFetchMethod } from "../../lib/source-display.js";
 
 function paginateExample(json: boolean): string {
   return `releases list${json ? " --json" : ""} --limit <n> --page <p>`;

--- a/src/cli/commands/source-show.ts
+++ b/src/cli/commands/source-show.ts
@@ -4,20 +4,8 @@ import { findSource } from "../../api/client.js";
 import { sourceNotFound } from "../suggest.js";
 import { stripAnsi } from "../../lib/sanitize.js";
 import { writeJson } from "../../lib/output.js";
+import { getFetchMethod } from "../../lib/source-display.js";
 import { parseMetadataObject } from "@buildinternet/releases-core/cli-contracts";
-
-/**
- * Derive the effective fetch method from the source type + discovered metadata.
- * Mirrors the same calc in `list.ts` so the inspect view and the list detail
- * agree on what a source actually fetches with.
- */
-function fetchMethod(type: string, meta: Record<string, unknown> | null): string {
-  if (type === "github") return "github";
-  if (type === "feed") return "feed";
-  if (meta?.feedUrl) return "feed";
-  if (meta?.noFeedFound) return "ai";
-  return "—";
-}
 
 /**
  * Well-known metadata keys surfaced (in this order) under "Fetch config" with
@@ -60,13 +48,13 @@ export async function showSourceAction(identifier: string, opts: ShowSourceOpts)
   if (!source) return sourceNotFound(identifier);
 
   const meta = parseMetadataObject(source.metadata);
-  const method = fetchMethod(source.type, meta);
+  const method = getFetchMethod(source.type, meta);
 
   if (opts.json) {
     // Return the parsed metadata object (not the raw JSON-in-JSON string) so
     // agents reading `--json` get structured fetch config without a second
     // JSON.parse, plus the derived `method`. Matches `list <source> --json`.
-    await writeJson({ ...source, method, metadata: meta ?? source.metadata });
+    await writeJson({ ...source, method, metadata: meta });
     return;
   }
 
@@ -91,7 +79,7 @@ export async function showSourceAction(identifier: string, opts: ShowSourceOpts)
   console.log(row("Type", source.type));
   if (s.kind) console.log(row("Kind", s.kind));
   console.log(row("URL", source.url));
-  console.log(row("Method", method));
+  console.log(row("Method", method === "-" ? null : method));
   console.log(row("Status", s.isHidden ? chalk.red("disabled") : chalk.green("active")));
   if (s.isPrimary) console.log(row("Primary", "yes"));
   const priority = s.fetchPriority ?? "normal";

--- a/src/cli/commands/source-show.ts
+++ b/src/cli/commands/source-show.ts
@@ -1,0 +1,155 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { findSource } from "../../api/client.js";
+import { sourceNotFound } from "../suggest.js";
+import { stripAnsi } from "../../lib/sanitize.js";
+import { writeJson } from "../../lib/output.js";
+import { parseMetadataObject } from "@buildinternet/releases-core/cli-contracts";
+
+/**
+ * Derive the effective fetch method from the source type + discovered metadata.
+ * Mirrors the same calc in `list.ts` so the inspect view and the list detail
+ * agree on what a source actually fetches with.
+ */
+function fetchMethod(type: string, meta: Record<string, unknown> | null): string {
+  if (type === "github") return "github";
+  if (type === "feed") return "feed";
+  if (meta?.feedUrl) return "feed";
+  if (meta?.noFeedFound) return "ai";
+  return "—";
+}
+
+/**
+ * Well-known metadata keys surfaced (in this order) under "Fetch config" with
+ * friendly labels. Anything left over is dumped generically afterwards so the
+ * view never silently hides a key an operator set.
+ */
+const KNOWN_META_LABELS: Array<[key: string, label: string]> = [
+  ["renderRequired", "Render required"],
+  ["crawlEnabled", "Crawl enabled"],
+  ["crawlIncludePathPrefix", "Crawl path prefix"],
+  ["firecrawl", "Firecrawl"],
+  ["feedUrl", "Feed URL"],
+  ["feedType", "Feed type"],
+  ["provider", "Provider"],
+  ["evaluatedMethod", "Evaluated method"],
+  ["githubUrl", "GitHub URL"],
+  ["markdownUrl", "Markdown URL"],
+  ["changelogPaths", "Changelog paths"],
+  ["categoryAllow", "Category allow"],
+  ["extractStrategy", "Extract strategy"],
+];
+
+/** Render one aligned `Label   value` row; dims a missing/empty value. */
+function row(label: string, value: string | null | undefined): string {
+  return `  ${chalk.bold(label.padEnd(18))} ${value && value.length > 0 ? value : chalk.dim("—")}`;
+}
+
+/** Stringify a metadata value compactly for a single-line row. */
+function fmtMetaValue(value: unknown): string {
+  if (Array.isArray(value)) return value.join(", ");
+  if (value === null) return "null";
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}
+
+export type ShowSourceOpts = { json?: boolean };
+
+export async function showSourceAction(identifier: string, opts: ShowSourceOpts): Promise<void> {
+  const source = await findSource(identifier);
+  if (!source) return sourceNotFound(identifier);
+
+  const meta = parseMetadataObject(source.metadata);
+  const method = fetchMethod(source.type, meta);
+
+  if (opts.json) {
+    // Return the parsed metadata object (not the raw JSON-in-JSON string) so
+    // agents reading `--json` get structured fetch config without a second
+    // JSON.parse, plus the derived `method`. Matches `list <source> --json`.
+    await writeJson({ ...source, method, metadata: meta ?? source.metadata });
+    return;
+  }
+
+  // Loose-read the enriched fields the API layers onto the source row (orgSlug,
+  // consecutiveErrors, …) that aren't on the narrow published Source type.
+  const s = source as typeof source & {
+    orgSlug?: string | null;
+    productId?: string | null;
+    consecutiveErrors?: number | null;
+    isHidden?: boolean | null;
+    isPrimary?: boolean | null;
+    kind?: string | null;
+    fetchPriority?: string | null;
+    lastFetchedAt?: string | null;
+  };
+
+  console.log(chalk.bold(`\n${stripAnsi(source.name)}`));
+  console.log(row("ID", source.id));
+  console.log(row("Slug", source.slug));
+  console.log(row("Org", s.orgSlug ?? s.orgId ?? null));
+  if (s.productId) console.log(row("Product", s.productId));
+  console.log(row("Type", source.type));
+  if (s.kind) console.log(row("Kind", s.kind));
+  console.log(row("URL", source.url));
+  console.log(row("Method", method));
+  console.log(row("Status", s.isHidden ? chalk.red("disabled") : chalk.green("active")));
+  if (s.isPrimary) console.log(row("Primary", "yes"));
+  const priority = s.fetchPriority ?? "normal";
+  console.log(row("Fetch priority", priority === "paused" ? chalk.yellow("paused") : priority));
+  if (s.consecutiveErrors && s.consecutiveErrors > 0) {
+    console.log(row("Errors", chalk.yellow(`${s.consecutiveErrors} consecutive`)));
+  }
+  console.log(row("Last fetched", s.lastFetchedAt ?? null));
+
+  // Fetch config — well-known metadata keys first (friendly labels), then any
+  // remaining keys generically. parseInstructions is handled separately below
+  // because it can be long.
+  if (meta) {
+    const shown = new Set<string>(["parseInstructions"]);
+    const configRows: string[] = [];
+    for (const [key, label] of KNOWN_META_LABELS) {
+      if (meta[key] === undefined) continue;
+      shown.add(key);
+      configRows.push(row(label, fmtMetaValue(meta[key])));
+    }
+    for (const [key, value] of Object.entries(meta)) {
+      if (shown.has(key) || value === undefined) continue;
+      configRows.push(row(key, fmtMetaValue(value)));
+    }
+    if (configRows.length > 0) {
+      console.log(`\n${chalk.dim("Fetch config")}`);
+      for (const r of configRows) console.log(r);
+    }
+
+    const parse = meta.parseInstructions;
+    if (typeof parse === "string" && parse.length > 0) {
+      console.log(`\n${chalk.dim(`Parse instructions (${parse.length} chars)`)}`);
+      const preview = parse.length > 280 ? `${parse.slice(0, 280)}…` : parse;
+      console.log(stripAnsi(preview));
+    }
+  }
+
+  console.log("");
+}
+
+export function registerShowSourceCommand(program: Command) {
+  program
+    .command("show")
+    // `get` is the verb operators reach for first (#295); keep it as an alias.
+    .alias("get")
+    .description("Inspect a single source's config (src_… id, org/slug coordinate, or slug)")
+    .argument("<identifier>", "Source ID (src_…), org/slug coordinate, or slug")
+    .option("--json", "Output the full source with parsed metadata as JSON")
+    .addHelpText(
+      "after",
+      `
+Examples:
+  releases admin source show src_abc123
+  releases admin source show vercel/next-js
+  releases admin source show src_abc123 --json
+
+A typed src_… id resolves unambiguously; a bare slug that collides across orgs
+(e.g. release-notes) errors with the org/slug + src_… disambiguators.`,
+    )
+    .action(showSourceAction);
+}

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -405,7 +405,12 @@ export async function updateSourceAction(
   const displaySlug = updated?.slug ?? source.slug;
 
   if (opts.json) {
-    const refreshed = await findSource(displaySlug);
+    // Refresh through the globally-unique typed id, never the (possibly
+    // colliding) bare slug. A slug like `release-notes` matches sources in many
+    // orgs, so `findSource(displaySlug)` would throw AmbiguousSourceError here —
+    // *after* the update already applied — even though the source was addressed
+    // by an unambiguous `src_…` id (#294).
+    const refreshed = await findSource(updated?.id ?? source.id);
     await writeJson(refreshed);
   } else {
     logger.info(chalk.green(`Updated ${source.name} (${displaySlug}):`));

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -9,6 +9,7 @@ import { registerUpdateCommand } from "./commands/update.js";
 import { registerRemoveCommand } from "./commands/remove.js";
 import { registerDeleteCommand } from "./commands/delete.js";
 import { registerListCommand } from "./commands/list.js";
+import { registerShowSourceCommand } from "./commands/source-show.js";
 import { registerFetchCommand } from "./commands/fetch.js";
 import { registerBackfillCommand, registerBackfillStatusCommand } from "./commands/backfill.js";
 import { registerReextractCommand } from "./commands/reextract.js";
@@ -267,6 +268,7 @@ const sourceAdmin = admin
   .description("Manage sources and source ingestion")
   .showSuggestionAfterError(true);
 registerListCommand(sourceAdmin);
+registerShowSourceCommand(sourceAdmin);
 // Canonical verbs: create, update, delete. Deprecated aliases: add, edit, remove (each emits a warning).
 registerCreateCommand(sourceAdmin);
 registerCreateAppStoreCommand(sourceAdmin);

--- a/src/lib/source-display.ts
+++ b/src/lib/source-display.ts
@@ -1,0 +1,17 @@
+/**
+ * Derive the effective fetch method (`github` / `feed` / `ai` / `-`) from a
+ * source's type and discovered metadata. Shared by the source list views
+ * (`list.ts`) and the single-source inspector (`source-show.ts`) so the two
+ * agree on what a source actually fetches with — they previously kept private
+ * copies that had already drifted on the no-method sentinel.
+ *
+ * Returns `"-"` when no method can be inferred; callers dim/relabel that
+ * sentinel as they see fit.
+ */
+export function getFetchMethod(type: string, meta: Record<string, unknown> | null): string {
+  if (type === "github") return "github";
+  if (type === "feed") return "feed";
+  if (meta?.feedUrl) return "feed";
+  if (meta?.noFeedFound) return "ai";
+  return "-";
+}

--- a/tests/unit/source-show.test.ts
+++ b/tests/unit/source-show.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
+import { stripAnsi } from "../../src/lib/sanitize.js";
+
+const prevEnv: { url?: string; key?: string } = {};
+beforeAll(() => {
+  prevEnv.url = process.env.RELEASES_API_URL;
+  prevEnv.key = process.env.RELEASES_API_KEY;
+  process.env.RELEASES_API_URL = "https://test.example.com";
+  process.env.RELEASES_API_KEY = "test-key";
+});
+afterAll(() => {
+  if (prevEnv.url === undefined) delete process.env.RELEASES_API_URL;
+  else process.env.RELEASES_API_URL = prevEnv.url;
+  if (prevEnv.key === undefined) delete process.env.RELEASES_API_KEY;
+  else process.env.RELEASES_API_KEY = prevEnv.key;
+});
+
+const { showSourceAction } = await import("../../src/cli/commands/source-show.js");
+
+/** A scrape source addressed by typed id, with rich fetch-config metadata. */
+const SOURCE = {
+  id: "src_abc",
+  name: "Release Notes",
+  slug: "release-notes",
+  type: "scrape",
+  url: "https://example.com/release-notes",
+  orgId: "org_1",
+  orgSlug: "example",
+  kind: "tool",
+  isPrimary: true,
+  isHidden: false,
+  fetchPriority: "paused",
+  lastFetchedAt: "2026-06-10T12:00:00Z",
+  metadata: JSON.stringify({
+    renderRequired: true,
+    crawlEnabled: true,
+    feedUrl: "https://example.com/feed.xml",
+    parseInstructions: "Only keep entries under the Changelog heading.",
+    customFlag: "kept",
+  }),
+};
+
+describe("admin source show (#295)", () => {
+  let originalFetch: typeof globalThis.fetch;
+  let originalWrite: typeof process.stdout.write;
+  let originalLog: typeof console.log;
+  let out: string;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    originalWrite = process.stdout.write;
+    originalLog = console.log;
+    out = "";
+    // The human view uses console.log; --json uses writeJson → stdout.write.
+    // Capture both so either path's output lands in `out`.
+    process.stdout.write = ((chunk: unknown) => {
+      out += typeof chunk === "string" ? chunk : String(chunk);
+      return true;
+    }) as typeof process.stdout.write;
+    console.log = (...args: unknown[]) => {
+      out += args.map(String).join(" ") + "\n";
+    };
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify(SOURCE), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })) as typeof globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    process.stdout.write = originalWrite;
+    console.log = originalLog;
+  });
+
+  it("human view surfaces the operator config the issue asks for", async () => {
+    await showSourceAction("src_abc", {});
+    const text = stripAnsi(out);
+    expect(text).toContain("src_abc"); // ID prominent
+    expect(text).toContain("Render required");
+    expect(text).toContain("Crawl enabled");
+    expect(text).toContain("Parse instructions");
+    expect(text).toContain("Only keep entries"); // preview body
+    expect(text).toContain("paused"); // fetch priority
+    expect(text).toContain("customFlag"); // unknown keys aren't hidden
+  });
+
+  it("--json returns metadata as a parsed object, not a JSON string", async () => {
+    await showSourceAction("src_abc", { json: true });
+    const parsed = JSON.parse(out);
+    expect(typeof parsed.metadata).toBe("object");
+    expect(parsed.metadata.renderRequired).toBe(true);
+    expect(parsed.metadata.crawlEnabled).toBe(true);
+    expect(parsed.method).toBe("feed"); // derived from feedUrl in metadata
+    expect(parsed.id).toBe("src_abc");
+  });
+});

--- a/tests/unit/source-update-json-refresh.test.ts
+++ b/tests/unit/source-update-json-refresh.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
+
+// Drive the real mode.ts via env (a top-level mock.module is process-global and
+// leaks into other files — see api-client.test.ts for the rationale). apiFetch
+// reads getApiUrl/getApiKey/isAdminMode lazily, so setting env before the
+// dynamic import reproduces admin mode against a fake host.
+const prevEnv: { url?: string; key?: string } = {};
+beforeAll(() => {
+  prevEnv.url = process.env.RELEASES_API_URL;
+  prevEnv.key = process.env.RELEASES_API_KEY;
+  process.env.RELEASES_API_URL = "https://test.example.com";
+  process.env.RELEASES_API_KEY = "test-key";
+});
+afterAll(() => {
+  if (prevEnv.url === undefined) delete process.env.RELEASES_API_URL;
+  else process.env.RELEASES_API_URL = prevEnv.url;
+  if (prevEnv.key === undefined) delete process.env.RELEASES_API_KEY;
+  else process.env.RELEASES_API_KEY = prevEnv.key;
+});
+
+const { updateSourceAction } = await import("../../src/cli/commands/update.js");
+
+/**
+ * Regression for #294: `source update <src_…> --render --json`.
+ *
+ * The source is addressed by a globally-unique `src_…` id, but its slug
+ * (`release-notes`) collides across 8 orgs. The JSON-refresh step used to call
+ * `findSource(displaySlug)` with the bare slug, which routes through the
+ * cross-org bare-slug resolver and throws `AmbiguousSourceError` — *after* the
+ * metadata PATCH already applied. The fix refreshes through the typed id, so
+ * the ambiguous slug-listing endpoint is never touched.
+ */
+describe("source update --json refresh resolves by typed id (#294)", () => {
+  let originalFetch: typeof globalThis.fetch;
+  let originalWrite: typeof process.stdout.write;
+  let requestedUrls: string[];
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    originalWrite = process.stdout.write;
+    requestedUrls = [];
+    // Silence the --json payload so the test output stays clean.
+    process.stdout.write = (() => true) as typeof process.stdout.write;
+
+    const source = {
+      id: "src_abc",
+      name: "Release Notes",
+      slug: "release-notes",
+      type: "scrape",
+      url: "https://example.com/release-notes",
+      orgId: "org_1",
+      metadata: "{}",
+    };
+
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const method = init?.method ?? "GET";
+      requestedUrls.push(`${method} ${url}`);
+
+      // The bare-slug listing endpoint returns *two* matches, so if anything
+      // routes a refresh through the slug it would throw AmbiguousSourceError.
+      if (url.includes("/v1/sources?slug=")) {
+        return new Response(
+          JSON.stringify([
+            { id: "src_abc", slug: "release-notes", orgSlug: "org-a" },
+            { id: "src_def", slug: "release-notes", orgSlug: "org-b" },
+          ]),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      // GET/PATCH /v1/sources/src_abc → the source row.
+      return new Response(JSON.stringify(source), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    process.stdout.write = originalWrite;
+  });
+
+  it("does not throw and never queries the ambiguous slug endpoint", async () => {
+    await expect(
+      updateSourceAction("src_abc", { render: true, json: true }),
+    ).resolves.toBeUndefined();
+
+    const hitSlugEndpoint = requestedUrls.some((u) => u.includes("/v1/sources?slug="));
+    expect(hitSlugEndpoint).toBe(false);
+
+    // The refresh GET went to the typed-id path.
+    const refreshById = requestedUrls.filter(
+      (u) => u === "GET https://test.example.com/v1/sources/src_abc",
+    );
+    expect(refreshById.length).toBeGreaterThanOrEqual(2); // initial findSource + json refresh
+  });
+});


### PR DESCRIPTION
Closes #295, closes #294. Both surfaced during the Harvey onboarding session.

## #295 — `releases admin source show <src_…|org/slug|slug>` (alias `get`)

There was no way to inspect a single source's config — the only path was `org get <org> --json` and filtering the `sources` array by hand, and operators reached for `source get`, which didn't exist. This adds a dedicated inspect verb under `admin source` (with `get` as an alias since that's the verb people try first).

The human view surfaces the operator config the issue named — render/crawl flags, fetch priority/`paused`, feed URL, **parse instructions** (with a char-count + preview), plus any other metadata keys generically so nothing is hidden. `--json` returns the source with **parsed** metadata (not the raw JSON-in-JSON string) plus the derived fetch `method`.

Real output against the source from #294:

```
Release Notes
  ID                 src_djFtfbJFwNTRq_dKhinln
  Slug               release-notes
  Org                org_c9DxFODr2PTTAf5l26y1l
  Type               scrape
  URL                https://help.harvey.ai/release-notes
  Status             active
  Primary            yes
  Fetch priority     normal

Fetch config
  Render required    true
  Crawl enabled      true
  lastCrawlJobId     431a684b-…
  lastCrawlAt        2026-06-11T01:01:03.079Z

Parse instructions (940 chars)
This is an index of individual, dated release-note entries; each card links to its own article page…
```

## #294 — `source update <src_…> --json` slug-ambiguity

The reported symptom: updating a source by its unique `src_…` id errored with `Source slug "release-notes" is ambiguous — it matches 8 sources across orgs`, yet the change still applied.

Root cause: the `--json` branch refreshed the source via `findSource(displaySlug)` using the **bare slug**. For a slug that collides across orgs, that routes through the cross-org bare-slug resolver and throws `AmbiguousSourceError` — **after** the metadata PATCH has already committed (hence "errors but still applies"). The boolean-flag theory in the issue was a red herring: `--render` and `--metadata-set` share the identical `updateSourceMeta(source, …)` path keyed on `source.id`; the divergence is purely whether `--json` triggers the slug-keyed refresh. The non-`--json` path was already safe via the `src_` short-circuit in `resolveSourceTarget`.

Fix: refresh through the typed id (`updated?.id ?? source.id`). `displaySlug` stays for the human-readable confirmation line only.

## Tests

- `source-update-json-refresh.test.ts` — drives `updateSourceAction("src_abc", { render: true, json: true })` against a mocked API where the slug-listing endpoint returns 2 matches; asserts it resolves without throwing and never queries `/v1/sources?slug=`. Fails on the pre-fix code (rejects with `AmbiguousSourceError`), passes after.
- `source-show.test.ts` — human view surfaces the config fields; `--json` returns metadata as a parsed object with the derived `method`.
- Full suite green (913 pass), `tsc --noEmit` clean, lint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)