### PR TITLE
fix: read API error messages from the standardized nested envelope

### DIFF
--- a/.changeset/std-errors-nested-envelope.md
+++ b/.changeset/std-errors-nested-envelope.md
@@ -1,0 +1,10 @@
+---
+"@buildinternet/releases": patch
+---
+
+Read API error messages from the standardized nested error envelope. The API now
+returns `{ error: { code, type, message } }`; the CLI was still reading a
+top-level `body.message`, so non-2xx responses surfaced a generic status text
+(e.g. "Bad Request") instead of the server's actual message. A new
+`apiErrorMessage()` reader pulls `error.message` (tolerating the legacy flat
+`{ message }` body), restoring precise error output.

--- a/src/api/core.ts
+++ b/src/api/core.ts
@@ -1,7 +1,7 @@
 import { getApiUrl, getApiKey, isAdminMode } from "../lib/mode.js";
 import { shouldRecordMutation, recordMutation } from "../lib/mutation-log.js";
 import { RELEASES_CLI_UA } from "../lib/user-agent.js";
-import { ApiError } from "../lib/errors.js";
+import { ApiError, apiErrorMessage } from "../lib/errors.js";
 import { assertSafePath } from "../lib/validate-input.js";
 import type { LatestRelease, MediaItem } from "./types.js";
 import { type ListResponse } from "@buildinternet/releases-core/cli-contracts";
@@ -86,8 +86,8 @@ export async function apiFetch<T>(path: string, opts?: RequestInit): Promise<T> 
   if (res.status === 404 && (!opts?.method || opts.method === "GET")) return null as T;
 
   if (!res.ok) {
-    const body = await res.json().catch(() => ({ message: res.statusText }));
-    const message = (body as { message?: string }).message ?? res.statusText;
+    const body: unknown = await res.json().catch(() => null);
+    const message = apiErrorMessage(body) ?? res.statusText;
     if (logMutation) {
       recordMutation({ method, path, ok: false, status: res.status, error: message });
     }

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -62,6 +62,27 @@ export type CliErrorPayload = {
   };
 };
 
+/**
+ * Pull the human message out of a non-2xx API body. The API emits the
+ * standardized nested envelope `{ error: { code, type, message } }`; this reads
+ * `error.message`, tolerating a legacy flat `{ message }` body and any
+ * malformed/empty payload (→ undefined so the caller falls back to statusText).
+ *
+ * A thin stand-in for `@buildinternet/releases-api-types`' `decodeApiError`:
+ * the CLI only needs the message, and the published api-types pin does not yet
+ * export the errors module. Swap for `decodeApiError().message` once it does.
+ */
+export function apiErrorMessage(body: unknown): string | undefined {
+  if (!body || typeof body !== "object") return undefined;
+  const nested = (body as { error?: unknown }).error;
+  if (nested && typeof nested === "object") {
+    const message = (nested as { message?: unknown }).message;
+    if (typeof message === "string" && message.length > 0) return message;
+  }
+  const flat = (body as { message?: unknown }).message;
+  return typeof flat === "string" && flat.length > 0 ? flat : undefined;
+}
+
 /** Render any thrown value into the stable structured error payload. */
 export function toErrorPayload(err: unknown): CliErrorPayload {
   if (err instanceof ApiError) {

--- a/tests/unit/api-client.test.ts
+++ b/tests/unit/api-client.test.ts
@@ -74,21 +74,29 @@ describe("apiFetch 404 handling", () => {
     expect(result).toBeNull();
   });
 
-  it("throws on POST 404 (addIgnoredUrl)", async () => {
-    mockFetch(404, { message: "Not Found" });
+  it("surfaces the message from the standardized nested error envelope (POST 404)", async () => {
+    // The API emits `{ error: { code, type, message } }`; the CLI must read
+    // `error.message`, not a top-level `message`.
+    mockFetch(404, { error: { code: "not_found", type: "not_found", message: "Org not found" } });
     await expect(client.addIgnoredUrl("https://example.com", "org_123")).rejects.toThrow(
-      /API error \(404\) on POST/,
+      /API error \(404\) on POST .*: Org not found/,
     );
   });
 
-  it("throws on DELETE 404 (deleteRelease)", async () => {
+  it("tolerates a legacy flat { message } body (DELETE 404)", async () => {
     mockFetch(404, { message: "Not Found" });
-    await expect(client.deleteRelease("rel_123")).rejects.toThrow(/API error \(404\) on DELETE/);
+    await expect(client.deleteRelease("rel_123")).rejects.toThrow(
+      /API error \(404\) on DELETE .*: Not Found/,
+    );
   });
 
-  it("throws on non-404 errors for GET", async () => {
-    mockFetch(500, { message: "Internal Server Error" });
-    await expect(client.findSource("test")).rejects.toThrow(/API error \(500\)/);
+  it("throws on non-404 errors for GET, surfacing the envelope message", async () => {
+    mockFetch(500, {
+      error: { code: "internal_error", type: "internal", message: "Internal server error" },
+    });
+    await expect(client.findSource("test")).rejects.toThrow(
+      /API error \(500\).*: Internal server error/,
+    );
   });
 });
 


### PR DESCRIPTION
Item 3b of buildinternet/releases#1830 (Phase 4 consumers) — the out-of-tree CLI
half of the standardized-errors migration.

## Problem

The API now emits the standardized nested error envelope
`{ error: { code, type, message } }`. The CLI's core client (`src/api/core.ts`)
read a **top-level** `body.message`, which post-migration is `undefined` — so
every non-2xx surfaced a generic `res.statusText` ("Bad Request", "Conflict", …)
instead of the server's actual message. A live regression since the API's Phase 3.

## Fix

- New `apiErrorMessage(body)` in `src/lib/errors.ts`: reads `error.message` from
  the nested envelope, tolerating a legacy flat `{ message }` body and any
  malformed/empty payload (→ `undefined`, so the caller falls back to statusText).
- Wired into `apiFetch`'s non-ok branch.

A deliberately thin stand-in for api-types' `decodeApiError`: the CLI only needs
the message, and the pinned `@buildinternet/releases-api-types@0.34.1` does **not
yet export the errors module** (it was added to the monorepo without a version
bump). Swap `apiErrorMessage` for `decodeApiError().message` once a new api-types
is published — tracked as the remaining nicety on the epic.

## Tests

`api-client.test.ts` now asserts the message is surfaced from the nested envelope
(POST 404, GET 500) and that a legacy flat `{ message }` body still works.

Changeset: `@buildinternet/releases` patch.

_Note: 7 pre-existing credential/auth e2e failures in the full suite are
environment-dependent (they read real `~/.releases` credentials) and unrelated to
this change — verified they fail identically on a clean tree._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API errors now show the server-provided message instead of generic HTTP status text.
  * Improved handling for both the new nested error format and the older flat message format, so failures are clearer and more consistent.

* **Tests**
  * Updated coverage for error responses to verify message extraction across multiple API response shapes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->