### PR TITLE
chore: adopt api-types 0.37.0 + releases.json v2 manifest

### DIFF
--- a/.changeset/api-types-037-releases-json-v2.md
+++ b/.changeset/api-types-037-releases-json-v2.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": patch
+---
+
+Adopt `@buildinternet/releases-api-types` 0.37.0 (releases.json v2 schema) and migrate the repo-root `releases.json` to the v2 manifest format (product binding + `github: "self"` release locator).

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "releases-cli",
       "dependencies": {
-        "@buildinternet/releases-api-types": "^0.35.0",
+        "@buildinternet/releases-api-types": "^0.37.0",
         "@buildinternet/releases-core": "^0.25.0",
         "@buildinternet/releases-lib": "workspace:*",
         "@buildinternet/releases-skills": "workspace:*",
@@ -29,7 +29,7 @@
     },
     "npm/releases": {
       "name": "@buildinternet/releases",
-      "version": "0.67.1",
+      "version": "0.67.3",
       "bin": {
         "releases": "bin/releases",
       },
@@ -43,31 +43,31 @@
     },
     "npm/releases-darwin-arm64": {
       "name": "@buildinternet/releases-darwin-arm64",
-      "version": "0.67.1",
+      "version": "0.67.3",
     },
     "npm/releases-darwin-x64": {
       "name": "@buildinternet/releases-darwin-x64",
-      "version": "0.67.1",
+      "version": "0.67.3",
     },
     "npm/releases-linux-arm64": {
       "name": "@buildinternet/releases-linux-arm64",
-      "version": "0.67.1",
+      "version": "0.67.3",
     },
     "npm/releases-linux-x64": {
       "name": "@buildinternet/releases-linux-x64",
-      "version": "0.67.1",
+      "version": "0.67.3",
     },
     "npm/releases-windows-x64": {
       "name": "@buildinternet/releases-windows-x64",
-      "version": "0.67.1",
+      "version": "0.67.3",
     },
     "packages/lib": {
       "name": "@buildinternet/releases-lib",
-      "version": "0.67.1",
+      "version": "0.67.3",
     },
     "packages/skills": {
       "name": "@buildinternet/releases-skills",
-      "version": "0.67.1",
+      "version": "0.67.3",
     },
   },
   "packages": {
@@ -75,7 +75,7 @@
 
     "@buildinternet/releases": ["@buildinternet/releases@workspace:npm/releases"],
 
-    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.35.0", "", { "dependencies": { "@buildinternet/releases-core": "^0.25.0", "zod": "^4.4.3" } }, "sha512-1jU38gwkllAtB844uqB1wG2UKnKa9+rz1QAisgFA59u6V3Yrwtfa4PhP2rqv14Yz2qwsT9cSYUrxNqUEUhNnJQ=="],
+    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.37.0", "", { "dependencies": { "@buildinternet/releases-core": "^0.25.0", "zod": "^4.4.3" } }, "sha512-/UXXkx1suIicIC5l3brWOxF2HCRHRAFN6ozYwIhDCIi92VGb7ml3d8U/1mfY+m4qwIpmDZwrQReEIVej6s3vew=="],
 
     "@buildinternet/releases-core": ["@buildinternet/releases-core@0.25.0", "", { "dependencies": { "drizzle-orm": "^0.45.2", "js-tiktoken": "^1.0.21", "nanoid": "^5.1.15" } }, "sha512-9tyVeyB/THz51NJ30U22bda7cpTLU8P54mcmxGJOdtHnGYiq7iS6eggIfxsQY0IKnilv8YEQF2ZJplkjGRDiSg=="],
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "homepage": "https://releases.sh",
   "dependencies": {
-    "@buildinternet/releases-api-types": "^0.35.0",
+    "@buildinternet/releases-api-types": "^0.37.0",
     "@buildinternet/releases-core": "^0.25.0",
     "@buildinternet/releases-lib": "workspace:*",
     "@buildinternet/releases-skills": "workspace:*",

--- a/releases.json
+++ b/releases.json
@@ -1,10 +1,9 @@
 {
   "$schema": "https://releases.sh/schemas/releases.json",
+  "version": 2,
   "product": {
     "name": "CLI",
-    "slug": "cli",
-    "description": "The Releases command-line interface — search, inspect, and manage the changelog registry from your terminal.",
-    "category": "developer-tools",
-    "kind": "tool"
-  }
+    "slug": "cli"
+  },
+  "releases": [{ "github": "self" }]
 }

--- a/tests/unit/releases-json.test.ts
+++ b/tests/unit/releases-json.test.ts
@@ -21,7 +21,7 @@ describe("releases.json (repo-root product mapping)", () => {
     expect(parsed.$schema).toBe("https://releases.sh/schemas/releases.json");
     expect(parsed.version).toBe(2);
     if (!("product" in parsed)) throw new Error("expected repo-scoped manifest");
-    expect(parsed.product?.slug).toBe("cli");
+    expect(parsed.product.slug).toBe("cli");
     expect(parsed.releases?.[0]?.github).toBe("self");
   });
 });

--- a/tests/unit/releases-json.test.ts
+++ b/tests/unit/releases-json.test.ts
@@ -3,10 +3,11 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { ReleasesJsonConfigSchema } from "@buildinternet/releases-api-types";
 
-// This repo dogfoods the owner-declared listing standard documented at
-// https://releases.sh/docs/listing: the repo-root releases.json maps this
-// source to the `cli` product, and the daily well-known sweep reads it from
-// GitHub. Keep it schema-valid so it can't silently drift.
+// This repo dogfoods the owner-declared manifest documented at
+// https://releases.sh/docs/listing: the repo-root releases.json (v2) binds this
+// repo to the `cli` product and declares its release locator, and the daily
+// well-known sweep reads it from GitHub. Keep it schema-valid so it can't
+// silently drift.
 describe("releases.json (repo-root product mapping)", () => {
   const raw = readFileSync(join(import.meta.dir, "..", "..", "releases.json"), "utf8");
 
@@ -15,9 +16,12 @@ describe("releases.json (repo-root product mapping)", () => {
     expect(() => ReleasesJsonConfigSchema.parse(parsed)).not.toThrow();
   });
 
-  it("declares the cli product", () => {
+  it("declares the cli product and its release locator", () => {
     const parsed = ReleasesJsonConfigSchema.parse(JSON.parse(raw));
     expect(parsed.$schema).toBe("https://releases.sh/schemas/releases.json");
+    expect(parsed.version).toBe(2);
+    if (!("product" in parsed)) throw new Error("expected repo-scoped manifest");
     expect(parsed.product?.slug).toBe("cli");
+    expect(parsed.releases?.[0]?.github).toBe("self");
   });
 });


### PR DESCRIPTION
Pre-phase-2 adoption of the releases.json v2 manifest (buildinternet/releases#1908, shipped in buildinternet/releases#1913).

- Bump `@buildinternet/releases-api-types` `^0.35.0` → `^0.37.0` (first published version carrying the v2 schema — npm 0.36.0 was claimed by earlier shapes).
- Migrate the repo-root `releases.json` to v2: `version: 2`, product binding reduced to `{ name, slug }` (description/category/kind are curator-owned now), plus a `releases: [{ "github": "self" }]` locator.
- Update `tests/unit/releases-json.test.ts` for the v2 union shape (asserts `version: 2`, repo-scoped product binding, and the `github: "self"` locator).
- Changeset (patch) included.

Verification: `npx tsc --noEmit` clean; `bun run check` clean; releases.json test 2/2 pass; lockfile still carries both zod versions (4.3.6 + 4.4.3 — MCP SDK pin intact). The 7 failing auth/credential e2e tests fail identically on an unmodified checkout (local env leak), unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upgraded release metadata support to the latest manifest format and schema.
  * Added product binding and a self-referenced release entry in the repository’s release configuration.

* **Bug Fixes**
  * Updated validation to better confirm the release manifest structure and required fields.

* **Tests**
  * Expanded release manifest checks to cover the new schema version and release locator format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->