### PR TITLE
fix: read API error messages via the published decodeApiError

### DIFF
--- a/.changeset/swap-decode-api-error.md
+++ b/.changeset/swap-decode-api-error.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": patch
+---
+
+Read API error messages through api-types' canonical `decodeApiError` instead of a hand-rolled envelope reader. Behavior is unchanged — the nested `{ error: { code, type, message } }` envelope, a legacy flat `{ message }` body, and malformed payloads (which fall back to the HTTP status text) all resolve exactly as before — but the CLI now shares the published wire-shape decoder rather than duplicating it. Bumps `@buildinternet/releases-api-types` to `^0.35.0` and `@buildinternet/releases-core` to `^0.25.0` (the versions that first export the errors module).

--- a/bun.lock
+++ b/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "releases-cli",
       "dependencies": {
-        "@buildinternet/releases-api-types": "^0.34.1",
-        "@buildinternet/releases-core": "^0.23.0",
+        "@buildinternet/releases-api-types": "^0.35.0",
+        "@buildinternet/releases-core": "^0.25.0",
         "@buildinternet/releases-lib": "workspace:*",
         "@buildinternet/releases-skills": "workspace:*",
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -29,7 +29,7 @@
     },
     "npm/releases": {
       "name": "@buildinternet/releases",
-      "version": "0.66.0",
+      "version": "0.67.1",
       "bin": {
         "releases": "bin/releases",
       },
@@ -43,31 +43,31 @@
     },
     "npm/releases-darwin-arm64": {
       "name": "@buildinternet/releases-darwin-arm64",
-      "version": "0.66.0",
+      "version": "0.67.1",
     },
     "npm/releases-darwin-x64": {
       "name": "@buildinternet/releases-darwin-x64",
-      "version": "0.66.0",
+      "version": "0.67.1",
     },
     "npm/releases-linux-arm64": {
       "name": "@buildinternet/releases-linux-arm64",
-      "version": "0.66.0",
+      "version": "0.67.1",
     },
     "npm/releases-linux-x64": {
       "name": "@buildinternet/releases-linux-x64",
-      "version": "0.66.0",
+      "version": "0.67.1",
     },
     "npm/releases-windows-x64": {
       "name": "@buildinternet/releases-windows-x64",
-      "version": "0.66.0",
+      "version": "0.67.1",
     },
     "packages/lib": {
       "name": "@buildinternet/releases-lib",
-      "version": "0.66.0",
+      "version": "0.67.1",
     },
     "packages/skills": {
       "name": "@buildinternet/releases-skills",
-      "version": "0.66.0",
+      "version": "0.67.1",
     },
   },
   "packages": {
@@ -75,9 +75,9 @@
 
     "@buildinternet/releases": ["@buildinternet/releases@workspace:npm/releases"],
 
-    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.34.1", "", { "dependencies": { "@buildinternet/releases-core": "^0.24.0", "zod": "^4.4.3" } }, "sha512-cNpudiEQZ1CE29pKCbX/HKqeHMg8i9cCsxZVSxHH4+u4kJeE1RZgAjr/4K+eiCXUolMDM069kGxJz0MiZDO/7g=="],
+    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.35.0", "", { "dependencies": { "@buildinternet/releases-core": "^0.25.0", "zod": "^4.4.3" } }, "sha512-1jU38gwkllAtB844uqB1wG2UKnKa9+rz1QAisgFA59u6V3Yrwtfa4PhP2rqv14Yz2qwsT9cSYUrxNqUEUhNnJQ=="],
 
-    "@buildinternet/releases-core": ["@buildinternet/releases-core@0.23.0", "", { "dependencies": { "drizzle-orm": "^0.45.2", "js-tiktoken": "^1.0.21", "nanoid": "^5.1.7" } }, "sha512-ieUK+KTlXmxX6nRHIft4alMuNNOJctk8AKCfbJmM0SbWqLHcHjLy9O+sj2R+4052IhwJI86gPFpTLM1QNfLFDA=="],
+    "@buildinternet/releases-core": ["@buildinternet/releases-core@0.25.0", "", { "dependencies": { "drizzle-orm": "^0.45.2", "js-tiktoken": "^1.0.21", "nanoid": "^5.1.15" } }, "sha512-9tyVeyB/THz51NJ30U22bda7cpTLU8P54mcmxGJOdtHnGYiq7iS6eggIfxsQY0IKnilv8YEQF2ZJplkjGRDiSg=="],
 
     "@buildinternet/releases-darwin-arm64": ["@buildinternet/releases-darwin-arm64@workspace:npm/releases-darwin-arm64"],
 
@@ -453,7 +453,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "nanoid": ["nanoid@5.1.9", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw=="],
+    "nanoid": ["nanoid@5.1.16", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ=="],
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
@@ -611,8 +611,6 @@
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
-    "@buildinternet/releases-api-types/@buildinternet/releases-core": ["@buildinternet/releases-core@0.24.0", "", { "dependencies": { "drizzle-orm": "^0.45.2", "js-tiktoken": "^1.0.21", "nanoid": "^5.1.15" } }, "sha512-NTrYXCeJ+XEmbAqBZSadY3Ya5VhGabXb5eJjCPPLw8nji/E54qCfzj1x/hdj/IHHrWBA/Sg8lHkT3O0CxiiJdw=="],
-
     "@buildinternet/releases-api-types/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "@manypkg/find-root/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
@@ -638,8 +636,6 @@
     "read-yaml-file/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 
     "wrap-ansi/string-width": ["string-width@8.2.1", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA=="],
-
-    "@buildinternet/releases-api-types/@buildinternet/releases-core/nanoid": ["nanoid@5.1.16", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ=="],
 
     "bun-types/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 

--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
   },
   "homepage": "https://releases.sh",
   "dependencies": {
-    "@buildinternet/releases-api-types": "^0.34.1",
-    "@buildinternet/releases-core": "^0.23.0",
+    "@buildinternet/releases-api-types": "^0.35.0",
+    "@buildinternet/releases-core": "^0.25.0",
     "@buildinternet/releases-lib": "workspace:*",
     "@buildinternet/releases-skills": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -9,6 +9,8 @@
  * (emitted to stdout by the top-level handler when `--json` is set).
  */
 
+import { decodeApiError, isApiError } from "@buildinternet/releases-api-types";
+
 /** A non-2xx response from the Releases API. Message format is preserved for
  * the existing `/API error \(NNN\) on METHOD path/` characterization tests. */
 export class ApiError extends Error {
@@ -64,22 +66,22 @@ export type CliErrorPayload = {
 
 /**
  * Pull the human message out of a non-2xx API body. The API emits the
- * standardized nested envelope `{ error: { code, type, message } }`; this reads
- * `error.message`, tolerating a legacy flat `{ message }` body and any
- * malformed/empty payload (→ undefined so the caller falls back to statusText).
+ * standardized nested envelope `{ error: { code, type, message } }`; a real
+ * envelope is decoded via api-types' canonical `decodeApiError`, the single
+ * source of truth for the wire shape.
  *
- * A thin stand-in for `@buildinternet/releases-api-types`' `decodeApiError`:
- * the CLI only needs the message, and the published api-types pin does not yet
- * export the errors module. Swap for `decodeApiError().message` once it does.
+ * Returns `undefined` (so the caller falls back to `res.statusText`) for
+ * anything that isn't a full envelope — an empty message, or a malformed body
+ * like a bare `{ error: "not_found" }`. We keep a manual fallback for a legacy
+ * flat `{ message }` body (which predates the envelope and so is NOT an
+ * `isApiError`); `decodeApiError` can't read that on its own.
  */
 export function apiErrorMessage(body: unknown): string | undefined {
-  if (!body || typeof body !== "object") return undefined;
-  const nested = (body as { error?: unknown }).error;
-  if (nested && typeof nested === "object") {
-    const message = (nested as { message?: unknown }).message;
-    if (typeof message === "string" && message.length > 0) return message;
+  if (isApiError(body)) {
+    const { message } = decodeApiError(body);
+    if (message.length > 0) return message;
   }
-  const flat = (body as { message?: unknown }).message;
+  const flat = (body as { message?: unknown } | null)?.message;
   return typeof flat === "string" && flat.length > 0 ? flat : undefined;
 }
 


### PR DESCRIPTION
Follow-up to the standardized-errors work (buildinternet/releases#1839). Now that `@buildinternet/releases-api-types@0.35.0` and `@buildinternet/releases-core@0.25.0` publish the errors module, the CLI can drop its hand-rolled envelope reader and use the canonical decoder.

## What changed

`src/lib/errors.ts` — `apiErrorMessage` now delegates to api-types' `decodeApiError` / `isApiError` instead of re-implementing the nested-envelope read. This was the swap the old `TODO` described ("swap for `decodeApiError().message` once the published pin exports the errors module") — the pin does now.

**Behavior is unchanged**, verified against the existing `/API error \(NNN\) on METHOD path/` characterization tests in `tests/unit/api-client.test.ts`:
- nested `{ error: { code, type, message } }` → `error.message`
- legacy flat `{ message }` → tolerated (kept as a manual fallback — a flat body is *not* an `isApiError`, so `decodeApiError` can't read it)
- malformed / empty (e.g. bare `{ error: "not_found" }`, empty message) → `undefined`, so the caller keeps falling back to `res.statusText`

The `isApiError` guard is what preserves that last case: a naive `decodeApiError(body).message` would regress it, because `decodeApiError` always returns a message (`"Unknown error"` on a parse miss) and requires a full envelope.

## Dependency bumps

- `@buildinternet/releases-api-types` `^0.34.1` → `^0.35.0` (adds `decodeApiError`/`isApiError`/`ErrorEnvelope`)
- `@buildinternet/releases-core` `^0.23.0` → `^0.25.0` (adds the `./errors` taxonomy; api-types 0.35.0 requires core `^0.25.0`)

## Verification

- `bun test` — 1050 pass (run with a clean env; unrelated auth/credential tests fail locally only when `RELEASES_API_KEY` leaks from the shell)
- `bun run check` (oxlint + oxfmt) — clean
- `bun run build` — compiles

Changeset: `@buildinternet/releases` patch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API error message handling so CLI output now consistently shows clearer messages for supported error responses, with sensible fallback text for unexpected payloads.

* **Chores**
  * Updated supporting package versions to pick up the latest shared error-handling improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->