### PR TITLE
chore: link releases backend for CodeRabbit multi-repo context

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+knowledge_base:
+  linked_repositories:
+    - repository: buildinternet/releases
+      instructions: >-
+        The Releases backend monorepo and source of truth for this CLI: the
+        Cloudflare API worker + D1, the remote MCP server, the web frontend, and
+        the published packages this CLI depends on —
+        @buildinternet/releases-core (DB schema + shared helpers),
+        @buildinternet/releases-api-types (wire protocol), and
+        @buildinternet/releases-lib. The wire protocol, shared schema, and CLI
+        contracts are defined there and land before this CLI adopts them on a
+        version bump. Consider this repo when reviewing changes that depend on or
+        assume server/API/wire behavior.


### PR DESCRIPTION
## What

Add a minimal `.coderabbit.yaml` that links this CLI to the backend monorepo for [CodeRabbit multi-repo analysis](https://docs.coderabbit.ai/knowledge-base/multi-repo-analysis).

```yaml
knowledge_base:
  linked_repositories:
    - repository: buildinternet/releases
      instructions: >-
        ...what the backend is and which published packages this CLI consumes...
```

## Why

This CLI is a thin client over the [`buildinternet/releases`](https://github.com/buildinternet/releases) backend and consumes its published packages — `@buildinternet/releases-core` (schema/helpers), `@buildinternet/releases-api-types` (wire protocol), and `@buildinternet/releases-lib`. Those wire/schema/CLI contracts are defined upstream and adopted here on a version bump.

Linking the repos gives CodeRabbit explicit context about that dependency so reviews here understand the upstream server/API behavior they assume. The companion PR in `releases` adds the reciprocal link back to this CLI.

## Scope

Config-only — a single new file, no published-package code touched (no changeset needed). No other CodeRabbit settings are set.
