### PR TITLE
feat(webhook): adopt api-types wire shapes for #1738

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "releases-cli",
       "dependencies": {
-        "@buildinternet/releases-api-types": "^0.34.0",
+        "@buildinternet/releases-api-types": "^0.34.1",
         "@buildinternet/releases-core": "^0.23.0",
         "@buildinternet/releases-lib": "workspace:*",
         "@buildinternet/releases-skills": "workspace:*",
@@ -75,7 +75,7 @@
 
     "@buildinternet/releases": ["@buildinternet/releases@workspace:npm/releases"],
 
-    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.34.0", "", { "dependencies": { "@buildinternet/releases-core": "^0.23.0", "zod": "^4.4.3" } }, "sha512-y0W0/N6XZ7kaMiXd+1XuPYea9xVIE5d+zshtDbXPmHiPRwBeVeIg5qZTHfOUtVaYrc3mf6wZZmy9jwUtmu7ZmQ=="],
+    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.34.1", "", { "dependencies": { "@buildinternet/releases-core": "^0.24.0", "zod": "^4.4.3" } }, "sha512-cNpudiEQZ1CE29pKCbX/HKqeHMg8i9cCsxZVSxHH4+u4kJeE1RZgAjr/4K+eiCXUolMDM069kGxJz0MiZDO/7g=="],
 
     "@buildinternet/releases-core": ["@buildinternet/releases-core@0.23.0", "", { "dependencies": { "drizzle-orm": "^0.45.2", "js-tiktoken": "^1.0.21", "nanoid": "^5.1.7" } }, "sha512-ieUK+KTlXmxX6nRHIft4alMuNNOJctk8AKCfbJmM0SbWqLHcHjLy9O+sj2R+4052IhwJI86gPFpTLM1QNfLFDA=="],
 
@@ -611,6 +611,8 @@
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
+    "@buildinternet/releases-api-types/@buildinternet/releases-core": ["@buildinternet/releases-core@0.24.0", "", { "dependencies": { "drizzle-orm": "^0.45.2", "js-tiktoken": "^1.0.21", "nanoid": "^5.1.15" } }, "sha512-NTrYXCeJ+XEmbAqBZSadY3Ya5VhGabXb5eJjCPPLw8nji/E54qCfzj1x/hdj/IHHrWBA/Sg8lHkT3O0CxiiJdw=="],
+
     "@buildinternet/releases-api-types/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "@manypkg/find-root/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
@@ -636,6 +638,8 @@
     "read-yaml-file/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 
     "wrap-ansi/string-width": ["string-width@8.2.1", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA=="],
+
+    "@buildinternet/releases-api-types/@buildinternet/releases-core/nanoid": ["nanoid@5.1.16", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ=="],
 
     "bun-types/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "releases-cli",
       "dependencies": {
-        "@buildinternet/releases-api-types": "file:../releases/.worktrees/issue-1738-slack-webhook-followups/packages/api-types",
+        "@buildinternet/releases-api-types": "^0.34.0",
         "@buildinternet/releases-core": "^0.23.0",
         "@buildinternet/releases-lib": "workspace:*",
         "@buildinternet/releases-skills": "workspace:*",
@@ -75,7 +75,7 @@
 
     "@buildinternet/releases": ["@buildinternet/releases@workspace:npm/releases"],
 
-    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@file:../releases/.worktrees/issue-1738-slack-webhook-followups/packages/api-types", { "dependencies": { "@buildinternet/releases-core": "^0.23.0", "zod": "^4.4.3" } }],
+    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.34.0", "", { "dependencies": { "@buildinternet/releases-core": "^0.23.0", "zod": "^4.4.3" } }, "sha512-y0W0/N6XZ7kaMiXd+1XuPYea9xVIE5d+zshtDbXPmHiPRwBeVeIg5qZTHfOUtVaYrc3mf6wZZmy9jwUtmu7ZmQ=="],
 
     "@buildinternet/releases-core": ["@buildinternet/releases-core@0.23.0", "", { "dependencies": { "drizzle-orm": "^0.45.2", "js-tiktoken": "^1.0.21", "nanoid": "^5.1.7" } }, "sha512-ieUK+KTlXmxX6nRHIft4alMuNNOJctk8AKCfbJmM0SbWqLHcHjLy9O+sj2R+4052IhwJI86gPFpTLM1QNfLFDA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "releases-cli",
       "dependencies": {
-        "@buildinternet/releases-api-types": "^0.33.0",
+        "@buildinternet/releases-api-types": "file:../releases/.worktrees/issue-1738-slack-webhook-followups/packages/api-types",
         "@buildinternet/releases-core": "^0.23.0",
         "@buildinternet/releases-lib": "workspace:*",
         "@buildinternet/releases-skills": "workspace:*",
@@ -75,7 +75,7 @@
 
     "@buildinternet/releases": ["@buildinternet/releases@workspace:npm/releases"],
 
-    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.33.0", "", { "dependencies": { "@buildinternet/releases-core": "^0.23.0", "zod": "^4.4.3" } }, "sha512-RCQtLDFztVv/mNtFvu0QWuL2IvS0j4L+mTDAv1nnChakPwgZz1/gRKfy0BdjWyrP7+pnDRA7fAD2PJvApYzODQ=="],
+    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@file:../releases/.worktrees/issue-1738-slack-webhook-followups/packages/api-types", { "dependencies": { "@buildinternet/releases-core": "^0.23.0", "zod": "^4.4.3" } }],
 
     "@buildinternet/releases-core": ["@buildinternet/releases-core@0.23.0", "", { "dependencies": { "drizzle-orm": "^0.45.2", "js-tiktoken": "^1.0.21", "nanoid": "^5.1.7" } }, "sha512-ieUK+KTlXmxX6nRHIft4alMuNNOJctk8AKCfbJmM0SbWqLHcHjLy9O+sj2R+4052IhwJI86gPFpTLM1QNfLFDA=="],
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "homepage": "https://releases.sh",
   "dependencies": {
-    "@buildinternet/releases-api-types": "^0.34.0",
+    "@buildinternet/releases-api-types": "^0.34.1",
     "@buildinternet/releases-core": "^0.23.0",
     "@buildinternet/releases-lib": "workspace:*",
     "@buildinternet/releases-skills": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "homepage": "https://releases.sh",
   "dependencies": {
-    "@buildinternet/releases-api-types": "^0.33.0",
+    "@buildinternet/releases-api-types": "^0.34.0",
     "@buildinternet/releases-core": "^0.23.0",
     "@buildinternet/releases-lib": "workspace:*",
     "@buildinternet/releases-skills": "workspace:*",

--- a/src/api/me-webhooks.ts
+++ b/src/api/me-webhooks.ts
@@ -1,5 +1,5 @@
+import type { UserWebhookFormat, WebhookDeliveryRow } from "@buildinternet/releases-api-types";
 import { apiFetch } from "./core.js";
-import type { WebhookDeliveryRow } from "./webhooks.js";
 
 /**
  * Self-serve `/v1/me/webhooks` wire shapes. Defined locally until they ship in
@@ -37,7 +37,7 @@ export interface UserWebhookSubscription {
   failureStreakStartedAt: string | null;
   deliveryHealth: WebhookDeliveryHealth;
   deliveryHealthSummary: string;
-  format?: "json" | "slack";
+  format?: UserWebhookFormat;
 }
 
 export interface UserWebhookListItem extends Omit<UserWebhookSubscription, "userId"> {
@@ -65,7 +65,7 @@ export interface CreateUserWebhookInput {
   productId?: string;
   releaseType?: UserWebhookReleaseTypeFilter;
   description?: string | null;
-  format?: "json" | "slack";
+  format?: UserWebhookFormat;
 }
 
 /** List the signed-in user's webhook subscriptions. */
@@ -103,7 +103,7 @@ export type UpdateMyWebhookInput = {
   productSlug?: string;
   productId?: string | null;
   releaseType?: UserWebhookReleaseTypeFilter | null;
-  format?: "json" | "slack";
+  format?: UserWebhookFormat;
 };
 
 export async function updateMyWebhook(

--- a/src/api/webhooks.ts
+++ b/src/api/webhooks.ts
@@ -1,4 +1,7 @@
+import type { WebhookDeliveryRow } from "@buildinternet/releases-api-types";
 import { apiFetch } from "./core.js";
+
+export type { WebhookDeliveryRow };
 
 /**
  * A webhook subscription as returned by the read paths. Defined locally rather
@@ -32,18 +35,6 @@ export interface CreateWebhookSubscriptionInput {
   url: string;
   sourceId?: string | null;
   description?: string | null;
-}
-
-/** One Analytics Engine delivery-attempt row from `GET /v1/webhooks/:id/deliveries`. */
-export interface WebhookDeliveryRow {
-  timestamp?: string;
-  event_id?: string;
-  error_message?: string | null;
-  error_code?: string | null;
-  outcome?: string;
-  http_status?: number;
-  latency_ms?: number;
-  attempt?: number;
 }
 
 /** Register a webhook subscription. The `signingKey` is shown once and never again. */

--- a/src/cli/commands/admin/webhook.ts
+++ b/src/cli/commands/admin/webhook.ts
@@ -82,6 +82,7 @@ function renderDeliveries(rows: WebhookDeliveryRow[]): string {
   return renderTable({
     head: [
       { label: "Time", noTruncate: true },
+      { label: "Format" },
       { label: "Outcome" },
       { label: "HTTP" },
       { label: "Latency" },
@@ -90,6 +91,7 @@ function renderDeliveries(rows: WebhookDeliveryRow[]): string {
     ],
     rows: rows.map((r) => [
       r.timestamp ?? chalk.dim("—"),
+      r.format?.trim() || chalk.dim("—"),
       r.outcome ?? chalk.dim("—"),
       r.http_status != null ? String(r.http_status) : chalk.dim("—"),
       r.latency_ms != null ? `${r.latency_ms}ms` : chalk.dim("—"),

--- a/src/cli/commands/webhook-manage.ts
+++ b/src/cli/commands/webhook-manage.ts
@@ -8,6 +8,7 @@ import chalk from "chalk";
 import { logger } from "@releases/lib/logger";
 import { isAuthenticated } from "../../lib/mode.js";
 import { writeJson } from "../../lib/output.js";
+import type { UserWebhookFormat } from "@buildinternet/releases-api-types";
 import type { WebhookDeliveryRow } from "../../api/webhooks.js";
 import {
   createMyWebhook,
@@ -57,7 +58,7 @@ function parseReleaseTypeOpt(value: string | undefined): "feature" | "rollup" | 
   process.exit(1);
 }
 
-function parseFormatOpt(format: string | undefined): "json" | "slack" {
+function parseFormatOpt(format: string | undefined): UserWebhookFormat {
   if (!format || format === "json") return "json";
   if (format === "slack") return "slack";
   logger.error("--format must be 'json' or 'slack'.");
@@ -114,6 +115,7 @@ function renderDeliveries(rows: WebhookDeliveryRow[]): string {
   return renderTable({
     head: [
       { label: "Time", noTruncate: true },
+      { label: "Format" },
       { label: "Outcome" },
       { label: "HTTP" },
       { label: "Latency" },
@@ -122,6 +124,7 @@ function renderDeliveries(rows: WebhookDeliveryRow[]): string {
     ],
     rows: rows.map((r) => [
       r.timestamp ?? chalk.dim("—"),
+      r.format?.trim() || chalk.dim("—"),
       r.outcome ?? chalk.dim("—"),
       r.http_status != null ? String(r.http_status) : chalk.dim("—"),
       r.latency_ms != null ? `${r.latency_ms}ms` : chalk.dim("—"),


### PR DESCRIPTION
Follow-up to buildinternet/releases#1738 / releases-cli#332.

## Summary
- Adopts `UserWebhookFormat` and `WebhookDeliveryRow` from `@buildinternet/releases-api-types`
- Shows delivery `format` column in `releases webhook deliveries` and admin webhook deliveries tables

## Dependency
Requires **@buildinternet/releases-api-types@0.34.0** from the paired releases PR. Merge/publish that first, then bump the lockfile here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Format” column to webhook delivery/history views, displaying the delivery format (or a placeholder when unavailable).

* **Bug Fixes**
  * Improved webhook format handling and validation by aligning webhook format types across the app.

* **Chores**
  * Updated the shared API types dependency to a newer minor version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->