### PR TITLE
fix(cli): exit cleanly on broken stdout pipe (--page-all | head no longer hangs)

### DIFF
--- a/.changeset/page-all-epipe-exit.md
+++ b/.changeset/page-all-epipe-exit.md
@@ -1,0 +1,7 @@
+---
+"@buildinternet/releases": patch
+---
+
+Fix: streaming output (`--page-all`, `tail -f --json`) now exits cleanly when a reader closes the pipe early (`… | head`).
+
+Piping NDJSON streaming output into a consumer that closes stdout before EOF — e.g. `releases list --json --page-all | head` or `… | jq | head` — caused the CLI to hang indefinitely. On the early close the next stdout write raises EPIPE, which Bun surfaces as an `'error'` event (rather than crashing); with no handler, the writer was left awaiting a `'drain'` that can never fire. A startup `process.stdout.on("error", …)` handler now treats a broken pipe as a clean `exit(0)`, so `| head` terminates immediately. Full consumption (to EOF, to a file, `| wc -l`) is unaffected.

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,11 @@ import { maybeShowCompletionHint } from "./cli/completion/hint.js";
 import { AmbiguousSourceError } from "./api/sources.js";
 import { formatAmbiguousSourceError } from "./cli/suggest.js";
 import { ApiError, InvalidInputError, CliError, toErrorPayload } from "./lib/errors.js";
-import { writeJson } from "./lib/output.js";
+import { writeJson, handleStdoutPipeError } from "./lib/output.js";
+
+// Exit cleanly when a downstream reader closes the pipe early (`… | head`),
+// rather than hanging in a streaming writer. Registered before any output.
+process.stdout.on("error", handleStdoutPipeError);
 
 /** Whether the invocation requested machine-readable output. `--json` is a
  * boolean flag across every command, so a presence check on argv is reliable

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -25,3 +25,17 @@ export async function writeJsonLine(value: unknown): Promise<void> {
     await new Promise<void>((resolve) => process.stdout.once("drain", resolve));
   }
 }
+
+/**
+ * Process-level handler for a broken stdout pipe. When a downstream reader
+ * closes the pipe early — `… | head`, `… | jq | head` — the next stdout write
+ * raises EPIPE. Bun surfaces it as an `'error'` event rather than crashing, so
+ * without a handler the streaming writers above (`--page-all`, `tail -f --json`)
+ * hang forever on a `'drain'` that can never fire. Treat a broken pipe as a
+ * clean exit (the consumer read all it wanted); rethrow anything else. Wire up
+ * once at startup, before any output: `process.stdout.on("error", handleStdoutPipeError)`.
+ */
+export function handleStdoutPipeError(err: NodeJS.ErrnoException): void {
+  if (err.code === "EPIPE") process.exit(0);
+  throw err;
+}

--- a/tests/unit/output-pipe.test.ts
+++ b/tests/unit/output-pipe.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, spyOn, afterEach } from "bun:test";
+import { handleStdoutPipeError } from "../../src/lib/output.js";
+
+describe("handleStdoutPipeError", () => {
+  let exitSpy: ReturnType<typeof spyOn>;
+  afterEach(() => exitSpy?.mockRestore());
+
+  it("exits cleanly (code 0) on a broken pipe (EPIPE)", () => {
+    // The classic `… | head` case: the reader closed the pipe early. Without
+    // this, the streaming writers (`--page-all`, `tail -f --json`) hang forever.
+    exitSpy = spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("exit");
+    }) as never);
+    const err: NodeJS.ErrnoException = Object.assign(new Error("write EPIPE"), { code: "EPIPE" });
+    expect(() => handleStdoutPipeError(err)).toThrow("exit");
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it("rethrows any non-EPIPE stdout error (does not swallow it)", () => {
+    exitSpy = spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("exit");
+    }) as never);
+    const err: NodeJS.ErrnoException = Object.assign(new Error("write ENOSPC"), { code: "ENOSPC" });
+    expect(() => handleStdoutPipeError(err)).toThrow("write ENOSPC");
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Problem

Piping streaming NDJSON output into a consumer that closes stdout before EOF hangs the CLI **indefinitely**:

```bash
releases list --json --page-all | head      # hung forever
releases org list --json --page-all | jq … | head
releases tail -f --json | head
```

Discovered when smoke-test commands from the `--page-all` work were found still running **45–57 minutes** later, stuck on exactly this pattern.

## Root cause

On the early close, the next `process.stdout.write()` raises `EPIPE`. Bun surfaces this as an `'error'` event on `process.stdout` rather than crashing the process (Node would throw on an unhandled stream error; Bun swallows it). The streaming writers do `await stdout.once("drain")` when `write()` returns `false` — and after a broken pipe that `'drain'` can never fire, so the writer hangs forever.

There was no `process.stdout` error handler anywhere in `src/`.

Verified empirically with a probe: `write()=false … EVENT error EPIPE` — the event fires; nothing was listening.

## Fix

Register a process-level handler at startup (before any output), extracted as `handleStdoutPipeError` in `lib/output.ts`:

```ts
export function handleStdoutPipeError(err: NodeJS.ErrnoException): void {
  if (err.code === "EPIPE") process.exit(0);
  throw err;
}
```

A broken stdout pipe is a clean exit — the consumer already read what it wanted. Any non-EPIPE stdout error is rethrown (not swallowed). This covers every streaming writer at once (`--page-all`, `tail -f --json`).

## Verification

- Unit test (`output-pipe.test.ts`): EPIPE → `exit(0)`; other codes → rethrow.
- End-to-end (bounded, against the live API): `list --page-all | head -3` and `org list --page-all | head -2` now **exit 0 with no orphaned process** (previously hung). Full consumption (`| wc -l` → 75, to a file) is unchanged.
- `tsc` clean, `oxlint` clean, `prettier` clean, `bun test` 1050 pass / 0 fail.

Ships a `patch` changeset.

## Suggested merge order

These `--page-all`/streaming features are unreleased, so it's worth landing this **before** the `chore: version packages` PR so the first published version doesn't hang on `| head`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
