### PR TITLE
feat(cli): account nudge on the signed-out landing screen

### DIFF
--- a/.changeset/light-pugs-clap.md
+++ b/.changeset/light-pugs-clap.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": patch
+---
+
+Show a one-line account nudge ("Create a free account for personalized feeds and higher rate limits — run `releases login`") on the bare `releases` landing screen when no credential is configured. TTY-only and self-resolving once signed in, mirroring the completion notice.

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -116,6 +116,18 @@ function styledCompletionNotice(): string | null {
   return notice ? chalk.dim(notice) : null;
 }
 
+// One-line account nudge for the curated landing screen, or null when a
+// credential is already configured or output isn't a TTY (piped/scripted
+// output stays clean — agents and CI never see it). Mirrors the completion
+// notice: passive, dim, self-resolving once the user signs in.
+function signedOutAccountNotice(): string | null {
+  if (!process.stdout.isTTY) return null;
+  if (isAuthenticated()) return null;
+  return chalk.dim(
+    `Create a free account for personalized feeds and higher rate limits — run ${chalk.white('"releases login"')}.`,
+  );
+}
+
 function printStyledHelp(): string {
   const lines: string[] = [];
 
@@ -160,6 +172,12 @@ function printStyledHelp(): string {
       `Run ${chalk.white('"releases --help"')} to see all commands, or ${chalk.white('"releases <command> --help"')} for details on one.`,
     ),
   );
+
+  const accountNotice = signedOutAccountNotice();
+  if (accountNotice) {
+    lines.push("");
+    lines.push(accountNotice);
+  }
 
   const notice = styledCompletionNotice();
   if (notice) {


### PR DESCRIPTION
## Summary

Adds a one-line account nudge to the bare `releases` landing screen when the user has no credential configured:

> Create a free account for personalized feeds and higher rate limits — run `"releases login"`.

Companion to the web home-page CTA under the CLI demo (monorepo PR).

## Behavior

- Rendered dim, as the last footnote on the curated landing (above the completion notice when both show).
- **TTY-only** — piped/scripted output, agents, and CI never see it.
- **Self-resolving** — hidden as soon as any credential resolves (`RELEASES_API_KEY` env or the stored `releases login` credential), same posture as the persistent completion notice.
- Landing screen only; `--help` output is untouched.

## Testing

- `npx tsc --noEmit` clean
- `bun test` — 918 pass
- Smoke-tested under a pseudo-TTY: notice shows with no credential, hidden when `RELEASES_API_KEY` resolves (including via `.env` autoload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
