### PR TITLE
feat(admin): bulk release delete and suppress (#1654)

### DIFF
--- a/.changeset/batch-release-crud.md
+++ b/.changeset/batch-release-crud.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": minor
+---
+
+Add bulk release delete and suppress to `releases admin release`. Multiple positional `rel_…` IDs or `--file` (one ID per line, `-` for stdin) route through `DELETE /v1/releases/batch` and `POST /v1/releases/batch-suppress`; a single ID keeps the existing per-row endpoints. `scripts/bulk-suppress.ts` now uses the batch API grouped by reason instead of one HTTP call per release. Pairs with buildinternet/releases#1654.

--- a/scripts/bulk-suppress.ts
+++ b/scripts/bulk-suppress.ts
@@ -1,20 +1,19 @@
 #!/usr/bin/env bun
 // One-off operator script: bulk-suppress releases listed as NDJSON on stdin.
 // Each line: {"id": "rel_…", "reason": "…"}.
-// Runs with bounded concurrency to be polite to the API.
 //
 // Usage:
-//   cat suppressions.ndjson | bun scripts/bulk-suppress.ts [--concurrency 8]
+//   cat suppressions.ndjson | bun scripts/bulk-suppress.ts [--chunk 500]
 
-import { suppressRelease } from "../src/api/releases.ts";
+import { batchSuppressReleases } from "../src/api/releases.ts";
 
-const CONCURRENCY = (() => {
-  const idx = process.argv.indexOf("--concurrency");
+const CHUNK = (() => {
+  const idx = process.argv.indexOf("--chunk");
   if (idx !== -1 && process.argv[idx + 1]) {
     const n = Number(process.argv[idx + 1]);
-    if (Number.isFinite(n) && n > 0 && n <= 32) return n;
+    if (Number.isFinite(n) && n > 0 && n <= 5000) return Math.floor(n);
   }
-  return 8;
+  return 500;
 })();
 
 const stdin = await new Response(Bun.stdin.stream()).text();
@@ -23,36 +22,38 @@ const rows = stdin
   .filter((l) => l.trim())
   .map((l) => JSON.parse(l) as { id: string; reason?: string });
 
-console.error(`Suppressing ${rows.length} releases (concurrency=${CONCURRENCY})…`);
+console.error(`Suppressing ${rows.length} releases (chunk=${CHUNK})…`);
 
-let ok = 0;
-let fail = 0;
-const errors: Array<{ id: string; err: string }> = [];
+const byReason = new Map<string | undefined, string[]>();
+for (const row of rows) {
+  const list = byReason.get(row.reason) ?? [];
+  list.push(row.id);
+  byReason.set(row.reason, list);
+}
 
-async function worker(queue: typeof rows) {
-  while (queue.length > 0) {
-    const row = queue.shift();
-    if (!row) break;
+let updated = 0;
+const errors: Array<{ ids: string[]; err: string }> = [];
+
+for (const [reason, ids] of byReason) {
+  for (let i = 0; i < ids.length; i += CHUNK) {
+    const slice = ids.slice(i, i + CHUNK);
     try {
-      // oxlint-disable-next-line no-await-in-loop -- worker drains shared queue; concurrency comes from running N workers in parallel
-      await suppressRelease(row.id, row.reason);
-      ok++;
+      // oxlint-disable-next-line no-await-in-loop -- bounded chunk writes under API bind budget
+      const result = await batchSuppressReleases(slice, true, reason);
+      updated += result.updated;
     } catch (err) {
-      fail++;
-      errors.push({ id: row.id, err: err instanceof Error ? err.message : String(err) });
-    }
-    if ((ok + fail) % 25 === 0) {
-      console.error(`  progress: ok=${ok} fail=${fail}`);
+      errors.push({
+        ids: slice,
+        err: err instanceof Error ? err.message : String(err),
+      });
     }
   }
 }
 
-const queue = [...rows];
-await Promise.all(Array.from({ length: CONCURRENCY }, () => worker(queue)));
-
-console.error(`DONE. ok=${ok} fail=${fail}`);
+console.error(`DONE. updated=${updated} requested=${rows.length} errors=${errors.length}`);
 if (errors.length) {
-  console.error("Errors (first 5):");
-  for (const e of errors.slice(0, 5)) console.error(`  ${e.id}: ${e.err}`);
+  console.error("Errors (first chunk):");
+  const e = errors[0];
+  console.error(`  ${e.ids.length} ids: ${e.err}`);
 }
-process.exit(fail > 0 ? 1 : 0);
+process.exit(errors.length > 0 ? 1 : 0);

--- a/skills/releases-cli/references/admin.md
+++ b/skills/releases-cli/references/admin.md
@@ -264,8 +264,13 @@ releases admin product adopt nextjs --into vercel   # convert an org into a prod
 releases admin release get rel_abc123
 releases admin release update rel_abc123 --title "Fixed title" --version "v2.0.1"
 releases admin release delete rel_abc123
+releases admin release delete rel_a rel_b rel_c              # bulk hard-delete
+releases admin release delete --file ids.txt                 # one rel_… per line (- for stdin)
 releases admin release suppress rel_abc123 --reason "promotional content"
+releases admin release suppress rel_a rel_b --reason "noise"   # bulk suppress
+releases admin release suppress --file ids.txt --reason spam
 releases admin release unsuppress rel_abc123
+releases admin release unsuppress rel_a rel_b                # bulk unsuppress
 ```
 
 Suppressed releases are hidden from all read paths (search, latest, stats, API) but preserved for audit.

--- a/src/api/releases.ts
+++ b/src/api/releases.ts
@@ -51,6 +51,24 @@ export async function unsuppressRelease(releaseId: string): Promise<boolean> {
   return result?.unsuppressed ?? false;
 }
 
+export async function deleteReleasesBatch(releaseIds: string[]): Promise<{ deleted: number }> {
+  return apiFetch<{ deleted: number }>(`/v1/releases/batch`, {
+    method: "DELETE",
+    body: JSON.stringify({ releaseIds }),
+  });
+}
+
+export async function batchSuppressReleases(
+  releaseIds: string[],
+  suppressed: boolean,
+  reason?: string,
+): Promise<{ updated: number }> {
+  return apiFetch<{ updated: number }>(`/v1/releases/batch-suppress`, {
+    method: "POST",
+    body: JSON.stringify({ releaseIds, suppressed, ...(reason !== undefined ? { reason } : {}) }),
+  });
+}
+
 // ── Latest releases ──
 
 export async function getLatestReleases(opts: {

--- a/src/cli/commands/agent-context.ts
+++ b/src/cli/commands/agent-context.ts
@@ -60,6 +60,10 @@ const STDIN_FLAGS: Array<{ pathSuffix: string[]; flagName: string }> = [
   { pathSuffix: ["overview", "update"], flagName: "--content-file" },
   // releases admin overview-write --content-file <path> (deprecated alias)
   { pathSuffix: ["overview-write"], flagName: "--content-file" },
+  // releases admin release {delete,suppress,unsuppress} --file <path>
+  { pathSuffix: ["delete"], flagName: "--file" },
+  { pathSuffix: ["suppress"], flagName: "--file" },
+  { pathSuffix: ["unsuppress"], flagName: "--file" },
 ];
 
 // ---------------------------------------------------------------------------

--- a/src/cli/commands/release.ts
+++ b/src/cli/commands/release.ts
@@ -6,6 +6,8 @@ import {
   unsuppressRelease,
   getRelease,
   deleteRelease,
+  deleteReleasesBatch,
+  batchSuppressReleases,
   updateRelease,
   deleteReleasesForSource,
 } from "../../api/releases.js";
@@ -13,9 +15,36 @@ import { findSource } from "../../api/sources.js";
 import { stripAnsi } from "../../lib/sanitize.js";
 import { humanDate } from "../../lib/release-display.js";
 import { normalizeReleaseId } from "@buildinternet/releases-core/id";
+import { readContentArg } from "../../lib/input.js";
 import { writeJson, writeJsonLine } from "../../lib/output.js";
 import { warnDeprecatedAlias } from "../../lib/deprecated-alias.js";
 import { logger } from "@releases/lib/logger";
+
+async function collectReleaseIds(positional: string[], file?: string): Promise<string[]> {
+  if (file && positional.length > 0) {
+    console.error("Error: pass release IDs as arguments or --file, not both\n");
+    process.exit(1);
+  }
+
+  const ids: string[] = [];
+  for (const raw of positional) ids.push(normalizeReleaseId(raw));
+
+  if (file) {
+    const raw = await readContentArg(file);
+    for (const line of raw.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+      ids.push(normalizeReleaseId(trimmed));
+    }
+  }
+
+  const unique = [...new Set(ids)];
+  if (unique.length === 0) {
+    console.error("Error: provide at least one release ID, or --file\n");
+    process.exit(1);
+  }
+  return unique;
+}
 
 function releaseNotFound(id: string): never {
   console.error(chalk.red(`Release not found: ${id}`));
@@ -181,8 +210,9 @@ export function registerReleaseCommand(program: Command) {
 
   release
     .command("delete")
-    .description("Delete a release by ID, or all releases for a source")
-    .argument("[id]", "Release ID to delete")
+    .description("Delete release(s) by ID, or all releases for a source")
+    .argument("[ids...]", "Release ID(s) to delete (rel_…)")
+    .option("--file <path>", "File with one release ID per line (use - for stdin)")
     .option("--source <identifier>", "Delete all releases for a source (src_… or slug)")
     .option(
       "--hard",
@@ -192,12 +222,21 @@ export function registerReleaseCommand(program: Command) {
     .option("--json", "Output as JSON")
     .action(
       async (
-        rawId: string | undefined,
-        opts: { source?: string; hard?: boolean; json?: boolean; dryRun?: boolean },
+        rawIds: string[],
+        opts: {
+          file?: string;
+          source?: string;
+          hard?: boolean;
+          json?: boolean;
+          dryRun?: boolean;
+        },
       ) => {
-        const id = rawId ? normalizeReleaseId(rawId) : undefined;
-        if (!id && !opts.source) {
-          console.error("Error: provide a release ID or --source\n");
+        if (opts.source && (rawIds.length > 0 || opts.file)) {
+          console.error("Error: --source cannot be combined with release IDs or --file\n");
+          process.exit(1);
+        }
+        if (rawIds.length === 0 && !opts.file && !opts.source) {
+          console.error("Error: provide a release ID, --file, or --source\n");
           process.exit(1);
         }
 
@@ -210,32 +249,38 @@ export function registerReleaseCommand(program: Command) {
           }
         }
 
-        if (id) {
+        if (!opts.source) {
+          const ids = await collectReleaseIds(rawIds, opts.file);
+
           if (opts.dryRun) {
-            const existing = await getRelease(id);
-            if (!existing) releaseNotFound(id);
-            if (opts.json) {
-              console.log(
-                JSON.stringify(
-                  { wouldDelete: 1, releases: [{ id, title: existing.title }] },
-                  null,
-                  2,
-                ),
-              );
-            } else {
-              console.log(chalk.yellow(`[dry-run] Would delete 1 release(s)`));
-              console.log(`  ${id}  ${stripAnsi(existing.title)}`);
+            if (opts.json) await writeJson({ wouldDelete: ids.length, releaseIds: ids });
+            else {
+              console.log(chalk.yellow(`[dry-run] Would delete ${ids.length} release(s)`));
+              for (const id of ids) console.log(`  ${id}`);
             }
             return;
           }
 
-          const deleted = await deleteRelease(id);
-          if (!deleted) {
-            console.error(chalk.red("No matching releases found."));
-            process.exit(1);
+          if (ids.length === 1) {
+            const deleted = await deleteRelease(ids[0]);
+            if (!deleted) {
+              console.error(chalk.red("No matching releases found."));
+              process.exit(1);
+            }
+            if (opts.json) await writeJson({ deleted: 1 });
+            else console.log(chalk.green("Deleted 1 release."));
+            return;
           }
-          if (opts.json) await writeJson({ deleted: 1 });
-          else console.log(chalk.green(`Deleted 1 release.`));
+
+          const result = await deleteReleasesBatch(ids);
+          if (opts.json) await writeJson(result);
+          else {
+            console.log(
+              chalk.green(
+                `Deleted ${result.deleted} release${result.deleted === 1 ? "" : "s"} (requested ${ids.length}).`,
+              ),
+            );
+          }
           return;
         }
 
@@ -318,54 +363,97 @@ export function registerReleaseCommand(program: Command) {
 
   release
     .command("suppress")
-    .description("Suppress a release from appearing in queries and search results")
-    .argument("<id>", "Release ID to suppress")
+    .description("Suppress release(s) from appearing in queries and search results")
+    .argument("[ids...]", "Release ID(s) to suppress (rel_…)")
+    .option("--file <path>", "File with one release ID per line (use - for stdin)")
     .option("--reason <reason>", "Reason for suppression")
     .option("--dry-run", "Show what would be suppressed without writing")
     .option("--json", "Output as JSON")
-    .action(async (rawId: string, opts: { reason?: string; dryRun?: boolean; json?: boolean }) => {
-      const id = normalizeReleaseId(rawId);
-      if (opts.dryRun) {
-        if (opts.json)
+    .action(
+      async (
+        rawIds: string[],
+        opts: { file?: string; reason?: string; dryRun?: boolean; json?: boolean },
+      ) => {
+        const ids = await collectReleaseIds(rawIds, opts.file);
+
+        if (opts.dryRun) {
+          if (opts.json)
+            await writeJson({
+              releaseIds: ids,
+              suppressed: true,
+              reason: opts.reason ?? null,
+              dryRun: true,
+            });
+          else {
+            console.log(
+              chalk.yellow(
+                `[dry-run] Would suppress ${ids.length} release(s)${opts.reason ? ` (${opts.reason})` : ""}`,
+              ),
+            );
+            for (const id of ids) console.log(`  ${id}`);
+          }
+          return;
+        }
+
+        if (ids.length === 1) {
+          const found = await suppressRelease(ids[0], opts.reason);
+          if (!found) releaseNotFound(ids[0]);
+          if (opts.json)
+            await writeJsonLine({ id: ids[0], suppressed: true, reason: opts.reason ?? null });
+          else
+            console.log(
+              chalk.green(`Suppressed release ${ids[0]}${opts.reason ? ` (${opts.reason})` : ""}`),
+            );
+          return;
+        }
+
+        const result = await batchSuppressReleases(ids, true, opts.reason);
+        if (opts.json) await writeJson({ ...result, releaseIds: ids, suppressed: true });
+        else {
           console.log(
-            JSON.stringify({ id, suppressed: true, reason: opts.reason ?? null, dryRun: true }),
-          );
-        else
-          console.log(
-            chalk.yellow(
-              `[dry-run] Would suppress release ${id}${opts.reason ? ` (${opts.reason})` : ""}`,
+            chalk.green(
+              `Suppressed ${result.updated} release${result.updated === 1 ? "" : "s"} (requested ${ids.length})${opts.reason ? ` (${opts.reason})` : ""}.`,
             ),
           );
-        return;
-      }
-
-      const found = await suppressRelease(id, opts.reason);
-      if (!found) releaseNotFound(id);
-
-      if (opts.json) await writeJsonLine({ id, suppressed: true, reason: opts.reason ?? null });
-      else
-        console.log(
-          chalk.green(`Suppressed release ${id}${opts.reason ? ` (${opts.reason})` : ""}`),
-        );
-    });
+        }
+      },
+    );
 
   release
     .command("unsuppress")
-    .description("Restore a suppressed release")
-    .argument("<id>", "Release ID to unsuppress")
+    .description("Restore suppressed release(s)")
+    .argument("[ids...]", "Release ID(s) to unsuppress (rel_…)")
+    .option("--file <path>", "File with one release ID per line (use - for stdin)")
     .option("--dry-run", "Show what would be unsuppressed without writing")
     .option("--json", "Output as JSON")
-    .action(async (rawId: string, opts: { dryRun?: boolean; json?: boolean }) => {
-      const id = normalizeReleaseId(rawId);
+    .action(async (rawIds: string[], opts: { file?: string; dryRun?: boolean; json?: boolean }) => {
+      const ids = await collectReleaseIds(rawIds, opts.file);
+
       if (opts.dryRun) {
-        if (opts.json) console.log(JSON.stringify({ id, suppressed: false, dryRun: true }));
-        else console.log(chalk.yellow(`[dry-run] Would unsuppress release ${id}`));
+        if (opts.json) await writeJson({ releaseIds: ids, suppressed: false, dryRun: true });
+        else {
+          console.log(chalk.yellow(`[dry-run] Would unsuppress ${ids.length} release(s)`));
+          for (const id of ids) console.log(`  ${id}`);
+        }
         return;
       }
-      const found = await unsuppressRelease(id);
-      if (!found) releaseNotFound(id);
 
-      if (opts.json) await writeJsonLine({ id, suppressed: false });
-      else console.log(chalk.green(`Unsuppressed release ${id}`));
+      if (ids.length === 1) {
+        const found = await unsuppressRelease(ids[0]);
+        if (!found) releaseNotFound(ids[0]);
+        if (opts.json) await writeJsonLine({ id: ids[0], suppressed: false });
+        else console.log(chalk.green(`Unsuppressed release ${ids[0]}`));
+        return;
+      }
+
+      const result = await batchSuppressReleases(ids, false);
+      if (opts.json) await writeJson({ ...result, releaseIds: ids, suppressed: false });
+      else {
+        console.log(
+          chalk.green(
+            `Unsuppressed ${result.updated} release${result.updated === 1 ? "" : "s"} (requested ${ids.length}).`,
+          ),
+        );
+      }
     });
 }

--- a/tests/cli/release-batch.test.ts
+++ b/tests/cli/release-batch.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "bun:test";
+import { runCli } from "../utils.js";
+
+describe("release batch flags (--help surface)", () => {
+  it("exposes --file on release delete", () => {
+    const { stdout, exitCode } = runCli(["admin", "release", "delete", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--file");
+    expect(stdout).toContain("[ids...]");
+  });
+
+  it("exposes --file on release suppress", () => {
+    const { stdout, exitCode } = runCli(["admin", "release", "suppress", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--file");
+    expect(stdout).toContain("[ids...]");
+  });
+
+  it("exposes --file on release unsuppress", () => {
+    const { stdout, exitCode } = runCli(["admin", "release", "unsuppress", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--file");
+    expect(stdout).toContain("[ids...]");
+  });
+});

--- a/tests/unit/api-client.test.ts
+++ b/tests/unit/api-client.test.ts
@@ -1358,6 +1358,28 @@ describe("release suppression", () => {
     expect(calls[0].init?.method).toBe("POST");
     expect(result).toBe(true);
   });
+
+  it("deleteReleasesBatch DELETEs /v1/releases/batch with releaseIds", async () => {
+    const calls = captureFetch(200, { deleted: 2 });
+    const result = await client.deleteReleasesBatch(["rel_1", "rel_2"]);
+    expect(calls[0].url).toContain("/v1/releases/batch");
+    expect(calls[0].init?.method).toBe("DELETE");
+    const body = JSON.parse(calls[0].init!.body as string);
+    expect(body.releaseIds).toEqual(["rel_1", "rel_2"]);
+    expect(result.deleted).toBe(2);
+  });
+
+  it("batchSuppressReleases POSTs /v1/releases/batch-suppress", async () => {
+    const calls = captureFetch(200, { updated: 3 });
+    const result = await client.batchSuppressReleases(["rel_1", "rel_2", "rel_3"], true, "spam");
+    expect(calls[0].url).toContain("/v1/releases/batch-suppress");
+    expect(calls[0].init?.method).toBe("POST");
+    const body = JSON.parse(calls[0].init!.body as string);
+    expect(body.releaseIds).toEqual(["rel_1", "rel_2", "rel_3"]);
+    expect(body.suppressed).toBe(true);
+    expect(body.reason).toBe("spam");
+    expect(result.updated).toBe(3);
+  });
 });
 
 // ── follows ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Pairs with buildinternet/releases#1669 (merged).

## Summary

Wires the new batch release API into `releases admin release`:

- **delete** — multiple positional IDs or `--file` (one `rel_…` per line, `-` for stdin) → `DELETE /v1/releases/batch`
- **suppress** / **unsuppress** — same input shapes → `POST /v1/releases/batch-suppress`

A single ID still uses the existing per-row endpoints so 404 semantics stay unchanged.

## Other changes

- `scripts/bulk-suppress.ts` now calls the batch endpoint (grouped by reason) instead of one HTTP request per release
- Agent-context stdin allowlist documents `--file` on the three release verbs

## Test plan

- [x] `bun test tests/unit/api-client.test.ts tests/cli/release-batch.test.ts`
- [x] `bun run typecheck`