### PR TITLE
chore(admin): remove overview batch subcommand — API lane retired

### DIFF
--- a/.changeset/remove-overview-batch.md
+++ b/.changeset/remove-overview-batch.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": patch
+---
+
+Removed `releases admin overview batch` — its API route was retired in buildinternet/releases#1902; use the automated overview regen (per-org cadence) or `--overview-cadence` instead.

--- a/src/api/sources.ts
+++ b/src/api/sources.ts
@@ -982,61 +982,6 @@ export async function reextractSource(body: {
   });
 }
 
-// ── Batch overview workflow (admin-only) ──
-
-/** Trigger body for POST /v1/workflows/batch-overview — mirrors `BatchOverviewBody` on the API worker. */
-export interface BatchOverviewTriggerBody {
-  minNewReleases?: number;
-  minOverviewAgeDays?: number;
-  maxCandidates?: number;
-  orgs?: string[];
-  maxCostUsd?: number;
-}
-
-export interface BatchOverviewTriggerResponse {
-  instanceId: string;
-  statusUrl: string;
-}
-
-/**
- * Cloudflare Workflows surfaces a small enum on `WorkflowInstance.status()`.
- * Terminal states are `complete | errored | terminated`; pre-terminal states
- * are `queued | running | paused`. We type the field as string to stay
- * forward-compatible with any new values CF introduces.
- */
-export interface BatchOverviewStatusResponse {
-  instanceId: string;
-  status: string;
-  output?: unknown;
-  error?: unknown;
-  [k: string]: unknown;
-}
-
-export async function triggerBatchOverview(
-  body: BatchOverviewTriggerBody,
-): Promise<BatchOverviewTriggerResponse> {
-  return apiFetch<BatchOverviewTriggerResponse>("/v1/workflows/batch-overview", {
-    method: "POST",
-    body: JSON.stringify(body),
-  });
-}
-
-export async function getBatchOverviewStatus(
-  instanceId: string,
-): Promise<BatchOverviewStatusResponse> {
-  // apiFetch returns null on 404 for GETs. The status route 404s with
-  // `instance_not_found` when the workflow ID is wrong (or briefly during
-  // the create→status race window). Throw so callers reading `.status`
-  // can't crash silently.
-  const res = await apiFetch<BatchOverviewStatusResponse | null>(
-    `/v1/workflows/batch-overview/status/${encodeURIComponent(instanceId)}`,
-  );
-  if (res === null) {
-    throw new Error(`Workflow instance not found: ${instanceId}`);
-  }
-  return res;
-}
-
 // ── Domain Aliases ──
 
 export async function getAliases(

--- a/src/cli/commands/admin/overview.ts
+++ b/src/cli/commands/admin/overview.ts
@@ -15,22 +15,15 @@ import {
   getOverviewInputsCheck,
   getOverviewManifest,
   upsertOverview,
-  triggerBatchOverview,
-  getBatchOverviewStatus,
   type OverviewInputs,
-  type BatchOverviewTriggerBody,
-  type BatchOverviewStatusResponse,
 } from "../../../api/sources.js";
 import { type OverviewCitation, type OverviewManifestRow } from "../../../api/types.js";
 import { orgNotFound } from "../../suggest.js";
 import { writeJson } from "../../../lib/output.js";
-import { trySaveBatchOverviewTrace } from "../../../lib/trace.js";
 import {
   MAX_CONTENT_CHARS_DEFAULT,
   parseMaxContentCharsFlag,
-  parseNonNegIntFlag,
   parsePositiveIntFlag,
-  parseTagList,
 } from "../../../lib/flags.js";
 import { logger } from "@releases/lib/logger";
 import { timeAgo } from "@buildinternet/releases-core/dates";
@@ -89,17 +82,6 @@ interface OverviewPlanOpts {
   staleDays?: string;
   missing?: boolean;
   hasActivity?: boolean;
-}
-
-interface OverviewBatchOpts {
-  orgs?: string;
-  minNewReleases?: string;
-  minOverviewAgeDays?: string;
-  maxCandidates?: string;
-  maxCostUsd?: string;
-  wait?: boolean;
-  json?: boolean;
-  traceDir?: string;
 }
 
 interface OverviewFreshnessInput {
@@ -635,87 +617,6 @@ async function overviewPlanAction(opts: OverviewPlanOpts): Promise<void> {
   console.log(chalk.dim(`\n${rows.length} org(s) — ${parts}`));
 }
 
-// ── Batch workflow trigger ────────────────────────────────────────────────────
-
-/** Terminal Workflows states per Cloudflare's WorkflowInstance.status() enum. */
-const TERMINAL_STATUSES = new Set(["complete", "errored", "terminated"]);
-
-/** Poll cadence for --wait. 30s matches the issue's spec and the workflow's typical 3-minute end-to-end. */
-const POLL_INTERVAL_MS = 30_000;
-
-function parsePositiveFloatFlag(label: string, raw: string | undefined): number | undefined {
-  if (raw === undefined) return undefined;
-  const n = Number(raw);
-  if (!Number.isFinite(n) || n <= 0) {
-    logger.error(`Invalid --${label}: must be a positive number (got ${raw})`);
-    process.exit(2);
-  }
-  return n;
-}
-
-async function overviewBatchAction(opts: OverviewBatchOpts): Promise<void> {
-  const minNewReleases = parseNonNegIntFlag("min-new-releases", opts.minNewReleases);
-  const minOverviewAgeDays = parseNonNegIntFlag("min-overview-age-days", opts.minOverviewAgeDays);
-  const maxCandidates = parsePositiveIntFlag("max-candidates", opts.maxCandidates);
-  const maxCostUsd = parsePositiveFloatFlag("max-cost-usd", opts.maxCostUsd);
-  const orgs = opts.orgs ? parseTagList(opts.orgs) : undefined;
-
-  const body: BatchOverviewTriggerBody = {
-    ...(minNewReleases !== undefined && { minNewReleases }),
-    ...(minOverviewAgeDays !== undefined && { minOverviewAgeDays }),
-    ...(maxCandidates !== undefined && { maxCandidates }),
-    ...(maxCostUsd !== undefined && { maxCostUsd }),
-    ...(orgs && orgs.length > 0 && { orgs }),
-  };
-
-  const triggered = await triggerBatchOverview(body);
-
-  if (!opts.wait) {
-    if (opts.json) {
-      await writeJson(triggered);
-      return;
-    }
-    console.log(chalk.green(`Triggered batch-overview workflow: ${triggered.instanceId}`));
-    console.log(chalk.dim(`  status: ${triggered.statusUrl}`));
-    console.log(
-      chalk.dim(`  Re-run with --wait or 'releases admin overview batch --wait' to poll inline.`),
-    );
-    return;
-  }
-
-  if (!opts.json) {
-    console.log(chalk.bold(`Triggered batch-overview workflow: ${triggered.instanceId}`));
-    console.log(chalk.dim(`  Polling every ${POLL_INTERVAL_MS / 1000}s until terminal...`));
-  }
-
-  let last: BatchOverviewStatusResponse | undefined;
-  while (true) {
-    // eslint-disable-next-line no-await-in-loop -- polling cadence
-    last = await getBatchOverviewStatus(triggered.instanceId);
-    if (!opts.json) {
-      console.log(chalk.dim(`  status: ${last.status}`));
-    }
-    if (TERMINAL_STATUSES.has(last.status)) break;
-    // eslint-disable-next-line no-await-in-loop
-    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
-  }
-
-  const tracePath = trySaveBatchOverviewTrace(last, triggered.instanceId, opts.traceDir);
-
-  if (opts.json) {
-    await writeJson(last);
-  } else {
-    if (last.status === "complete") {
-      logger.info(chalk.green(`Done. Final status: ${last.status}`));
-    } else {
-      logger.error(chalk.red(`Workflow ended in non-success state: ${last.status}`));
-    }
-    if (tracePath) process.stderr.write(chalk.dim(`  Trace: ${tracePath}\n`));
-  }
-
-  if (last.status !== "complete") process.exit(1);
-}
-
 // ── Command registration ──────────────────────────────────────────────────────
 
 export function registerOverviewCommands(admin: Command): void {
@@ -847,41 +748,6 @@ happens client-side — the CLI still receives the full payload over the wire �
 so it removes that footgun without a multi-step jq workaround.`,
     )
     .action(overviewInputsAction);
-
-  overview
-    .command("batch")
-    .description("Trigger BatchOverviewWorkflow for the eligibility-filtered org set")
-    .option("--orgs <slugs>", "Comma-separated org slug allowlist (skips eligibility filtering)")
-    .option("--min-new-releases <n>", "Min releases shipped since the last overview (default 20)")
-    .option(
-      "--min-overview-age-days <n>",
-      "Min age in days of an existing overview to consider it stale (default 14)",
-    )
-    .option("--max-candidates <n>", "Cap on candidate count picked by the workflow (default 100)")
-    .option("--max-cost-usd <n>", "Per-run cost ceiling in USD; workflow aborts above this")
-    .option("--wait", "Poll the workflow status every 30s until it reaches a terminal state")
-    .option(
-      "--trace-dir <dir>",
-      "With --wait, write the terminal workflow as <dir>/<instanceId>/{trace.json,summary.md} (default: ~/.releases/work/runs)",
-    )
-    .option("--json", "Output as JSON")
-    .addHelpText(
-      "after",
-      `
-Examples:
-  releases admin overview batch --orgs vercel,anthropic --wait
-  releases admin overview batch --max-candidates 4 --max-cost-usd 0.05 --json
-  releases admin overview batch --min-new-releases 30 --min-overview-age-days 7
-
-Triggers POST /v1/workflows/batch-overview. When --wait is omitted the command
-returns immediately with the instanceId and statusUrl; with --wait it polls
-GET /v1/workflows/batch-overview/status/:instanceId every 30s and exits
-non-zero on any terminal state other than 'complete'.
-
---orgs explicitly bypasses the workflow's eligibility predicate (recency +
-overview-age) so handpicked smoke tests run even on already-fresh orgs.`,
-    )
-    .action(overviewBatchAction);
 
   overview
     .command("update")

--- a/src/cli/commands/backfill.ts
+++ b/src/cli/commands/backfill.ts
@@ -27,7 +27,6 @@ type BackfillOpts = {
 
 // Deep Firecrawl backfills run as a durable workflow (minutes). When `--wait`
 // polls inline, hit the status endpoint at this cadence until terminal.
-// Single-source backfills finish faster than the batch-overview sweep (30s).
 const POLL_INTERVAL_MS = 5_000;
 const TERMINAL_STATUSES = new Set(["complete", "errored", "terminated"]);
 
@@ -56,10 +55,10 @@ export async function backfillAction(identifier: string, opts: BackfillOpts): Pr
   }
 
   // ── Async path: deep Firecrawl backfill dispatched to a durable workflow ────
-  // Mirrors `admin overview batch`: dispatch and return the handle by default;
-  // `--wait` polls inline. Non-blocking-by-default is the right primitive for
-  // agents — pair the printed instanceId with `backfill-status` to poll on your
-  // own cadence, or pass `--wait` for a blocking report.
+  // Dispatch and return the handle by default; `--wait` polls inline.
+  // Non-blocking-by-default is the right primitive for agents — pair the
+  // printed instanceId with `backfill-status` to poll on your own cadence, or
+  // pass `--wait` for a blocking report.
   if (isBackfillAsync(res)) {
     if (!wait) {
       if (opts.json) return writeJson(res);

--- a/src/lib/trace.ts
+++ b/src/lib/trace.ts
@@ -3,15 +3,14 @@ import { basename, join } from "node:path";
 import { getRunsDir, expandHome } from "@releases/lib/config";
 import { resolveRunDir } from "./run-dir.js";
 import type { Session } from "@buildinternet/releases-api-types";
-import { type BatchOverviewStatusResponse } from "../api/sources.js";
 
 /**
  * Managed-session traces. Server-triggered sessions (`onboard`,
- * `source fetch --wait`, `overview batch --wait`) return full records the CLI
- * reads but does not persist. These helpers land one as
- * `<dir>/<id>/{trace.json,summary.md}`, with `summary.md` mirroring the
- * run-summary template in `docs/architecture/maintenance-workspace.md` so
- * managed sessions and Claude-Code batches read uniformly.
+ * `source fetch --wait`) return full records the CLI reads but does not
+ * persist. These helpers land one as `<dir>/<id>/{trace.json,summary.md}`,
+ * with `summary.md` mirroring the run-summary template in
+ * `docs/architecture/maintenance-workspace.md` so managed sessions and
+ * Claude-Code batches read uniformly.
  */
 
 /**
@@ -105,45 +104,6 @@ export function buildSessionSummaryMarkdown(session: Session): string {
   ].join("\n");
 }
 
-function workflowStatusLabel(status: string): string {
-  if (status === "complete") return "completed";
-  if (status === "errored" || status === "terminated") return "failed";
-  return status;
-}
-
-export function buildBatchOverviewSummaryMarkdown(
-  status: BatchOverviewStatusResponse,
-  instanceId: string,
-): string {
-  const label = workflowStatusLabel(status.status);
-  const errText =
-    status.error != null
-      ? typeof status.error === "string"
-        ? status.error
-        : JSON.stringify(status.error)
-      : null;
-  const resultBlock = errText ?? "See ./trace.json for the full workflow output.";
-
-  return [
-    `# batch-overview workflow — ${instanceId}`,
-    "",
-    `**Status:** ${label}`,
-    `**Cost:** see ./trace.json (per-org estimatedUsd in the workflow output)`,
-    "",
-    "## Workflow",
-    "",
-    mdTable([
-      ["Instance ID", instanceId],
-      ["Status", status.status],
-    ]),
-    "",
-    "## Result",
-    "",
-    resultBlock,
-    "",
-  ].join("\n");
-}
-
 /**
  * Trace IDs come from API responses (session/instance IDs). Constrain them to a
  * single safe path segment so a malicious or tampered response can't traverse
@@ -184,40 +144,15 @@ export function writeSessionTrace(session: Session, explicitDir?: string): strin
   });
 }
 
-export function writeBatchOverviewTrace(
-  status: BatchOverviewStatusResponse,
-  instanceId: string,
-  explicitDir?: string,
-): string {
-  return writeTrace({
-    traceDir: resolveTraceDir(explicitDir),
-    id: instanceId,
-    record: status,
-    summaryMarkdown: buildBatchOverviewSummaryMarkdown(status, instanceId),
-  });
-}
-
 /**
- * Fail-open variants for auto-capture paths (onboard / fetch --wait / overview
- * batch --wait). A trace write must never break the session command, so these
- * swallow errors and return `null` instead of throwing. Explicit `--save`
- * surfaces errors via the throwing `writeSessionTrace` directly.
+ * Fail-open variant for auto-capture paths (onboard / fetch --wait). A trace
+ * write must never break the session command, so this swallows errors and
+ * returns `null` instead of throwing. Explicit `--save` surfaces errors via
+ * the throwing `writeSessionTrace` directly.
  */
 export function trySaveSessionTrace(session: Session, explicitDir?: string): string | null {
   try {
     return writeSessionTrace(session, explicitDir);
-  } catch {
-    return null;
-  }
-}
-
-export function trySaveBatchOverviewTrace(
-  status: BatchOverviewStatusResponse,
-  instanceId: string,
-  explicitDir?: string,
-): string | null {
-  try {
-    return writeBatchOverviewTrace(status, instanceId, explicitDir);
   } catch {
     return null;
   }

--- a/tests/cli/overview-subcommands.test.ts
+++ b/tests/cli/overview-subcommands.test.ts
@@ -80,89 +80,10 @@ describe("admin overview subcommand group", () => {
     expect(flat).toContain("no-op");
   });
 
-  it("`overview batch --help` exposes the workflow trigger flag set", () => {
-    const { stdout, exitCode } = runCli(["admin", "overview", "batch", "--help"]);
-    expect(exitCode).toBe(0);
-    expect(stdout).toContain("--orgs");
-    expect(stdout).toContain("--min-new-releases");
-    expect(stdout).toContain("--min-overview-age-days");
-    expect(stdout).toContain("--max-candidates");
-    expect(stdout).toContain("--max-cost-usd");
-    expect(stdout).toContain("--wait");
-    expect(stdout).toContain("--json");
-    expect(stdout).toContain("BatchOverviewWorkflow");
-  });
-
-  it("`overview --help` lists batch as a subcommand", () => {
+  it("`overview --help` no longer lists the retired batch subcommand", () => {
     const { stdout, exitCode } = runCli(["admin", "overview", "--help"]);
     expect(exitCode).toBe(0);
-    expect(stdout).toContain("batch");
-  });
-});
-
-describe("`overview batch` flag validation", () => {
-  it("accepts 0 for --min-new-releases (no validation error)", () => {
-    // With 0 the flag parses fine; the action itself would need a live API so
-    // we only check that the CLI doesn't exit(2) on argument validation.
-    // Passing an unknown flag that triggers usage error would give exit 1,
-    // but a bad value gives exit 2 — so exit != 2 proves the validator passed.
-    const { exitCode, stderr } = runCli(["admin", "overview", "batch", "--min-new-releases", "0"]);
-    expect(exitCode).not.toBe(2);
-    expect(stderr).not.toContain("must be a non-negative integer");
-  });
-
-  it("accepts 0 for --min-overview-age-days (no validation error)", () => {
-    const { exitCode, stderr } = runCli([
-      "admin",
-      "overview",
-      "batch",
-      "--min-overview-age-days",
-      "0",
-    ]);
-    expect(exitCode).not.toBe(2);
-    expect(stderr).not.toContain("must be a non-negative integer");
-  });
-
-  it("rejects -1 for --min-new-releases with a clear message", () => {
-    const { exitCode, stderr } = runCli(["admin", "overview", "batch", "--min-new-releases", "-1"]);
-    expect(exitCode).toBe(2);
-    expect(stderr).toContain("must be a non-negative integer");
-  });
-
-  it("rejects -1 for --min-overview-age-days with a clear message", () => {
-    const { exitCode, stderr } = runCli([
-      "admin",
-      "overview",
-      "batch",
-      "--min-overview-age-days",
-      "-1",
-    ]);
-    expect(exitCode).toBe(2);
-    expect(stderr).toContain("must be a non-negative integer");
-  });
-
-  it("rejects non-integer strings like '1.5' for --min-new-releases", () => {
-    const { exitCode, stderr } = runCli([
-      "admin",
-      "overview",
-      "batch",
-      "--min-new-releases",
-      "1.5",
-    ]);
-    expect(exitCode).toBe(2);
-    expect(stderr).toContain("must be a non-negative integer");
-  });
-
-  it("rejects trailing-garbage strings like '10abc' for --min-new-releases", () => {
-    const { exitCode, stderr } = runCli([
-      "admin",
-      "overview",
-      "batch",
-      "--min-new-releases",
-      "10abc",
-    ]);
-    expect(exitCode).toBe(2);
-    expect(stderr).toContain("must be a non-negative integer");
+    expect(stdout).not.toContain("batch");
   });
 });
 

--- a/tests/unit/api-client.test.ts
+++ b/tests/unit/api-client.test.ts
@@ -1173,44 +1173,6 @@ describe("backfill and re-extract", () => {
 
 // ── Batch overview ───────────────────────────────────────────────────────────
 
-describe("batch overview workflow", () => {
-  let originalFetch: typeof globalThis.fetch;
-  beforeEach(() => {
-    originalFetch = globalThis.fetch;
-  });
-  afterEach(() => {
-    globalThis.fetch = originalFetch;
-  });
-
-  it("triggerBatchOverview POSTs to /v1/workflows/batch-overview", async () => {
-    const calls = captureFetch(200, {
-      instanceId: "inst_ov",
-      statusUrl: "https://api/status/inst_ov",
-    });
-    const result = await client.triggerBatchOverview({ maxCostUsd: 1.0, dryRun: false } as any);
-    expect(calls[0].url).toContain("/v1/workflows/batch-overview");
-    expect(calls[0].init?.method).toBe("POST");
-    const body = JSON.parse(calls[0].init!.body as string);
-    expect(body.maxCostUsd).toBe(1.0);
-    expect(result.instanceId).toBe("inst_ov");
-  });
-
-  it("getBatchOverviewStatus GETs /v1/workflows/batch-overview/status/:id", async () => {
-    const calls = captureFetch(200, { instanceId: "inst_ov", status: "running" });
-    const result = await client.getBatchOverviewStatus("inst_ov");
-    expect(calls[0].url).toContain("/v1/workflows/batch-overview/status/inst_ov");
-    expect(calls[0].init?.method).toBeUndefined();
-    expect(result.status).toBe("running");
-  });
-
-  it("getBatchOverviewStatus throws when instance not found (null body)", async () => {
-    captureFetch(404);
-    await expect(client.getBatchOverviewStatus("bad_id")).rejects.toThrow(
-      /Workflow instance not found/,
-    );
-  });
-});
-
 // ── Media assets ─────────────────────────────────────────────────────────────
 
 describe("media assets", () => {

--- a/tests/unit/trace.test.ts
+++ b/tests/unit/trace.test.ts
@@ -6,7 +6,6 @@ import type { Session } from "@buildinternet/releases-api-types";
 import {
   resolveTraceDir,
   buildSessionSummaryMarkdown,
-  buildBatchOverviewSummaryMarkdown,
   writeTrace,
   writeSessionTrace,
   trySaveSessionTrace,
@@ -87,26 +86,6 @@ describe("buildSessionSummaryMarkdown", () => {
     const md = buildSessionSummaryMarkdown({ ...baseSession, usage: undefined });
     expect(md).toContain("**Status:** completed");
     expect(md).toContain("n/a");
-  });
-});
-
-describe("buildBatchOverviewSummaryMarkdown", () => {
-  it("maps a complete workflow to completed and includes the instance id", () => {
-    const md = buildBatchOverviewSummaryMarkdown(
-      { instanceId: "wf_1", status: "complete" },
-      "wf_1",
-    );
-    expect(md).toContain("**Status:** completed");
-    expect(md).toContain("wf_1");
-  });
-
-  it("maps errored/terminated to failed and surfaces the error", () => {
-    const md = buildBatchOverviewSummaryMarkdown(
-      { instanceId: "wf_2", status: "errored", error: "boom" },
-      "wf_2",
-    );
-    expect(md).toContain("**Status:** failed");
-    expect(md).toContain("boom");
   });
 });
 


### PR DESCRIPTION
Closes #347

## What changed

The API route `POST /v1/workflows/batch-overview` (and its status route) was retired in buildinternet/releases#1902 in favor of the per-org-cadence `OverviewRegenWorkflow`. This PR mirrors that retirement by removing the CLI's `releases admin overview batch` subcommand, which would otherwise 404.

Removed:
- `overview batch` subcommand registration and its `overviewBatchAction` handler, `OverviewBatchOpts` interface, `parsePositiveFloatFlag` helper, `TERMINAL_STATUSES`/`POLL_INTERVAL_MS` constants (`src/cli/commands/admin/overview.ts`)
- `triggerBatchOverview`, `getBatchOverviewStatus`, `BatchOverviewTriggerBody`, `BatchOverviewTriggerResponse`, `BatchOverviewStatusResponse` (`src/api/sources.ts`)
- `buildBatchOverviewSummaryMarkdown`, `writeBatchOverviewTrace`, `trySaveBatchOverviewTrace` (`src/lib/trace.ts`)
- Corresponding tests in `tests/unit/trace.test.ts`, `tests/unit/api-client.test.ts`, and `tests/cli/overview-subcommands.test.ts`
- Stale comment references to the batch-overview sweep in `src/cli/commands/backfill.ts`

Kept as-is (shared, not batch-overview-specific):
- `writeTrace` / `resolveTraceDir` / `writeSessionTrace` / `trySaveSessionTrace` in `src/lib/trace.ts` — general session-trace infrastructure used by `onboard` and `source fetch --wait`
- `parseNonNegIntFlag` in `src/lib/flags.ts` — a generic flag parser with its own pre-existing unit tests, not tied to the batch workflow
- `parseTagList` — used elsewhere (`product`, `org`, `create` commands)
- The rest of the `admin overview` family (`get`, `list`, `plan`, `inputs`, `update`, plus the deprecated kebab aliases) is untouched

## Changeset

Added `.changeset/remove-overview-batch.md` targeting `@buildinternet/releases` (patch):

> Removed `releases admin overview batch` — its API route was retired in buildinternet/releases#1902; use the automated overview regen (per-org cadence) or `--overview-cadence` instead.

## Verification

- `bunx oxfmt` on all changed files
- `bun run check` passes (lint + typecheck + format)
- `bun test` — 1031 pass, 7 fail. All 7 failures are the known pre-existing local auth/credential issue on this machine (`tests/unit/mode-credential.test.ts`, `tests/unit/preflight.test.ts`, `tests/cli/auth.test.ts`) and fail identically on clean `main`; unrelated to this change. No new failures.
- `grep -rn "batch-overview|BatchOverview|batchOverview" src/ tests/` returns nothing.
