### PR TITLE
feat: dogfood releases.json — map this repo to the cli product

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://releases.sh/schemas/releases.json",
+  "product": {
+    "name": "CLI",
+    "slug": "cli",
+    "description": "The Releases command-line interface — search, inspect, and manage the changelog registry from your terminal.",
+    "category": "developer-tools",
+    "kind": "tool"
+  }
+}

--- a/tests/unit/releases-json.test.ts
+++ b/tests/unit/releases-json.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { ReleasesJsonConfigSchema } from "@buildinternet/releases-api-types";
+
+// This repo dogfoods the owner-declared listing standard documented at
+// https://releases.sh/docs/listing: the repo-root releases.json maps this
+// source to the `cli` product, and the daily well-known sweep reads it from
+// GitHub. Keep it schema-valid so it can't silently drift.
+describe("releases.json (repo-root product mapping)", () => {
+  const raw = readFileSync(join(import.meta.dir, "..", "..", "releases.json"), "utf8");
+
+  it("is valid JSON and conforms to the published releases.json schema", () => {
+    const parsed = JSON.parse(raw);
+    expect(() => ReleasesJsonConfigSchema.parse(parsed)).not.toThrow();
+  });
+
+  it("declares the cli product", () => {
+    const parsed = ReleasesJsonConfigSchema.parse(JSON.parse(raw));
+    expect(parsed.$schema).toBe("https://releases.sh/schemas/releases.json");
+    expect(parsed.product?.slug).toBe("cli");
+  });
+});


### PR DESCRIPTION
## What

Dogfoods the owner-declared listing standard documented at [releases.sh/docs/listing](https://releases.sh/docs/listing): adds a repo-root `releases.json` that maps this repo's source to the `cli` product.

The daily well-known sweep reads `releases.json` from a repo root and applies the `product` block (fill-if-empty), grouping the source under one product. Since this repo *is* the Releases CLI source in the registry, it's the natural place to demonstrate the repo-scope half of the standard.

## Changes

- `releases.json` (repo root) — `product` block: `name` "CLI", `slug` `cli`, `kind` `tool`, `developer-tools` category, matching the existing registry product. `$schema`-pointed at the published schema so editors validate it.
- `tests/unit/releases-json.test.ts` — parses the file with the published `ReleasesJsonConfigSchema` (from `@buildinternet/releases-api-types`) so it can't drift out of spec.

The root package is `private: true`, so this file isn't part of any published npm tarball — it exists for the GitHub-hosted sweep to read.

## Verification

- `bun test tests/unit/releases-json.test.ts` — 2 pass.
- `bun run typecheck` clean; `prettier --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
