### PR TITLE
feat(cli): user webhook commands for /v1/me/webhooks

### DIFF
--- a/.changeset/user-webhook-cli.md
+++ b/.changeset/user-webhook-cli.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": minor
+---
+
+Add user-facing `releases webhook` commands for self-serve `/v1/me/webhooks`: `list`, `add`, `show`, `edit`, `remove`, `test`, `rotate-secret`, and `deliveries`. Requires `releases login` (or `RELEASES_API_KEY`). Supports org-scoped (`--org`, optional `--source`) and follows-scoped (`--scope follows`) subscriptions. `webhook verify` remains a local, no-auth signature check. Closes buildinternet/releases-cli#320.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 The changelog & release-notes registry for developers and AI agents — a lean HTTP client for [releases.sh](https://releases.sh). Search and browse release notes from GitHub, RSS/Atom/JSON feeds, and product changelog pages, with no local infrastructure.
 
-The CLI talks to the hosted registry at `api.releases.sh`. **Search and browse work out of the box — no account or config.** Sign in with `releases login` to follow orgs and products and get a personalized feed; it mints a personal **read-only** API key (and earns you higher rate limits as those roll out). Write/admin access (`releases admin …`) is a separate, closed beta — open an issue for early access.
+The CLI talks to the hosted registry at `api.releases.sh`. **Search and browse work out of the box — no account or config.** Sign in with `releases login` to follow orgs and products, get a personalized feed, and manage outbound webhooks; it mints a personal **read-only** API key (and earns you higher rate limits as those roll out). Write/admin access (`releases admin …`) is a separate, closed beta — open an issue for early access.
 
 ## Install
 
@@ -54,6 +54,20 @@ releases unfollow vercel
 
 Following an organization includes all of its products.
 
+### Outbound webhooks
+
+Receive signed `release.created` POSTs in real time — for everything you follow or a single org:
+
+```bash
+releases webhook add --scope follows --url https://your.app/hook
+releases webhook add --org vercel --url https://your.app/hook --description "prod"
+releases webhook list
+releases webhook test <id>
+releases webhook verify --key … --signature … --timestamp … --body-file capture.json
+```
+
+Org-scoped: up to 10 (`--org`, optional `--source`). Follows-scoped: one webhook (`--scope follows`) that tracks your current follow graph. Signing keys are shown once on `add` / `rotate-secret`. You can also manage webhooks in the browser at [releases.sh/account/notifications](https://releases.sh/account/notifications). Operator/admin webhooks (`releases admin webhook …`) are a separate root-key surface.
+
 ### Contribute to the registry
 
 Neither needs an account or API key:
@@ -89,7 +103,7 @@ releases skills install        # or, without the CLI: npx skills add buildintern
 
 ## Authentication
 
-Search and browse need no auth. Signing in is what powers the personal touches — **following orgs/products and your customized feed** — and mints a personal **read-only** key (it can't write or administer anything; it just identifies you, and unlocks higher rate limits as those land). The easiest way in is your browser — nothing to copy or paste:
+Search and browse need no auth. Signing in powers the personal surfaces — **follows, feed, and outbound webhooks** — and mints a personal **read-only** key (it can't write to the catalog or run `admin` commands; it identifies you for `/v1/me/*` account routes). The easiest way in is your browser — nothing to copy or paste:
 
 ```bash
 releases login              # opens your browser to approve, then saves the key

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "releases-cli",
       "dependencies": {
-        "@buildinternet/releases-api-types": "^0.32.0",
+        "@buildinternet/releases-api-types": "^0.33.0",
         "@buildinternet/releases-core": "^0.23.0",
         "@buildinternet/releases-lib": "workspace:*",
         "@buildinternet/releases-skills": "workspace:*",
@@ -27,7 +27,7 @@
     },
     "npm/releases": {
       "name": "@buildinternet/releases",
-      "version": "0.60.0",
+      "version": "0.63.0",
       "bin": {
         "releases": "bin/releases",
       },
@@ -41,31 +41,31 @@
     },
     "npm/releases-darwin-arm64": {
       "name": "@buildinternet/releases-darwin-arm64",
-      "version": "0.60.0",
+      "version": "0.63.0",
     },
     "npm/releases-darwin-x64": {
       "name": "@buildinternet/releases-darwin-x64",
-      "version": "0.60.0",
+      "version": "0.63.0",
     },
     "npm/releases-linux-arm64": {
       "name": "@buildinternet/releases-linux-arm64",
-      "version": "0.60.0",
+      "version": "0.63.0",
     },
     "npm/releases-linux-x64": {
       "name": "@buildinternet/releases-linux-x64",
-      "version": "0.60.0",
+      "version": "0.63.0",
     },
     "npm/releases-windows-x64": {
       "name": "@buildinternet/releases-windows-x64",
-      "version": "0.60.0",
+      "version": "0.63.0",
     },
     "packages/lib": {
       "name": "@buildinternet/releases-lib",
-      "version": "0.60.0",
+      "version": "0.63.0",
     },
     "packages/skills": {
       "name": "@buildinternet/releases-skills",
-      "version": "0.60.0",
+      "version": "0.63.0",
     },
   },
   "packages": {
@@ -73,7 +73,7 @@
 
     "@buildinternet/releases": ["@buildinternet/releases@workspace:npm/releases"],
 
-    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.32.0", "", { "dependencies": { "@buildinternet/releases-core": "^0.23.0", "zod": "^4.4.3" } }, "sha512-YG4jaobtRvq5/gvYojyWlL9cCW98WkonST9jdxHQSurpIA/ds6W7k1mszqXdhRH+dM2eXufIEh1lP3AU75VUxw=="],
+    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.33.0", "", { "dependencies": { "@buildinternet/releases-core": "^0.23.0", "zod": "^4.4.3" } }, "sha512-RCQtLDFztVv/mNtFvu0QWuL2IvS0j4L+mTDAv1nnChakPwgZz1/gRKfy0BdjWyrP7+pnDRA7fAD2PJvApYzODQ=="],
 
     "@buildinternet/releases-core": ["@buildinternet/releases-core@0.23.0", "", { "dependencies": { "drizzle-orm": "^0.45.2", "js-tiktoken": "^1.0.21", "nanoid": "^5.1.7" } }, "sha512-ieUK+KTlXmxX6nRHIft4alMuNNOJctk8AKCfbJmM0SbWqLHcHjLy9O+sj2R+4052IhwJI86gPFpTLM1QNfLFDA=="],
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "homepage": "https://releases.sh",
   "dependencies": {
-    "@buildinternet/releases-api-types": "^0.32.0",
+    "@buildinternet/releases-api-types": "^0.33.0",
     "@buildinternet/releases-core": "^0.23.0",
     "@buildinternet/releases-lib": "workspace:*",
     "@buildinternet/releases-skills": "workspace:*",

--- a/skills/releases-cli/SKILL.md
+++ b/skills/releases-cli/SKILL.md
@@ -62,6 +62,24 @@ Two commands built for agents specifically:
 - There is **no** `summary` or `compare` command in this CLI, and **no** AI summarization tools on the hosted MCP (`summarize_changes` / `compare_products` do not exist). To summarize or compare, read each entity with `releases get` / `releases tail` (or `--json`) and synthesize the answer yourself.
 - Don't reach for `admin` commands to do reads — every read above is keyless. `admin` is only for registry maintenance and requires a key (below).
 
+## Signed-in user commands (`releases login`)
+
+After `releases login` (device flow) or with a stored `relu_` key, you can manage your own account state — no admin key required:
+
+```bash
+releases follow vercel              # follow an org or product
+releases following                # list follows
+releases feed                     # personalized release timeline
+
+releases webhook list             # your outbound webhook subscriptions
+releases webhook add --scope follows --url https://your.app/hook
+releases webhook add --org vercel --url https://your.app/hook
+releases webhook test <id>        # enqueue a signed test delivery
+releases webhook verify --key …   # local HMAC check (no auth)
+```
+
+Org-scoped webhooks: up to 10 per account (`--org`, optional `--source`). Follows-scoped: one webhook that tracks your current follow graph (real-time sibling to `feed` + digest email). Signing keys are shown once on `add` / `rotate-secret`. Operator/admin webhooks (`releases admin webhook …`) are a separate root-key surface.
+
 ## Admin surface (invite-only — reads never need it)
 
 `releases admin <noun> <verb>` manages the registry (create/update sources, orgs, products; fetch; discovery; policies). It requires `RELEASES_API_KEY`, and **keys are not self-serve** — there's no public signup. Admin commands fail fast at startup without a key, so don't retry them unauthenticated, and don't fall back to them for read tasks. If a user asks how to get a key, tell them access is currently invite-only and point them at the project repo; don't invent a signup URL. Full operator reference: **[references/admin.md](references/admin.md)**.

--- a/skills/releases-cli/references/reader.md
+++ b/skills/releases-cli/references/reader.md
@@ -159,6 +159,24 @@ releases submit https://acme.dev/changelog --dry-run --json # preview the payloa
 
 `--note` carries extra context (product name, GitHub repo, feed quirks); `--contact` is an optional email to notify once it's reviewed. With no URL argument in an interactive terminal, `submit` prompts for the URL (and the optional note/contact); otherwise pass it inline or pipe via stdin. Index pages, changelogs, GitHub releases, and feed URLs are all ideal.
 
+## Signed-in account commands (`releases login`)
+
+These act on **your** account via `/v1/me/*` — sign in first (`releases login` or `RELEASES_API_KEY`):
+
+```bash
+releases follow vercel
+releases following
+releases feed
+
+releases webhook list
+releases webhook add --scope follows --url https://your.app/hook
+releases webhook add --org vercel --url https://your.app/hook
+releases webhook test <id>
+releases webhook verify --key <hex> --signature … --timestamp … --body-file -
+```
+
+`webhook verify` is local (no auth). Admin webhooks (`releases admin webhook …`) are a separate root-key operator surface.
+
 ## Agent self-discovery
 
 ```bash

--- a/src/api/me-webhooks.ts
+++ b/src/api/me-webhooks.ts
@@ -1,0 +1,128 @@
+import { apiFetch } from "./core.js";
+import type { WebhookDeliveryRow } from "./webhooks.js";
+
+/**
+ * Self-serve `/v1/me/webhooks` wire shapes. Defined locally until they ship in
+ * `@buildinternet/releases-api-types` (follows the admin `webhooks.ts` pattern).
+ */
+export type UserWebhookScope = "org" | "follows";
+
+export type WebhookDeliveryHealth =
+  | "never_delivered"
+  | "healthy"
+  | "degraded"
+  | "failing"
+  | "paused"
+  | "auto_paused";
+
+export interface UserWebhookSubscription {
+  id: string;
+  userId: string;
+  scope: UserWebhookScope;
+  orgId: string | null;
+  url: string;
+  sourceId: string | null;
+  enabled: boolean;
+  description: string | null;
+  secretVersion: number;
+  createdAt: string;
+  lastSuccessAt: string | null;
+  lastErrorAt: string | null;
+  lastErrorMsg: string | null;
+  consecutiveFailures: number;
+  disabledReason: string | null;
+  failureStreakStartedAt: string | null;
+  deliveryHealth: WebhookDeliveryHealth;
+  deliveryHealthSummary: string;
+}
+
+export interface UserWebhookListItem extends Omit<UserWebhookSubscription, "userId"> {
+  orgSlug: string | null;
+  orgName: string | null;
+  sourceSlug: string | null;
+  sourceName: string | null;
+}
+
+export interface CreateUserWebhookResponse extends UserWebhookListItem {
+  signingKey: string;
+}
+
+export interface CreateUserWebhookInput {
+  url: string;
+  scope?: UserWebhookScope;
+  orgSlug?: string;
+  orgId?: string;
+  sourceSlug?: string;
+  sourceId?: string;
+  description?: string | null;
+}
+
+/** List the signed-in user's webhook subscriptions. */
+export async function listMyWebhooks(opts?: { enabled?: boolean }): Promise<UserWebhookListItem[]> {
+  const params = new URLSearchParams();
+  if (opts?.enabled !== undefined) params.set("enabled", String(opts.enabled));
+  const qs = params.toString();
+  const res = await apiFetch<{ subscriptions: UserWebhookListItem[] } | null>(
+    `/v1/me/webhooks${qs ? `?${qs}` : ""}`,
+  );
+  return res?.subscriptions ?? [];
+}
+
+/** Register a self-serve webhook. The `signingKey` is shown once. */
+export async function createMyWebhook(
+  input: CreateUserWebhookInput,
+): Promise<CreateUserWebhookResponse> {
+  return apiFetch<CreateUserWebhookResponse>(`/v1/me/webhooks`, {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
+}
+
+/** Read one owned subscription. Returns null on 404. */
+export async function getMyWebhook(id: string): Promise<UserWebhookSubscription | null> {
+  return apiFetch<UserWebhookSubscription | null>(`/v1/me/webhooks/${encodeURIComponent(id)}`);
+}
+
+export async function updateMyWebhook(
+  id: string,
+  fields: { url?: string; description?: string | null; enabled?: boolean },
+): Promise<UserWebhookSubscription> {
+  return apiFetch<UserWebhookSubscription>(`/v1/me/webhooks/${encodeURIComponent(id)}`, {
+    method: "PATCH",
+    body: JSON.stringify(fields),
+  });
+}
+
+export async function deleteMyWebhook(id: string): Promise<void> {
+  await apiFetch<void>(`/v1/me/webhooks/${encodeURIComponent(id)}`, { method: "DELETE" });
+}
+
+export async function rotateMyWebhookSecret(
+  id: string,
+): Promise<{ secretVersion: number; signingKey: string }> {
+  return apiFetch<{ secretVersion: number; signingKey: string }>(
+    `/v1/me/webhooks/${encodeURIComponent(id)}/rotate-secret`,
+    { method: "POST" },
+  );
+}
+
+export async function testMyWebhook(id: string): Promise<{ enqueued: true; eventId: string }> {
+  return apiFetch<{ enqueued: true; eventId: string }>(
+    `/v1/me/webhooks/${encodeURIComponent(id)}/test`,
+    { method: "POST" },
+  );
+}
+
+export async function getMyWebhookDeliveries(
+  id: string,
+  opts?: { failed?: boolean; limit?: number },
+): Promise<WebhookDeliveryRow[]> {
+  const params = new URLSearchParams();
+  if (opts?.failed) params.set("failed", "true");
+  if (opts?.limit !== undefined) params.set("limit", String(opts.limit));
+  const qs = params.toString();
+  const res = await apiFetch<{ data?: WebhookDeliveryRow[] } | null>(
+    `/v1/me/webhooks/${encodeURIComponent(id)}/deliveries${qs ? `?${qs}` : ""}`,
+  );
+  return res?.data ?? [];
+}

--- a/src/cli/commands/webhook-manage.ts
+++ b/src/cli/commands/webhook-manage.ts
@@ -1,0 +1,352 @@
+/**
+ * `releases webhook {list,add,…}` — manage your own outbound webhook
+ * subscriptions via `/v1/me/webhooks`. Requires `releases login` (or
+ * RELEASES_API_KEY). `releases webhook verify` stays in `webhook.ts` (no auth).
+ */
+import { Command } from "commander";
+import chalk from "chalk";
+import { logger } from "@releases/lib/logger";
+import { isAuthenticated } from "../../lib/mode.js";
+import { writeJson } from "../../lib/output.js";
+import type { WebhookDeliveryRow } from "../../api/webhooks.js";
+import {
+  createMyWebhook,
+  deleteMyWebhook,
+  getMyWebhook,
+  getMyWebhookDeliveries,
+  listMyWebhooks,
+  rotateMyWebhookSecret,
+  testMyWebhook,
+  updateMyWebhook,
+  type UserWebhookListItem,
+  type UserWebhookSubscription,
+} from "../../api/me-webhooks.js";
+import { renderTable } from "../render/table.js";
+
+function requireAuth(): void {
+  if (!isAuthenticated()) {
+    console.error(
+      chalk.red("Not signed in. Run `releases login` first (or set RELEASES_API_KEY)."),
+    );
+    process.exit(1);
+  }
+}
+
+function statusLabel(enabled: boolean): string {
+  return enabled ? chalk.green("enabled") : chalk.red("disabled");
+}
+
+function scopeLabel(sub: UserWebhookListItem | UserWebhookSubscription): string {
+  if (sub.scope === "follows") return chalk.dim("follows");
+  if ("orgSlug" in sub && sub.orgSlug) return sub.orgSlug;
+  return sub.orgId ?? chalk.dim("org");
+}
+
+function subscriptionTitle(sub: UserWebhookListItem | UserWebhookSubscription): string {
+  if (sub.description?.trim()) return sub.description.trim();
+  if (sub.scope === "follows") return "Everything you follow";
+  if ("orgName" in sub && sub.orgName) return sub.orgName;
+  return sub.id;
+}
+
+function parseLimit(value: string): number {
+  const n = parseInt(value, 10);
+  if (Number.isNaN(n) || n === 0) return 20;
+  return Math.min(100, Math.max(1, n));
+}
+
+function printSubscription(sub: UserWebhookSubscription | UserWebhookListItem): void {
+  logger.info(`${chalk.bold(sub.id)}  ${statusLabel(sub.enabled)}  ${scopeLabel(sub)}`);
+  logger.info(`  url:     ${sub.url}`);
+  if (sub.scope === "org") {
+    const source =
+      "sourceSlug" in sub && sub.sourceSlug
+        ? sub.sourceSlug
+        : sub.sourceId
+          ? sub.sourceId
+          : chalk.dim("(all org sources)");
+    logger.info(`  source:  ${source}`);
+  }
+  if (sub.description) logger.info(`  desc:    ${sub.description}`);
+  logger.info(`  secret:  v${sub.secretVersion}${chalk.dim(`  · created ${sub.createdAt}`)}`);
+  logger.info(`  health:  ${sub.deliveryHealthSummary}`);
+  logger.info(
+    `  last ok: ${sub.lastSuccessAt ?? chalk.dim("—")}   failures: ${sub.consecutiveFailures}`,
+  );
+  if (sub.lastErrorAt) {
+    logger.info(`  last err: ${sub.lastErrorAt} ${chalk.dim(sub.lastErrorMsg ?? "")}`);
+  }
+  if (!sub.enabled && sub.disabledReason) {
+    logger.info(`  ${chalk.red(`disabled: ${sub.disabledReason}`)}`);
+  }
+}
+
+function isDeliveriesUnavailable(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return /\(501\)|deliveries_unavailable|CF_API_TOKEN/.test(msg);
+}
+
+function renderDeliveries(rows: WebhookDeliveryRow[]): string {
+  return renderTable({
+    head: [
+      { label: "Time", noTruncate: true },
+      { label: "Outcome" },
+      { label: "HTTP" },
+      { label: "Latency" },
+      { label: "Attempt" },
+      { label: "Error" },
+    ],
+    rows: rows.map((r) => [
+      r.timestamp ?? chalk.dim("—"),
+      r.outcome ?? chalk.dim("—"),
+      r.http_status != null ? String(r.http_status) : chalk.dim("—"),
+      r.latency_ms != null ? `${r.latency_ms}ms` : chalk.dim("—"),
+      r.attempt != null ? String(r.attempt) : chalk.dim("—"),
+      r.error_message ?? chalk.dim("—"),
+    ]),
+  });
+}
+
+export function registerWebhookManageCommands(webhook: Command): void {
+  webhook
+    .command("list")
+    .description("List your webhook subscriptions")
+    .option("--enabled", "Only enabled subscriptions")
+    .option("--disabled", "Only disabled subscriptions")
+    .option("--json", "Output JSON")
+    .action(async (opts: { enabled?: boolean; disabled?: boolean; json?: boolean }) => {
+      requireAuth();
+      if (opts.enabled && opts.disabled) {
+        logger.error("Pass at most one of --enabled / --disabled.");
+        process.exit(1);
+      }
+      let filter: { enabled?: boolean } | undefined;
+      if (opts.enabled) filter = { enabled: true };
+      else if (opts.disabled) filter = { enabled: false };
+      const subscriptions = await listMyWebhooks(filter);
+      if (opts.json) return writeJson({ subscriptions });
+      if (subscriptions.length === 0) {
+        logger.info("No webhook subscriptions.");
+        return;
+      }
+      console.log(
+        renderTable({
+          head: [
+            { label: "ID", noTruncate: true },
+            { label: "Scope" },
+            { label: "Label" },
+            { label: "URL", noTruncate: true },
+            { label: "Status" },
+            { label: "Health" },
+          ],
+          rows: subscriptions.map((s) => [
+            s.id,
+            s.scope,
+            subscriptionTitle(s),
+            s.url,
+            s.enabled ? "enabled" : "disabled",
+            s.deliveryHealth,
+          ]),
+        }),
+      );
+    });
+
+  webhook
+    .command("add")
+    .description("Create a webhook subscription (signing key shown once)")
+    .requiredOption("--url <url>", "HTTPS delivery URL")
+    .option("--scope <scope>", "org (default) or follows", "org")
+    .option("--org <slug>", "Org slug or id (required for org scope)")
+    .option("--source <slug>", "Limit to one source (org scope only)")
+    .option("--description <text>", "Human-readable label")
+    .option("--json", "Output JSON")
+    .action(
+      async (opts: {
+        url: string;
+        scope: string;
+        org?: string;
+        source?: string;
+        description?: string;
+        json?: boolean;
+      }) => {
+        requireAuth();
+        const scope = opts.scope === "follows" ? "follows" : "org";
+        if (scope === "org" && !opts.org) {
+          logger.error("--org is required for org-scoped webhooks.");
+          process.exit(1);
+        }
+        if (scope === "follows" && (opts.org || opts.source)) {
+          logger.error("follows-scoped webhooks must not include --org or --source.");
+          process.exit(1);
+        }
+        const result = await createMyWebhook({
+          url: opts.url,
+          scope,
+          ...(scope === "org"
+            ? {
+                orgSlug: opts.org,
+                ...(opts.source ? { sourceSlug: opts.source } : {}),
+              }
+            : {}),
+          description: opts.description,
+        });
+        if (opts.json) return writeJson(result);
+        printSubscription(result);
+        logger.info("");
+        logger.info(chalk.bold("Signing key (shown once — store it now):"));
+        logger.info(`  ${chalk.green(result.signingKey)}`);
+        logger.info(
+          chalk.dim("  Re-derive only via `webhook rotate-secret` (invalidates the old key)."),
+        );
+      },
+    );
+
+  webhook
+    .command("show <id>")
+    .description("Show one subscription plus its last 10 delivery attempts")
+    .option("--json", "Output JSON")
+    .action(async (id: string, opts: { json?: boolean }) => {
+      requireAuth();
+      const sub = await getMyWebhook(id);
+      if (!sub) {
+        logger.error("Subscription not found.");
+        process.exit(1);
+      }
+      let deliveries: WebhookDeliveryRow[] = [];
+      let deliveriesUnavailable = false;
+      try {
+        deliveries = await getMyWebhookDeliveries(id, { limit: 10 });
+      } catch (err) {
+        if (isDeliveriesUnavailable(err)) deliveriesUnavailable = true;
+        else throw err;
+      }
+      if (opts.json) return writeJson({ ...sub, deliveries });
+      printSubscription(sub);
+      logger.info("");
+      if (deliveriesUnavailable) {
+        logger.info(chalk.dim("Delivery history unavailable (Analytics Engine not configured)."));
+      } else if (deliveries.length === 0) {
+        logger.info(chalk.dim("No delivery attempts recorded."));
+      } else {
+        logger.info(chalk.bold("Recent deliveries:"));
+        console.log(renderDeliveries(deliveries));
+      }
+    });
+
+  webhook
+    .command("edit <id>")
+    .description("Update a subscription's url / description / enabled state")
+    .option("--url <url>", "New HTTPS delivery URL (does not rotate the signing key)")
+    .option("--description <text>", "New description")
+    .option("--enable", "Enable the subscription (resets the failure counter)")
+    .option("--disable", "Disable the subscription")
+    .option("--json", "Output JSON")
+    .action(
+      async (
+        id: string,
+        opts: {
+          url?: string;
+          description?: string;
+          enable?: boolean;
+          disable?: boolean;
+          json?: boolean;
+        },
+      ) => {
+        requireAuth();
+        if (opts.enable && opts.disable) {
+          logger.error("Pass at most one of --enable / --disable.");
+          process.exit(1);
+        }
+        const fields: { url?: string; description?: string; enabled?: boolean } = {};
+        if (opts.url !== undefined) fields.url = opts.url;
+        if (opts.description !== undefined) fields.description = opts.description;
+        if (opts.enable) fields.enabled = true;
+        if (opts.disable) fields.enabled = false;
+        if (Object.keys(fields).length === 0) {
+          logger.error("Nothing to change. Pass --url, --description, --enable, or --disable.");
+          process.exit(1);
+        }
+        const updated = await updateMyWebhook(id, fields);
+        if (opts.json) return writeJson(updated);
+        printSubscription(updated);
+      },
+    );
+
+  webhook
+    .command("remove <id>")
+    .description("Hard-delete a subscription")
+    .option("--json", "Output JSON")
+    .action(async (id: string, opts: { json?: boolean }) => {
+      requireAuth();
+      await deleteMyWebhook(id);
+      if (opts.json) return writeJson({ id, deleted: true });
+      logger.info(`${id}: ${chalk.red("deleted")}`);
+    });
+
+  webhook
+    .command("test <id>")
+    .description("Enqueue a synthetic release.created event to the subscription URL")
+    .option("--json", "Output JSON")
+    .action(async (id: string, opts: { json?: boolean }) => {
+      requireAuth();
+      const result = await testMyWebhook(id);
+      if (opts.json) return writeJson(result);
+      logger.info(`${chalk.green("enqueued")} test event ${chalk.dim(result.eventId)} → ${id}`);
+    });
+
+  webhook
+    .command("rotate-secret <id>")
+    .description("Rotate the signing key (new key shown once; old key invalidated)")
+    .option("--json", "Output JSON")
+    .action(async (id: string, opts: { json?: boolean }) => {
+      requireAuth();
+      const result = await rotateMyWebhookSecret(id);
+      if (opts.json) return writeJson(result);
+      logger.info(
+        chalk.bold(`New signing key (v${result.secretVersion}, shown once — store it now):`),
+      );
+      logger.info(`  ${chalk.green(result.signingKey)}`);
+    });
+
+  webhook
+    .command("deliveries <id>")
+    .description("Show recent delivery attempts from Analytics Engine")
+    .option("--failed", "Only failed attempts (retry / perm_fail / dlq / auto_disabled)")
+    .option("--since <iso>", "Only attempts at or after this ISO timestamp (filtered client-side)")
+    .option("--limit <n>", "Max attempts to fetch (default 20, max 100)", parseLimit)
+    .option("--json", "Output JSON")
+    .action(
+      async (
+        id: string,
+        opts: { failed?: boolean; since?: string; limit?: number; json?: boolean },
+      ) => {
+        requireAuth();
+        let rows: WebhookDeliveryRow[];
+        try {
+          rows = await getMyWebhookDeliveries(id, { failed: opts.failed, limit: opts.limit });
+        } catch (err) {
+          if (isDeliveriesUnavailable(err)) {
+            logger.error(
+              "Delivery history unavailable — the API has no Analytics Engine query configured.",
+            );
+            process.exit(1);
+          }
+          throw err;
+        }
+        if (opts.since) {
+          const cutoff = Date.parse(opts.since);
+          if (Number.isNaN(cutoff)) {
+            logger.error(`Invalid --since timestamp: ${opts.since}`);
+            process.exit(1);
+          }
+          rows = rows.filter((r) => r.timestamp != null && Date.parse(r.timestamp) >= cutoff);
+        }
+        if (opts.json) return writeJson({ deliveries: rows });
+        if (rows.length === 0) {
+          logger.info("No delivery attempts.");
+          return;
+        }
+        console.log(renderDeliveries(rows));
+      },
+    );
+}

--- a/src/cli/commands/webhook.ts
+++ b/src/cli/commands/webhook.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import { readContentArg } from "../../lib/input.js";
+import { registerWebhookManageCommands } from "./webhook-manage.js";
 
 // Web Crypto only — no node:crypto dependency.
 const enc = new TextEncoder();
@@ -100,8 +101,10 @@ interface VerifyOpts {
 export function registerWebhookCommand(parent: Command): void {
   const webhook = parent
     .command("webhook")
-    .description("Webhook utilities")
+    .description("Manage your webhook subscriptions and verify signatures")
     .showSuggestionAfterError(true);
+
+  registerWebhookManageCommands(webhook);
 
   webhook
     .command("verify")

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -264,8 +264,8 @@ registerFollowsCommands(program);
 registerAgentContextCommand(program);
 registerCompletionCommand(program);
 registerSkillsCommand(program);
-// Subscriber-facing `webhook verify` — local signature check, no auth. The
-// admin webhook CRUD lives under `admin` (registerWebhookAdminCommand).
+// `webhook {list,add,…}` — self-serve `/v1/me/webhooks` (auth required).
+// `webhook verify` — local signature check, no auth. Admin CRUD under `admin webhook`.
 registerWebhookCommand(program);
 
 const admin = program

--- a/tests/unit/me-webhooks.test.ts
+++ b/tests/unit/me-webhooks.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
+
+const prevEnv: { url?: string; key?: string } = {};
+beforeAll(() => {
+  prevEnv.url = process.env.RELEASES_API_URL;
+  prevEnv.key = process.env.RELEASES_API_KEY;
+  process.env.RELEASES_API_URL = "https://test.example.com";
+  process.env.RELEASES_API_KEY = "test-key";
+});
+afterAll(() => {
+  if (prevEnv.url === undefined) delete process.env.RELEASES_API_URL;
+  else process.env.RELEASES_API_URL = prevEnv.url;
+  if (prevEnv.key === undefined) delete process.env.RELEASES_API_KEY;
+  else process.env.RELEASES_API_KEY = prevEnv.key;
+});
+
+const client = await import("../../src/api/me-webhooks.js");
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("me-webhooks client wire contract", () => {
+  let originalFetch: typeof globalThis.fetch;
+  let calls: Array<{ url: string; method: string; body: unknown }> = [];
+  let responder: (url: string) => Response;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    calls = [];
+    responder = () => json({});
+    globalThis.fetch = (async (url: string, init?: RequestInit) => {
+      const u = String(url);
+      calls.push({
+        url: u,
+        method: init?.method ?? "GET",
+        body: init?.body ? JSON.parse(String(init.body)) : null,
+      });
+      return responder(u);
+    }) as unknown as typeof globalThis.fetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("listMyWebhooks GETs /v1/me/webhooks", async () => {
+    responder = () => json({ subscriptions: [{ id: "whk_1", scope: "follows" }] });
+    const subs = await client.listMyWebhooks();
+    expect(subs).toHaveLength(1);
+    expect(calls[0]!.method).toBe("GET");
+    expect(calls[0]!.url.endsWith("/v1/me/webhooks")).toBe(true);
+  });
+
+  it("createMyWebhook POSTs follows scope", async () => {
+    responder = () => json({ id: "whk_2", signingKey: "abc", scope: "follows" }, 201);
+    const created = await client.createMyWebhook({
+      url: "https://ex.com/h",
+      scope: "follows",
+    });
+    expect(created.signingKey).toBe("abc");
+    expect(calls[0]!.method).toBe("POST");
+    expect(calls[0]!.body).toEqual({ url: "https://ex.com/h", scope: "follows" });
+  });
+
+  it("createMyWebhook POSTs org scope with orgSlug", async () => {
+    responder = () => json({ id: "whk_3", signingKey: "def", scope: "org" });
+    await client.createMyWebhook({ url: "https://ex.com/o", orgSlug: "vercel" });
+    expect(calls[0]!.body).toEqual({ url: "https://ex.com/o", orgSlug: "vercel" });
+  });
+
+  it("updateMyWebhook PATCHes enabled", async () => {
+    responder = () => json({ id: "whk_4", enabled: false });
+    await client.updateMyWebhook("whk_4", { enabled: false });
+    expect(calls[0]!.method).toBe("PATCH");
+    expect(calls[0]!.url.endsWith("/v1/me/webhooks/whk_4")).toBe(true);
+    expect(calls[0]!.body).toEqual({ enabled: false });
+  });
+
+  it("deleteMyWebhook DELETEs by id", async () => {
+    responder = () => new Response(null, { status: 204 });
+    await client.deleteMyWebhook("whk_5");
+    expect(calls[0]!.method).toBe("DELETE");
+  });
+
+  it("testMyWebhook POSTs /test", async () => {
+    responder = () => json({ enqueued: true, eventId: "evt_1" });
+    const out = await client.testMyWebhook("whk_6");
+    expect(out.eventId).toBe("evt_1");
+    expect(calls[0]!.url.endsWith("/test")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds self-serve webhook management to the top-level `releases webhook` command group (alongside existing `verify`):

- `list`, `add`, `show`, `edit`, `remove`, `test`, `rotate-secret`, `deliveries`
- Auth: `releases login` or `RELEASES_API_KEY` (same gate as `follow`/`feed`)
- Org scope: `--org` + optional `--source` (max 10)
- Follows scope: `--scope follows` (max 1)

Closes #320.

## Notes

- API client: `src/api/me-webhooks.ts`
- Command wiring: `src/cli/commands/webhook-manage.ts`
- Bumps `@buildinternet/releases-api-types` to ^0.33.0 (no UserWebhook types published yet — local wire shapes like admin `webhooks.ts`)
- Skill docs updated with signed-in user section

## Test plan

- [x] `bun run typecheck`
- [x] `bun test` (973 pass)
- [x] `tests/unit/me-webhooks.test.ts`