### PR TITLE
feat(webhook): add --product and --type filter flags

### DIFF
--- a/.changeset/webhook-event-filters.md
+++ b/.changeset/webhook-event-filters.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": patch
+---
+
+Add `--product`, `--type`, and `--clear-*` filter flags to `releases webhook add` and `webhook edit`, matching per-event filters on `POST/PATCH /v1/me/webhooks`. Companion to buildinternet/releases#1683.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ releases webhook test <id>
 releases webhook verify --key … --signature … --timestamp … --body-file capture.json
 ```
 
-Org-scoped: up to 10 (`--org`, optional `--source`). Follows-scoped: one webhook (`--scope follows`) that tracks your current follow graph. Signing keys are shown once on `add` / `rotate-secret`. You can also manage webhooks in the browser at [releases.sh/account/notifications](https://releases.sh/account/notifications). Operator/admin webhooks (`releases admin webhook …`) are a separate root-key surface.
+Org-scoped: up to 10 (`--org`, optional `--source`, `--product`, `--type feature|rollup`). Follows-scoped: one webhook (`--scope follows`) that tracks your current follow graph; optional `--type` narrows delivery. Signing keys are shown once on `add` / `rotate-secret`. You can also manage webhooks in the browser at [releases.sh/account/notifications](https://releases.sh/account/notifications). Operator/admin webhooks (`releases admin webhook …`) are a separate root-key surface.
 
 ### Contribute to the registry
 

--- a/skills/releases-cli/SKILL.md
+++ b/skills/releases-cli/SKILL.md
@@ -78,7 +78,7 @@ releases webhook test <id>        # enqueue a signed test delivery
 releases webhook verify --key …   # local HMAC check (no auth)
 ```
 
-Org-scoped webhooks: up to 10 per account (`--org`, optional `--source`). Follows-scoped: one webhook that tracks your current follow graph (real-time sibling to `feed` + digest email). Signing keys are shown once on `add` / `rotate-secret`. Operator/admin webhooks (`releases admin webhook …`) are a separate root-key surface.
+Org-scoped webhooks: up to 10 per account (`--org`, optional `--source`, `--product`, `--type feature|rollup`). Follows-scoped: one webhook that tracks your current follow graph (real-time sibling to `feed` + digest email); optional `--type` narrows delivery. `webhook edit` can update filters (`--clear-source`, `--clear-product`, `--clear-type`). Signing keys are shown once on `add` / `rotate-secret`. Operator/admin webhooks (`releases admin webhook …`) are a separate root-key surface.
 
 ## Admin surface (invite-only — reads never need it)
 

--- a/skills/releases-cli/references/reader.md
+++ b/skills/releases-cli/references/reader.md
@@ -171,6 +171,8 @@ releases feed
 releases webhook list
 releases webhook add --scope follows --url https://your.app/hook
 releases webhook add --org vercel --url https://your.app/hook
+releases webhook add --org vercel --product next-js --type feature --url https://your.app/hook
+releases webhook edit <id> --type rollup
 releases webhook test <id>
 releases webhook verify --key <hex> --signature … --timestamp … --body-file -
 ```

--- a/src/api/me-webhooks.ts
+++ b/src/api/me-webhooks.ts
@@ -6,6 +6,7 @@ import type { WebhookDeliveryRow } from "./webhooks.js";
  * `@buildinternet/releases-api-types` (follows the admin `webhooks.ts` pattern).
  */
 export type UserWebhookScope = "org" | "follows";
+export type UserWebhookReleaseTypeFilter = "feature" | "rollup";
 
 export type WebhookDeliveryHealth =
   | "never_delivered"
@@ -22,6 +23,8 @@ export interface UserWebhookSubscription {
   orgId: string | null;
   url: string;
   sourceId: string | null;
+  productId: string | null;
+  releaseType: UserWebhookReleaseTypeFilter | null;
   enabled: boolean;
   description: string | null;
   secretVersion: number;
@@ -41,6 +44,8 @@ export interface UserWebhookListItem extends Omit<UserWebhookSubscription, "user
   orgName: string | null;
   sourceSlug: string | null;
   sourceName: string | null;
+  productSlug: string | null;
+  productName: string | null;
 }
 
 export interface CreateUserWebhookResponse extends UserWebhookListItem {
@@ -54,6 +59,9 @@ export interface CreateUserWebhookInput {
   orgId?: string;
   sourceSlug?: string;
   sourceId?: string;
+  productSlug?: string;
+  productId?: string;
+  releaseType?: UserWebhookReleaseTypeFilter;
   description?: string | null;
 }
 
@@ -83,9 +91,20 @@ export async function getMyWebhook(id: string): Promise<UserWebhookSubscription 
   return apiFetch<UserWebhookSubscription | null>(`/v1/me/webhooks/${encodeURIComponent(id)}`);
 }
 
+export type UpdateMyWebhookInput = {
+  url?: string;
+  description?: string | null;
+  enabled?: boolean;
+  sourceSlug?: string;
+  sourceId?: string | null;
+  productSlug?: string;
+  productId?: string | null;
+  releaseType?: UserWebhookReleaseTypeFilter | null;
+};
+
 export async function updateMyWebhook(
   id: string,
-  fields: { url?: string; description?: string | null; enabled?: boolean },
+  fields: UpdateMyWebhookInput,
 ): Promise<UserWebhookSubscription> {
   return apiFetch<UserWebhookSubscription>(`/v1/me/webhooks/${encodeURIComponent(id)}`, {
     method: "PATCH",

--- a/src/cli/commands/webhook-manage.ts
+++ b/src/cli/commands/webhook-manage.ts
@@ -18,6 +18,7 @@ import {
   rotateMyWebhookSecret,
   testMyWebhook,
   updateMyWebhook,
+  type UpdateMyWebhookInput,
   type UserWebhookListItem,
   type UserWebhookSubscription,
 } from "../../api/me-webhooks.js";
@@ -49,6 +50,13 @@ function subscriptionTitle(sub: UserWebhookListItem | UserWebhookSubscription): 
   return sub.id;
 }
 
+function parseReleaseTypeOpt(value: string | undefined): "feature" | "rollup" | undefined {
+  if (!value) return undefined;
+  if (value === "feature" || value === "rollup") return value;
+  logger.error("--type must be feature or rollup.");
+  process.exit(1);
+}
+
 function parseLimit(value: string): number {
   const n = parseInt(value, 10);
   if (Number.isNaN(n) || n === 0) return 20;
@@ -59,14 +67,22 @@ function printSubscription(sub: UserWebhookSubscription | UserWebhookListItem): 
   logger.info(`${chalk.bold(sub.id)}  ${statusLabel(sub.enabled)}  ${scopeLabel(sub)}`);
   logger.info(`  url:     ${sub.url}`);
   if (sub.scope === "org") {
+    const product =
+      "productSlug" in sub && sub.productSlug
+        ? sub.productSlug
+        : sub.productId
+          ? sub.productId
+          : chalk.dim("(all products)");
     const source =
       "sourceSlug" in sub && sub.sourceSlug
         ? sub.sourceSlug
         : sub.sourceId
           ? sub.sourceId
           : chalk.dim("(all org sources)");
+    logger.info(`  product: ${product}`);
     logger.info(`  source:  ${source}`);
   }
+  if (sub.releaseType) logger.info(`  type:    ${sub.releaseType}`);
   if (sub.description) logger.info(`  desc:    ${sub.description}`);
   logger.info(`  secret:  v${sub.secretVersion}${chalk.dim(`  · created ${sub.createdAt}`)}`);
   logger.info(`  health:  ${sub.deliveryHealthSummary}`);
@@ -158,6 +174,8 @@ export function registerWebhookManageCommands(webhook: Command): void {
     .option("--scope <scope>", "org (default) or follows", "org")
     .option("--org <slug>", "Org slug or id (required for org scope)")
     .option("--source <slug>", "Limit to one source (org scope only)")
+    .option("--product <slug>", "Limit to one product (org scope only)")
+    .option("--type <kind>", "Limit to release type: feature or rollup")
     .option("--description <text>", "Human-readable label")
     .option("--json", "Output JSON")
     .action(
@@ -166,17 +184,20 @@ export function registerWebhookManageCommands(webhook: Command): void {
         scope: string;
         org?: string;
         source?: string;
+        product?: string;
+        type?: string;
         description?: string;
         json?: boolean;
       }) => {
         requireAuth();
         const scope = opts.scope === "follows" ? "follows" : "org";
+        const releaseType = parseReleaseTypeOpt(opts.type);
         if (scope === "org" && !opts.org) {
           logger.error("--org is required for org-scoped webhooks.");
           process.exit(1);
         }
-        if (scope === "follows" && (opts.org || opts.source)) {
-          logger.error("follows-scoped webhooks must not include --org or --source.");
+        if (scope === "follows" && (opts.org || opts.source || opts.product)) {
+          logger.error("follows-scoped webhooks must not include --org, --source, or --product.");
           process.exit(1);
         }
         const result = await createMyWebhook({
@@ -186,8 +207,10 @@ export function registerWebhookManageCommands(webhook: Command): void {
             ? {
                 orgSlug: opts.org,
                 ...(opts.source ? { sourceSlug: opts.source } : {}),
+                ...(opts.product ? { productSlug: opts.product } : {}),
               }
             : {}),
+          ...(releaseType ? { releaseType } : {}),
           description: opts.description,
         });
         if (opts.json) return writeJson(result);
@@ -235,9 +258,15 @@ export function registerWebhookManageCommands(webhook: Command): void {
 
   webhook
     .command("edit <id>")
-    .description("Update a subscription's url / description / enabled state")
+    .description("Update a subscription's url / description / enabled state / filters")
     .option("--url <url>", "New HTTPS delivery URL (does not rotate the signing key)")
     .option("--description <text>", "New description")
+    .option("--source <slug>", "Org scope: limit to this source slug")
+    .option("--product <slug>", "Org scope: limit to this product slug")
+    .option("--type <kind>", "Limit to release type: feature or rollup")
+    .option("--clear-source", "Org scope: remove source filter")
+    .option("--clear-product", "Org scope: remove product filter")
+    .option("--clear-type", "Remove release-type filter")
     .option("--enable", "Enable the subscription (resets the failure counter)")
     .option("--disable", "Disable the subscription")
     .option("--json", "Output JSON")
@@ -247,6 +276,12 @@ export function registerWebhookManageCommands(webhook: Command): void {
         opts: {
           url?: string;
           description?: string;
+          source?: string;
+          product?: string;
+          type?: string;
+          clearSource?: boolean;
+          clearProduct?: boolean;
+          clearType?: boolean;
           enable?: boolean;
           disable?: boolean;
           json?: boolean;
@@ -257,13 +292,34 @@ export function registerWebhookManageCommands(webhook: Command): void {
           logger.error("Pass at most one of --enable / --disable.");
           process.exit(1);
         }
-        const fields: { url?: string; description?: string; enabled?: boolean } = {};
+        if (opts.clearSource && opts.source) {
+          logger.error("Pass at most one of --source / --clear-source.");
+          process.exit(1);
+        }
+        if (opts.clearProduct && opts.product) {
+          logger.error("Pass at most one of --product / --clear-product.");
+          process.exit(1);
+        }
+        if (opts.clearType && opts.type) {
+          logger.error("Pass at most one of --type / --clear-type.");
+          process.exit(1);
+        }
+        const fields: UpdateMyWebhookInput = {};
         if (opts.url !== undefined) fields.url = opts.url;
         if (opts.description !== undefined) fields.description = opts.description;
         if (opts.enable) fields.enabled = true;
         if (opts.disable) fields.enabled = false;
+        if (opts.source) fields.sourceSlug = opts.source;
+        if (opts.clearSource) fields.sourceId = null;
+        if (opts.product) fields.productSlug = opts.product;
+        if (opts.clearProduct) fields.productId = null;
+        if (opts.clearType) fields.releaseType = null;
+        else if (opts.type !== undefined)
+          fields.releaseType = parseReleaseTypeOpt(opts.type) ?? null;
         if (Object.keys(fields).length === 0) {
-          logger.error("Nothing to change. Pass --url, --description, --enable, or --disable.");
+          logger.error(
+            "Nothing to change. Pass --url, --description, filter flags, --enable, or --disable.",
+          );
           process.exit(1);
         }
         const updated = await updateMyWebhook(id, fields);

--- a/tests/unit/me-webhooks.test.ts
+++ b/tests/unit/me-webhooks.test.ts
@@ -71,6 +71,38 @@ describe("me-webhooks client wire contract", () => {
     expect(calls[0]!.body).toEqual({ url: "https://ex.com/o", orgSlug: "vercel" });
   });
 
+  it("createMyWebhook POSTs org filters and releaseType", async () => {
+    responder = () => json({ id: "whk_7", signingKey: "ghi", scope: "org" });
+    await client.createMyWebhook({
+      url: "https://ex.com/f",
+      orgSlug: "vercel",
+      productSlug: "next-js",
+      sourceSlug: "changelog",
+      releaseType: "feature",
+    });
+    expect(calls[0]!.body).toEqual({
+      url: "https://ex.com/f",
+      orgSlug: "vercel",
+      productSlug: "next-js",
+      sourceSlug: "changelog",
+      releaseType: "feature",
+    });
+  });
+
+  it("updateMyWebhook PATCHes filter fields", async () => {
+    responder = () => json({ id: "whk_8", releaseType: "rollup" });
+    await client.updateMyWebhook("whk_8", {
+      productSlug: "next-js",
+      releaseType: "rollup",
+      sourceId: null,
+    });
+    expect(calls[0]!.body).toEqual({
+      productSlug: "next-js",
+      releaseType: "rollup",
+      sourceId: null,
+    });
+  });
+
   it("updateMyWebhook PATCHes enabled", async () => {
     responder = () => json({ id: "whk_4", enabled: false });
     await client.updateMyWebhook("whk_4", { enabled: false });


### PR DESCRIPTION
## Summary

CLI companion for [buildinternet/releases#1683](https://github.com/buildinternet/releases/pull/1683) / [#1681](https://github.com/buildinternet/releases/issues/1681).

Adds self-serve webhook filter flags matching `POST/PATCH /v1/me/webhooks`:

- **`webhook add`**: `--product <slug>`, `--type feature|rollup` (org scope); `--type` only for follows scope
- **`webhook edit`**: `--source`, `--product`, `--type`, plus `--clear-source`, `--clear-product`, `--clear-type`
- **`webhook show` / `list`**: display product and type filters

## Test plan

- [x] `bun test tests/unit/me-webhooks.test.ts`