### PR TITLE
feat: add --format slack to webhook add/edit

### DIFF
--- a/.changeset/slack-webhook-format.md
+++ b/.changeset/slack-webhook-format.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": minor
+---
+
+Add `--format slack` to `releases webhook add`/`edit` to deliver releases as formatted Slack messages via a Slack incoming webhook URL.

--- a/src/api/me-webhooks.ts
+++ b/src/api/me-webhooks.ts
@@ -49,7 +49,8 @@ export interface UserWebhookListItem extends Omit<UserWebhookSubscription, "user
 }
 
 export interface CreateUserWebhookResponse extends UserWebhookListItem {
-  signingKey: string;
+  /** Present for json-format webhooks; absent for slack-format (the URL is the secret). */
+  signingKey?: string;
 }
 
 export interface CreateUserWebhookInput {
@@ -63,6 +64,7 @@ export interface CreateUserWebhookInput {
   productId?: string;
   releaseType?: UserWebhookReleaseTypeFilter;
   description?: string | null;
+  format?: "json" | "slack";
 }
 
 /** List the signed-in user's webhook subscriptions. */
@@ -100,6 +102,7 @@ export type UpdateMyWebhookInput = {
   productSlug?: string;
   productId?: string | null;
   releaseType?: UserWebhookReleaseTypeFilter | null;
+  format?: "json" | "slack";
 };
 
 export async function updateMyWebhook(

--- a/src/api/me-webhooks.ts
+++ b/src/api/me-webhooks.ts
@@ -37,6 +37,7 @@ export interface UserWebhookSubscription {
   failureStreakStartedAt: string | null;
   deliveryHealth: WebhookDeliveryHealth;
   deliveryHealthSummary: string;
+  format?: "json" | "slack";
 }
 
 export interface UserWebhookListItem extends Omit<UserWebhookSubscription, "userId"> {

--- a/src/cli/commands/webhook-manage.ts
+++ b/src/cli/commands/webhook-manage.ts
@@ -57,6 +57,13 @@ function parseReleaseTypeOpt(value: string | undefined): "feature" | "rollup" | 
   process.exit(1);
 }
 
+function parseFormatOpt(format: string | undefined): "json" | "slack" {
+  if (!format || format === "json") return "json";
+  if (format === "slack") return "slack";
+  logger.error("--format must be 'json' or 'slack'.");
+  process.exit(1);
+}
+
 function parseLimit(value: string): number {
   const n = parseInt(value, 10);
   if (Number.isNaN(n) || n === 0) return 20;
@@ -193,11 +200,7 @@ export function registerWebhookManageCommands(webhook: Command): void {
         json?: boolean;
       }) => {
         requireAuth();
-        if (opts.format && opts.format !== "json" && opts.format !== "slack") {
-          logger.error("--format must be 'json' or 'slack'.");
-          process.exit(1);
-        }
-        const format = opts.format === "slack" ? "slack" : "json";
+        const format = parseFormatOpt(opts.format);
         const scope = opts.scope === "follows" ? "follows" : "org";
         const releaseType = parseReleaseTypeOpt(opts.type);
         if (scope === "org" && !opts.org) {
@@ -320,10 +323,6 @@ export function registerWebhookManageCommands(webhook: Command): void {
           logger.error("Pass at most one of --type / --clear-type.");
           process.exit(1);
         }
-        if (opts.format && opts.format !== "json" && opts.format !== "slack") {
-          logger.error("--format must be 'json' or 'slack'.");
-          process.exit(1);
-        }
         const fields: UpdateMyWebhookInput = {};
         if (opts.url !== undefined) fields.url = opts.url;
         if (opts.description !== undefined) fields.description = opts.description;
@@ -336,7 +335,7 @@ export function registerWebhookManageCommands(webhook: Command): void {
         if (opts.clearType) fields.releaseType = null;
         else if (opts.type !== undefined)
           fields.releaseType = parseReleaseTypeOpt(opts.type) ?? null;
-        if (opts.format) fields.format = opts.format as "json" | "slack";
+        if (opts.format) fields.format = parseFormatOpt(opts.format);
         if (Object.keys(fields).length === 0) {
           logger.error(
             "Nothing to change. Pass --url, --description, --format, filter flags, --enable, or --disable.",

--- a/src/cli/commands/webhook-manage.ts
+++ b/src/cli/commands/webhook-manage.ts
@@ -83,6 +83,7 @@ function printSubscription(sub: UserWebhookSubscription | UserWebhookListItem): 
     logger.info(`  source:  ${source}`);
   }
   if (sub.releaseType) logger.info(`  type:    ${sub.releaseType}`);
+  if (sub.format === "slack") logger.info(`  format:  slack (Slack Block Kit, unsigned)`);
   if (sub.description) logger.info(`  desc:    ${sub.description}`);
   logger.info(`  secret:  v${sub.secretVersion}${chalk.dim(`  · created ${sub.createdAt}`)}`);
   logger.info(`  health:  ${sub.deliveryHealthSummary}`);

--- a/src/cli/commands/webhook-manage.ts
+++ b/src/cli/commands/webhook-manage.ts
@@ -177,6 +177,7 @@ export function registerWebhookManageCommands(webhook: Command): void {
     .option("--product <slug>", "Limit to one product (org scope only)")
     .option("--type <kind>", "Limit to release type: feature or rollup")
     .option("--description <text>", "Human-readable label")
+    .option("--format <format>", "Delivery format: json (default) or slack")
     .option("--json", "Output JSON")
     .action(
       async (opts: {
@@ -187,9 +188,15 @@ export function registerWebhookManageCommands(webhook: Command): void {
         product?: string;
         type?: string;
         description?: string;
+        format?: string;
         json?: boolean;
       }) => {
         requireAuth();
+        if (opts.format && opts.format !== "json" && opts.format !== "slack") {
+          logger.error("--format must be 'json' or 'slack'.");
+          process.exit(1);
+        }
+        const format = opts.format === "slack" ? "slack" : "json";
         const scope = opts.scope === "follows" ? "follows" : "org";
         const releaseType = parseReleaseTypeOpt(opts.type);
         if (scope === "org" && !opts.org) {
@@ -203,6 +210,7 @@ export function registerWebhookManageCommands(webhook: Command): void {
         const result = await createMyWebhook({
           url: opts.url,
           scope,
+          format,
           ...(scope === "org"
             ? {
                 orgSlug: opts.org,
@@ -215,12 +223,17 @@ export function registerWebhookManageCommands(webhook: Command): void {
         });
         if (opts.json) return writeJson(result);
         printSubscription(result);
-        logger.info("");
-        logger.info(chalk.bold("Signing key (shown once — store it now):"));
-        logger.info(`  ${chalk.green(result.signingKey)}`);
-        logger.info(
-          chalk.dim("  Re-derive only via `webhook rotate-secret` (invalidates the old key)."),
-        );
+        if (result.signingKey) {
+          logger.info("");
+          logger.info(chalk.bold("Signing key (shown once — store it now):"));
+          logger.info(`  ${chalk.green(result.signingKey)}`);
+          logger.info(
+            chalk.dim("  Re-derive only via `webhook rotate-secret` (invalidates the old key)."),
+          );
+        } else {
+          logger.info("");
+          logger.info(chalk.dim("  Slack webhook — no signing key (the URL is the secret)."));
+        }
       },
     );
 
@@ -269,6 +282,7 @@ export function registerWebhookManageCommands(webhook: Command): void {
     .option("--clear-type", "Remove release-type filter")
     .option("--enable", "Enable the subscription (resets the failure counter)")
     .option("--disable", "Disable the subscription")
+    .option("--format <format>", "Change delivery format: json or slack")
     .option("--json", "Output JSON")
     .action(
       async (
@@ -284,6 +298,7 @@ export function registerWebhookManageCommands(webhook: Command): void {
           clearType?: boolean;
           enable?: boolean;
           disable?: boolean;
+          format?: string;
           json?: boolean;
         },
       ) => {
@@ -304,6 +319,10 @@ export function registerWebhookManageCommands(webhook: Command): void {
           logger.error("Pass at most one of --type / --clear-type.");
           process.exit(1);
         }
+        if (opts.format && opts.format !== "json" && opts.format !== "slack") {
+          logger.error("--format must be 'json' or 'slack'.");
+          process.exit(1);
+        }
         const fields: UpdateMyWebhookInput = {};
         if (opts.url !== undefined) fields.url = opts.url;
         if (opts.description !== undefined) fields.description = opts.description;
@@ -316,9 +335,10 @@ export function registerWebhookManageCommands(webhook: Command): void {
         if (opts.clearType) fields.releaseType = null;
         else if (opts.type !== undefined)
           fields.releaseType = parseReleaseTypeOpt(opts.type) ?? null;
+        if (opts.format) fields.format = opts.format as "json" | "slack";
         if (Object.keys(fields).length === 0) {
           logger.error(
-            "Nothing to change. Pass --url, --description, filter flags, --enable, or --disable.",
+            "Nothing to change. Pass --url, --description, --format, filter flags, --enable, or --disable.",
           );
           process.exit(1);
         }


### PR DESCRIPTION
## Summary

Adds a `--format` flag to `releases webhook add` and `releases webhook edit`, so a webhook subscription can deliver releases as formatted Slack messages instead of the default signed JSON payload.

- `--format json` (default) keeps today's behavior.
- `--format slack` posts releases to a Slack incoming-webhook URL as a Block Kit card. Slack subscriptions are unsigned (the URL is the secret), so no signing key is printed — the CLI shows a short note instead.

Validation fails closed: any value other than `json`/`slack` errors and exits non-zero. The check is factored into a `parseFormatOpt` helper shared by both commands, mirroring the existing `parseReleaseTypeOpt` pattern. `releases webhook show`/`list` now surface the format for Slack subscriptions.

The server side (format column, delivery formatting, Slack host allowlist) ships in the monorepo PR (buildinternet/releases#1737).

## Testing

- `npx tsc --noEmit`: clean.
- `bun test`: no new failures (the handful of pre-existing auth/credential env-leak failures are unrelated to this change).

## Notes

- Includes a changeset (`minor`) targeting `@buildinternet/releases`.
