### PR TITLE
feat(cli): add autoGenerateContent toggle to admin org update (#1794)

### DIFF
--- a/.changeset/auto-generate-content-toggle.md
+++ b/.changeset/auto-generate-content-toggle.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": minor
+---
+
+Add `--auto-generate-content` / `--no-auto-generate-content` to `releases admin org update` — the single backend gate that decides whether an org gets AI overviews and per-release summaries. Previously the only way to toggle it was a raw `curl` PATCH. `releases admin org get` now shows the current value, and `releases admin overview plan` surfaces an `opted_out` action for orgs the batch skips because the flag is off.

--- a/src/cli/commands/admin/overview.ts
+++ b/src/cli/commands/admin/overview.ts
@@ -626,7 +626,12 @@ async function overviewPlanAction(opts: OverviewPlanOpts): Promise<void> {
     if (r.action) acc[r.action] = (acc[r.action] ?? 0) + 1;
     return acc;
   }, {});
-  const parts = ["missing", "refresh", "skip"].map((a) => `${a}: ${byAction[a] ?? 0}`).join(" · ");
+  // `opted_out` = autoGenerateContent is off, so the batch skips the org
+  // regardless of staleness (buildinternet/releases#1795). Surfaced here so it
+  // isn't silently absent from the tally.
+  const parts = ["missing", "refresh", "skip", "opted_out"]
+    .map((a) => `${a}: ${byAction[a] ?? 0}`)
+    .join(" · ");
   console.log(chalk.dim(`\n${rows.length} org(s) — ${parts}`));
 }
 
@@ -795,9 +800,11 @@ Examples:
   releases admin overview plan --stale-days 14 --missing --has-activity --json
   releases admin overview plan --json
 
-Adds per-row \`action\` (missing | refresh | skip) and \`needsFetch\` (true when
-the org has active sources but the most recent release is more than 7 days
-old — orchestrator should poll-and-fetch first).`,
+Adds per-row \`action\` (missing | refresh | skip | opted_out) and \`needsFetch\`
+(true when the org has active sources but the most recent release is more than
+7 days old — orchestrator should poll-and-fetch first). \`opted_out\` means the
+org has auto-generate content off, so the batch skips it regardless of
+staleness — flip it on with \`releases admin org update <org> --auto-generate-content\`.`,
     )
     .action(overviewPlanAction);
 

--- a/src/cli/commands/org.ts
+++ b/src/cli/commands/org.ts
@@ -215,6 +215,11 @@ async function orgGetAction(identifier: string, opts: OrgGetOpts): Promise<void>
   console.log(`  Created: ${found.createdAt}`);
   console.log(`  Updated: ${found.updatedAt}`);
   if (found.category) console.log(`  Category: ${found.category}`);
+  console.log(
+    `  AI content: ${
+      found.autoGenerateContent ? chalk.green("on (overviews + summaries)") : chalk.dim("off")
+    }`,
+  );
   if (orgTags.length > 0) console.log(`  Tags:    ${orgTags.join(", ")}`);
   if (found.notice) console.log(`  ${chalk.yellow(formatNotice(found.notice))}`);
 
@@ -282,6 +287,7 @@ type OrgUpdateOpts = {
   avatar?: string | boolean;
   paused?: boolean;
   featured?: boolean;
+  autoGenerateContent?: boolean;
   discovery?: string;
   notice?: string;
   noticeLink?: string;
@@ -330,6 +336,12 @@ async function orgUpdateAction(identifier: string, opts: OrgUpdateOpts): Promise
   // boolean (undefined when neither is passed).
   if (opts.featured !== undefined) updates.featured = opts.featured;
 
+  // The single backend gate for both org overviews and per-release summaries
+  // (buildinternet/releases#1794). Commander surfaces --auto-generate-content /
+  // --no-auto-generate-content as one boolean (undefined when neither passed).
+  if (opts.autoGenerateContent !== undefined)
+    updates.autoGenerateContent = opts.autoGenerateContent;
+
   if (opts.discovery !== undefined) updates.discovery = opts.discovery;
 
   const noticePatch = buildNoticePatch(opts, logger);
@@ -357,8 +369,16 @@ async function orgUpdateAction(identifier: string, opts: OrgUpdateOpts): Promise
   else {
     const pausedSuffix =
       opts.paused === true ? "  — paused" : opts.paused === false ? "  — unpaused" : "";
+    const autoGenSuffix =
+      opts.autoGenerateContent === true
+        ? "  — AI content on"
+        : opts.autoGenerateContent === false
+          ? "  — AI content off"
+          : "";
     logger.info(
-      chalk.green(`Updated organization: ${updated.name} (${updated.slug})${pausedSuffix}`),
+      chalk.green(
+        `Updated organization: ${updated.name} (${updated.slug})${pausedSuffix}${autoGenSuffix}`,
+      ),
     );
   }
 }
@@ -743,6 +763,14 @@ Examples:
     .option("--featured", "Promote this org on the home-page featured rail")
     .option("--no-featured", "Remove this org from the home-page featured rail")
     .option(
+      "--auto-generate-content",
+      "Opt this org into automatic AI content (overviews + per-release summaries)",
+    )
+    .option(
+      "--no-auto-generate-content",
+      "Opt this org out of automatic AI content (overviews + per-release summaries)",
+    )
+    .option(
       "--discovery <status>",
       `Promote/demote discovery status (${SOURCE_DISCOVERY.join(" | ")})`,
     )
@@ -815,6 +843,14 @@ Examples:
     .option("--no-paused", "Resume ingest for this org's sources")
     .option("--featured", "Promote this org on the home-page featured rail")
     .option("--no-featured", "Remove this org from the home-page featured rail")
+    .option(
+      "--auto-generate-content",
+      "Opt this org into automatic AI content (overviews + per-release summaries)",
+    )
+    .option(
+      "--no-auto-generate-content",
+      "Opt this org out of automatic AI content (overviews + per-release summaries)",
+    )
     .option(
       "--discovery <status>",
       `Promote/demote discovery status (${SOURCE_DISCOVERY.join(" | ")})`,


### PR DESCRIPTION
Closes #1794.

## Problem

`releases admin org update` had no flag to set `autoGenerateContent` — the single backend gate that decides whether an org gets AI overviews **and** per-release summaries. The REST route already accepted it (`PATCH /v1/orgs/:slug`), so the capability existed; only the CLI surface was missing. During the 2026-06-30 audit, ~16 curated orgs found opted out had to be flipped with raw `curl` PATCH calls.

## Changes

- **`releases admin org update`** — add `--auto-generate-content` / `--no-auto-generate-content` (mirrors the existing `--paused` / `--no-paused` pair), wired to the existing PATCH field. Added to both the canonical `update` and the deprecated `edit` alias, matching the existing option-duplication convention.
- **`releases admin org get`** — now prints an `AI content:` line showing the current value.
- **`releases admin overview plan`** — the action tally and help text now surface the new `opted_out` action (an org the batch-overview sweep skips because auto-generate is off), with a pointer to flip it on.

## Notes

- The `opted_out` action is a runtime string from the API; the published `@buildinternet/releases-api-types` type gains it in the companion backend PR (buildinternet/releases#1809) — the CLI reads it as a value, so no api-types pin bump is required here.
- Smoke-tested: `--no-auto-generate-content --dry-run` produces `autoGenerateContent → false`; `org get` shows `AI content: on`.
- `bun run check` (oxlint + format) clean; 1050 tests pass. Changeset added (`minor`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added organization controls for AI content generation, including on/off options during updates.
  * Organization details now show the current AI content setting.
  * Overview planning now recognizes organizations skipped because AI content generation is turned off.

* **Bug Fixes**
  * Update confirmations now include the AI content status alongside other organization status details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->