### PR TITLE
fix(import): dedup org accounts on (platform, handle), not platform alone (#283)

### DIFF
--- a/.changeset/import-account-dedup-pair.md
+++ b/.changeset/import-account-dedup-pair.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": patch
+---
+
+`releases import` now dedups org accounts on the exact `(platform, handle)` pair instead of platform alone (#283). `org_accounts` is one-to-many — the server's unique index is on the pair — so an org can hold a second handle on a platform it's already linked to (e.g. Cloudflare's `x/Cloudflare` plus `x/cfchangelog`). Previously, importing a manifest that added a second handle on an already-linked platform was silently skipped, logging "already linked" for a handle that was never linked. The import now fetches the org's full account list and links any pair it doesn't already hold; an exact already-linked pair still reports "already linked" and is not re-created. The `--dry-run` preview mirrors the same dedup so it no longer over-reports accounts it would link.

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -360,13 +360,6 @@ export async function listOrgs(opts?: {
   return apiFetch<ListResponse<Organization>>(`/v1/orgs${qs ? `?${qs}` : ""}`);
 }
 
-export async function getOrgAccountByPlatform(
-  orgId: string,
-  platform: string,
-): Promise<OrgAccount | null> {
-  return apiFetch<OrgAccount | null>(`/v1/orgs/${orgId}/accounts?platform=${platform}`);
-}
-
 // ── Ignored URLs (org-scoped) ──
 
 export async function findIgnoredUrl(url: string, orgId: string): Promise<IgnoredUrl | null> {

--- a/src/cli/commands/import.ts
+++ b/src/cli/commands/import.ts
@@ -43,10 +43,11 @@ export function partitionAccounts(
   const toLink: ManifestAccount[] = [];
   const alreadyLinked: ManifestAccount[] = [];
   for (const acc of desired) {
-    if (seen.has(accountKey(acc))) {
+    const key = accountKey(acc);
+    if (seen.has(key)) {
       alreadyLinked.push(acc);
     } else {
-      seen.add(accountKey(acc));
+      seen.add(key);
       toLink.push(acc);
     }
   }

--- a/src/cli/commands/import.ts
+++ b/src/cli/commands/import.ts
@@ -10,7 +10,7 @@ import {
   findOrg,
   createOrg,
   findSourcesByUrls,
-  getOrgAccountByPlatform,
+  getOrgAccountsBySlug,
   linkOrgAccount,
   createSource,
   findProduct,
@@ -23,6 +23,37 @@ interface ManifestAccount {
   platform: string;
   handle: string;
 }
+
+/**
+ * Split desired org accounts into the ones to link vs. the ones already linked,
+ * keying on the exact `(platform, handle)` pair — not platform alone (#283).
+ *
+ * `org_accounts` is one-to-many (the server's unique index is on the pair, and
+ * the DELETE route keys on it too), so an org can hold a second handle on a
+ * platform it's already linked to. Keying on platform alone silently skipped
+ * that second handle. Matching is case-sensitive to mirror the server's index.
+ * A pair listed twice in one manifest links once, then reports the rest as
+ * already linked.
+ */
+export function partitionAccounts(
+  existing: Array<{ platform: string; handle: string }>,
+  desired: Array<{ platform: string; handle: string }>,
+): { toLink: ManifestAccount[]; alreadyLinked: ManifestAccount[] } {
+  const seen = new Set(existing.map(accountKey));
+  const toLink: ManifestAccount[] = [];
+  const alreadyLinked: ManifestAccount[] = [];
+  for (const acc of desired) {
+    if (seen.has(accountKey(acc))) {
+      alreadyLinked.push(acc);
+    } else {
+      seen.add(accountKey(acc));
+      toLink.push(acc);
+    }
+  }
+  return { toLink, alreadyLinked };
+}
+
+const accountKey = (a: { platform: string; handle: string }) => `${a.platform}/${a.handle}`;
 
 interface ManifestSource {
   name: string;
@@ -228,7 +259,21 @@ Examples:
               }
 
               if (orgEntry.accounts) {
-                for (const acc of orgEntry.accounts) {
+                // Mirror the apply-path dedup so the preview is honest about a
+                // second handle on an already-linked platform (#283). A to-be-
+                // created org has no accounts yet, so everything would link.
+                // eslint-disable-next-line no-await-in-loop
+                const linked = existing ? await getOrgAccountsBySlug(orgSlug) : [];
+                const { toLink, alreadyLinked } = partitionAccounts(linked, orgEntry.accounts);
+                for (const acc of alreadyLinked) {
+                  if (!opts.json)
+                    logger.info(
+                      chalk.yellow(
+                        `[dry-run] Account already linked: ${acc.platform}/${acc.handle}`,
+                      ),
+                    );
+                }
+                for (const acc of toLink) {
                   if (!opts.json)
                     logger.info(
                       chalk.green(
@@ -325,28 +370,30 @@ Examples:
             }
 
             if (orgEntry.accounts) {
-              for (const acc of orgEntry.accounts) {
-                // eslint-disable-next-line no-await-in-loop
-                const existing = await getOrgAccountByPlatform(org.id, acc.platform);
-                if (existing) {
+              // Dedup on the exact (platform, handle) pair (#283): an org can
+              // hold a second handle on a platform it's already linked to.
+              // eslint-disable-next-line no-await-in-loop
+              const linked = await getOrgAccountsBySlug(org.slug);
+              const { toLink, alreadyLinked } = partitionAccounts(linked, orgEntry.accounts);
+              for (const acc of alreadyLinked) {
+                if (!opts.json)
+                  logger.info(
+                    chalk.yellow(`Account already linked: ${acc.platform}/${acc.handle}`),
+                  );
+              }
+              for (const acc of toLink) {
+                try {
+                  // eslint-disable-next-line no-await-in-loop
+                  await linkOrgAccount(org.slug, acc.platform, acc.handle);
+                  report.created.accounts++;
                   if (!opts.json)
                     logger.info(
-                      chalk.yellow(`Account already linked: ${acc.platform}/${acc.handle}`),
+                      chalk.green(`Linked account: ${acc.platform}/${acc.handle} -> ${org.slug}`),
                     );
-                } else {
-                  try {
-                    // eslint-disable-next-line no-await-in-loop
-                    await linkOrgAccount(org.slug, acc.platform, acc.handle);
-                    report.created.accounts++;
-                    if (!opts.json)
-                      logger.info(
-                        chalk.green(`Linked account: ${acc.platform}/${acc.handle} -> ${org.slug}`),
-                      );
-                  } catch (err) {
-                    const msg = `Failed to link account ${acc.platform}/${acc.handle}: ${err instanceof Error ? err.message : String(err)}`;
-                    report.errors.push(msg);
-                    if (!opts.json) logger.error(chalk.red(msg));
-                  }
+                } catch (err) {
+                  const msg = `Failed to link account ${acc.platform}/${acc.handle}: ${err instanceof Error ? err.message : String(err)}`;
+                  report.errors.push(msg);
+                  if (!opts.json) logger.error(chalk.red(msg));
                 }
               }
             }

--- a/tests/unit/import-account-dedup.test.ts
+++ b/tests/unit/import-account-dedup.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "bun:test";
+import { partitionAccounts } from "../../src/cli/commands/import.js";
+
+// #283: import must dedup org accounts on (platform, handle), not platform
+// alone — org_accounts is one-to-many (the server unique index is on the pair),
+// so an org can hold a second handle on a platform it's already linked to.
+describe("partitionAccounts (#283)", () => {
+  it("links a new handle on an already-linked platform", () => {
+    const existing = [{ platform: "x", handle: "Cloudflare" }];
+    const desired = [{ platform: "x", handle: "cfchangelog" }];
+    const { toLink, alreadyLinked } = partitionAccounts(existing, desired);
+    expect(toLink).toEqual([{ platform: "x", handle: "cfchangelog" }]);
+    expect(alreadyLinked).toEqual([]);
+  });
+
+  it("reports an exact (platform, handle) pair as already linked", () => {
+    const existing = [{ platform: "x", handle: "Cloudflare" }];
+    const desired = [{ platform: "x", handle: "Cloudflare" }];
+    const { toLink, alreadyLinked } = partitionAccounts(existing, desired);
+    expect(toLink).toEqual([]);
+    expect(alreadyLinked).toEqual([{ platform: "x", handle: "Cloudflare" }]);
+  });
+
+  it("handle match is case-sensitive (mirrors the server unique index)", () => {
+    const existing = [{ platform: "x", handle: "Cloudflare" }];
+    const desired = [{ platform: "x", handle: "cloudflare" }];
+    const { toLink } = partitionAccounts(existing, desired);
+    expect(toLink).toEqual([{ platform: "x", handle: "cloudflare" }]);
+  });
+
+  it("dedups a pair listed twice in the same manifest", () => {
+    const existing: Array<{ platform: string; handle: string }> = [];
+    const desired = [
+      { platform: "x", handle: "acme" },
+      { platform: "x", handle: "acme" },
+    ];
+    const { toLink, alreadyLinked } = partitionAccounts(existing, desired);
+    expect(toLink).toEqual([{ platform: "x", handle: "acme" }]);
+    expect(alreadyLinked).toEqual([{ platform: "x", handle: "acme" }]);
+  });
+
+  it("links every account when the org has none", () => {
+    const desired = [
+      { platform: "x", handle: "acme" },
+      { platform: "github", handle: "acme" },
+    ];
+    const { toLink, alreadyLinked } = partitionAccounts([], desired);
+    expect(toLink).toEqual(desired);
+    expect(alreadyLinked).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

`releases import` deduped org accounts by **platform only**, not `(platform, handle)`. Because `org_accounts` is one-to-many (the server's unique index is on the pair, and the DELETE route keys on it too), an org can hold a second handle on a platform it's already linked to — e.g. Cloudflare's `x/Cloudflare` + `x/cfchangelog`. Importing a manifest that added the second handle was silently skipped, logging `Account already linked: x/cfchangelog` for a handle that was never linked. With the server-side `?platform=` fix (buildinternet/releases#1452) returning the oldest-linked account deterministically, the pre-check would see the *other* handle and skip.

Fixes #283.

## Approach (fix option 1 — check the exact pair)

- New pure, unit-tested `partitionAccounts(existing, desired)` in `import.ts` splits desired accounts into to-link vs. already-linked by the exact `(platform, handle)` pair. Case-sensitive (mirrors the server's unique index); a pair listed twice in one manifest links once, then reports the rest as already linked.
- The apply path fetches the org's full account list via `getOrgAccountsBySlug` (already existed) and links any pair it doesn't already hold.
- The `--dry-run` preview mirrors the same dedup so it no longer over-reports accounts it would link (a to-be-created org has no accounts; an existing org's list is consulted).
- Removes the now-unused, structurally-limited `getOrgAccountByPlatform` client helper — it returned a single `OrgAccount | null` per platform and couldn't represent "handle A but not handle B on platform X" (the root of the bug). It had no other callers.

## Acceptance

- [x] Importing a manifest that adds a new handle on an already-linked platform links the new handle.
- [x] Importing an already-linked `(platform, handle)` still reports "already linked" and does not error/duplicate.

## Testing

- New `tests/unit/import-account-dedup.test.ts` (5 cases: new handle on linked platform, exact-pair dedup, case sensitivity, same-manifest dup, empty org).
- `bun test` — 918 pass. `tsc --noEmit`, `oxlint`, `prettier --check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)