### PR TITLE
feat(json): releases json validate <path> — v2 manifest owner tooling

### DIFF
--- a/.changeset/json-validate-command.md
+++ b/.changeset/json-validate-command.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": minor
+---
+
+Add `releases json validate <path>` — validate a `releases.json` v2 owner manifest against the published schema (`ReleasesJsonConfigSchema`) before publishing it. Accepts a file path or `-` for stdin, detects the hosting scope (domain vs repo) for readable path-anchored errors, and supports `--json` for machine output (exit 0 valid / 1 invalid). The `domain` form (live fetch + materialization plan) is deferred until the public dry-run endpoint lands (buildinternet/releases#1910) so web and CLI share one verdict.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Org-scoped: up to 10 (`--org`, optional `--source`, `--product`, `--type feature
 
 ### Contribute to the registry
 
-Neither needs an account or API key:
+None of these need an account or API key:
 
 ```bash
 releases submit https://acme.dev/changelog       # suggest a changelog / release-notes URL
@@ -78,7 +78,9 @@ releases feedback "tail -f reconnects slowly"     # report a bug or share an ide
 releases json validate releases.json              # check a releases.json manifest before publishing
 ```
 
-Both prompt interactively when run with no argument, accept input on stdin, and take `--dry-run --json` to preview the payload without sending. `feedback --type` is `bug` / `idea` / `other`; `submit --note` carries extra context (product name, repo, feed quirks). Submissions feed the same review queue as the [web submit form](https://releases.sh/submit).
+`submit` and `feedback` both prompt interactively when run with no argument, accept input on stdin, and take `--dry-run --json` to preview the payload without sending. `feedback --type` is `bug` / `idea` / `other`; `submit --note` carries extra context (product name, repo, feed quirks). Submissions feed the same review queue as the [web submit form](https://releases.sh/submit).
+
+`json validate` is a read-only manifest check: it validates a [`releases.json`](https://releases.sh/docs/listing) v2 file against the published schema (pass a path or `-` for stdin) and adds `--json` for machine-readable output — no network, no submission.
 
 ### MCP & Claude Code
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Neither needs an account or API key:
 ```bash
 releases submit https://acme.dev/changelog       # suggest a changelog / release-notes URL
 releases feedback "tail -f reconnects slowly"     # report a bug or share an idea
+releases json validate releases.json              # check a releases.json manifest before publishing
 ```
 
 Both prompt interactively when run with no argument, accept input on stdin, and take `--dry-run --json` to preview the payload without sending. `feedback --type` is `bug` / `idea` / `other`; `submit --note` carries extra context (product name, repo, feed quirks). Submissions feed the same review queue as the [web submit form](https://releases.sh/submit).

--- a/src/cli/commands/json.ts
+++ b/src/cli/commands/json.ts
@@ -1,0 +1,309 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { existsSync } from "node:fs";
+import {
+  ReleasesJsonConfigSchema,
+  ReleasesJsonDomainSchema,
+  ReleasesJsonRepoSchema,
+} from "@buildinternet/releases-api-types";
+import { logger } from "@releases/lib/logger";
+import { readContentArg } from "../../lib/input.js";
+import { writeJson } from "../../lib/output.js";
+
+// The owner-declared manifest documented at https://releases.sh/docs/listing.
+// Two hosting scopes share one public union schema (ReleasesJsonConfigSchema):
+//   - domain: /.well-known/releases.json — flat org identity + products[]
+//   - repo:   repo-root releases.json    — product binding + repo releases[]
+// See buildinternet/releases#1908 (v2 manifest) / releases-cli#351.
+
+type Scope = "domain" | "repo";
+
+interface Issue {
+  path: string;
+  message: string;
+  code: string;
+}
+
+interface ValidateResult {
+  target: string;
+  valid: boolean;
+  scope: Scope | null;
+  issues: Issue[];
+  summary?: DomainSummary | RepoSummary;
+}
+
+interface DomainSummary {
+  scope: "domain";
+  name: string | null;
+  category: string | null;
+  products: number;
+  releaseLocations: number;
+  registryBinding: RegistryBinding | null;
+}
+
+interface RepoSummary {
+  scope: "repo";
+  product: string | null;
+  releaseLocations: number;
+  registryBinding: RegistryBinding | null;
+}
+
+interface RegistryBinding {
+  org: string | null;
+  product: string | null;
+  verification: boolean;
+}
+
+// A bare hostname (no scheme, path, port, or query) — the future `domain` form.
+// A local file argument almost always carries a `.`-json suffix, a path
+// separator, or is `-`, so this only misfires on a dotted, slash-free,
+// non-existent argument, which is exactly the domain intent.
+const HOSTNAME_RE =
+  /^(?=.{1,253}$)[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)+$/i;
+
+function looksLikeDomain(target: string): boolean {
+  if (target === "-") return false;
+  if (target.includes("/") || target.includes("\\")) return false;
+  // A `.json` argument is always a file — even a missing one — so a typo'd path
+  // surfaces a clean "cannot read file" instead of the domain-deferred notice.
+  if (target.toLowerCase().endsWith(".json")) return false;
+  if (existsSync(target)) return false;
+  return HOSTNAME_RE.test(target);
+}
+
+// Domain-only top-level keys. Their presence disambiguates the union so a
+// mis-typed file gets errors from the scope it clearly intended rather than the
+// noisy "matched neither branch" union failure.
+const DOMAIN_KEYS = new Set([
+  "name",
+  "description",
+  "category",
+  "avatar",
+  "tags",
+  "social",
+  "products",
+]);
+
+function detectScope(data: unknown): Scope {
+  if (typeof data !== "object" || data === null) return "domain";
+  const keys = Object.keys(data as Record<string, unknown>);
+  if (keys.includes("product")) return "repo";
+  if (keys.some((k) => DOMAIN_KEYS.has(k))) return "domain";
+  return "domain";
+}
+
+function scopeSchema(
+  scope: Scope,
+): typeof ReleasesJsonDomainSchema | typeof ReleasesJsonRepoSchema {
+  return scope === "repo" ? ReleasesJsonRepoSchema : ReleasesJsonDomainSchema;
+}
+
+// Structurally typed to sidestep the dual-zod version skew between this repo's
+// pinned zod and the copy api-types resolves — we only read `path`/`message`/
+// `code` off each issue.
+interface ZodIssueLike {
+  path: PropertyKey[];
+  message: string;
+  code: string;
+}
+
+function collectIssues(error: { issues: ZodIssueLike[] }): Issue[] {
+  return error.issues.map((issue) => ({
+    path: issue.path.length ? issue.path.map(String).join(".") : "(root)",
+    message: issue.message,
+    code: issue.code,
+  }));
+}
+
+function countReleaseLocations(parsed: Record<string, unknown>): number {
+  const top = Array.isArray(parsed.releases) ? parsed.releases.length : 0;
+  const products = Array.isArray(parsed.products) ? parsed.products : [];
+  const nested = products.reduce<number>((sum, product) => {
+    const rel = (product as { releases?: unknown }).releases;
+    return sum + (Array.isArray(rel) ? rel.length : 0);
+  }, 0);
+  return top + nested;
+}
+
+function registryBinding(parsed: Record<string, unknown>): RegistryBinding | null {
+  const registries = parsed.registries as Record<string, unknown> | undefined;
+  const entry = registries?.["releases.sh"] as Record<string, unknown> | undefined;
+  if (!entry) return null;
+  return {
+    org: typeof entry.org === "string" ? entry.org : null,
+    product: typeof entry.product === "string" ? entry.product : null,
+    verification: typeof entry.verification === "string" && entry.verification.length > 0,
+  };
+}
+
+function buildSummary(parsed: Record<string, unknown>): DomainSummary | RepoSummary {
+  const binding = registryBinding(parsed);
+  if ("product" in parsed) {
+    const product = parsed.product as { name?: string; slug?: string } | undefined;
+    return {
+      scope: "repo",
+      product: product?.slug ?? product?.name ?? null,
+      releaseLocations: Array.isArray(parsed.releases) ? parsed.releases.length : 0,
+      registryBinding: binding,
+    };
+  }
+  return {
+    scope: "domain",
+    name: typeof parsed.name === "string" ? parsed.name : null,
+    category: typeof parsed.category === "string" ? parsed.category : null,
+    products: Array.isArray(parsed.products) ? parsed.products.length : 0,
+    releaseLocations: countReleaseLocations(parsed),
+    registryBinding: binding,
+  };
+}
+
+function line(label: string, value: string): void {
+  console.log(`  ${chalk.dim(label.padEnd(16))}${value}`);
+}
+
+function printSummary(summary: DomainSummary | RepoSummary): void {
+  console.log(chalk.green("✓ valid releases.json") + chalk.dim(` (${summary.scope} scope)`));
+  if (summary.scope === "domain") {
+    if (summary.name) line("org", summary.name);
+    if (summary.category) line("category", summary.category);
+    line("products", String(summary.products));
+  } else {
+    line("product", summary.product ?? chalk.dim("(unbound)"));
+  }
+  line("release locators", String(summary.releaseLocations));
+  const binding = summary.registryBinding;
+  if (binding) {
+    const parts: string[] = [];
+    if (binding.org) parts.push(`org ${binding.org}`);
+    if (binding.product) parts.push(`product ${binding.product}`);
+    if (binding.verification) parts.push("verification set");
+    line("releases.sh", parts.length ? parts.join(", ") : chalk.dim("(present, empty)"));
+  }
+}
+
+function printIssues(target: string, scope: Scope, issues: Issue[]): void {
+  console.log(chalk.red(`✗ invalid releases.json`) + chalk.dim(` (${scope} scope) — ${target}`));
+  console.log("");
+  for (const issue of issues) {
+    console.log(`  ${chalk.yellow(issue.path)}  ${issue.message}`);
+  }
+  console.log("");
+  console.log(
+    chalk.dim(
+      `${issues.length} issue${issues.length === 1 ? "" : "s"}. Schema: https://releases.sh/docs/listing`,
+    ),
+  );
+}
+
+async function runValidate(target: string, opts: { json?: boolean }): Promise<void> {
+  if (looksLikeDomain(target)) {
+    // The domain form fetches https://<domain>/.well-known/releases.json and
+    // renders the materialization plan. Its verdict must come from the shared
+    // web fast-lane backend (the public rate-limited dry-run endpoint) so web
+    // and CLI never disagree — that endpoint is buildinternet/releases#1910 and
+    // hasn't landed. Ship the local-file half first; keep the surface stable.
+    const message =
+      `Domain validation isn't available yet — it needs the public dry-run ` +
+      `endpoint (buildinternet/releases#1910). ` +
+      `For now, save the file locally and validate the path:\n` +
+      `  curl -s https://${target}/.well-known/releases.json | releases json validate -`;
+    if (opts.json) {
+      await writeJson({
+        target,
+        valid: false,
+        scope: null,
+        issues: [],
+        unsupported: "domain",
+        message: message.replace(/\n\s*/g, " "),
+      });
+    } else {
+      logger.error(message);
+    }
+    process.exit(2);
+  }
+
+  const raw = await readContentArg(target);
+
+  let data: unknown;
+  try {
+    data = JSON.parse(raw);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    if (opts.json) {
+      await writeJson({
+        target,
+        valid: false,
+        scope: null,
+        issues: [{ path: "(root)", message: `not valid JSON: ${detail}`, code: "invalid_json" }],
+      });
+    } else {
+      logger.error(`Not valid JSON: ${detail}`);
+    }
+    process.exit(1);
+  }
+
+  const verdict = ReleasesJsonConfigSchema.safeParse(data);
+  const scope = detectScope(data);
+
+  if (verdict.success) {
+    const summary = buildSummary(data as Record<string, unknown>);
+    const result: ValidateResult = {
+      target,
+      valid: true,
+      scope: summary.scope,
+      issues: [],
+      summary,
+    };
+    if (opts.json) {
+      await writeJson(result);
+    } else {
+      printSummary(summary);
+    }
+    return;
+  }
+
+  // The union's own error nests both branches' failures, which is noise. Re-run
+  // against the scope the file clearly intended for readable, path-anchored
+  // messages.
+  const scoped = scopeSchema(scope).safeParse(data);
+  const issues = scoped.success ? collectIssues(verdict.error) : collectIssues(scoped.error);
+
+  const result: ValidateResult = { target, valid: false, scope, issues };
+  if (opts.json) {
+    await writeJson(result);
+  } else {
+    printIssues(target, scope, issues);
+  }
+  process.exit(1);
+}
+
+export function registerJsonCommand(program: Command): void {
+  const json = program
+    .command("json")
+    .description("Work with releases.json owner manifests")
+    .showSuggestionAfterError(true)
+    .action(() => {
+      console.log(chalk.dim('Run "releases json --help" to see manifest commands.'));
+    });
+
+  json
+    .command("validate")
+    .description("Validate a releases.json manifest against the v2 schema")
+    .argument("<target>", 'Path to a releases.json file, or "-" to read from stdin')
+    .option("--json", "Machine-readable JSON output")
+    .addHelpText(
+      "after",
+      `
+Examples:
+  $ releases json validate releases.json
+  $ releases json validate ./path/to/.well-known/releases.json --json
+  $ cat releases.json | releases json validate -
+
+Validates either hosting scope (domain-hosted /.well-known/releases.json or a
+repo-root releases.json). Exit code 0 when valid, 1 when invalid.
+Docs: https://releases.sh/docs/listing`,
+    )
+    .action(async (target: string, opts: { json?: boolean }) => {
+      await runValidate(target, opts);
+    });
+}

--- a/src/cli/commands/json.ts
+++ b/src/cli/commands/json.ts
@@ -30,6 +30,11 @@ interface ValidateResult {
   scope: Scope | null;
   issues: Issue[];
   summary?: DomainSummary | RepoSummary;
+  // Set only on the deferred domain form (exit 2): the outcome is neither a
+  // pass nor a schema failure, so it carries a marker plus operator guidance
+  // rather than issues. Keeps every `--json` outcome on one documented shape.
+  unsupported?: "domain";
+  message?: string;
 }
 
 interface DomainSummary {
@@ -71,24 +76,12 @@ function looksLikeDomain(target: string): boolean {
   return HOSTNAME_RE.test(target);
 }
 
-// Domain-only top-level keys. Their presence disambiguates the union so a
-// mis-typed file gets errors from the scope it clearly intended rather than the
-// noisy "matched neither branch" union failure.
-const DOMAIN_KEYS = new Set([
-  "name",
-  "description",
-  "category",
-  "avatar",
-  "tags",
-  "social",
-  "products",
-]);
-
+// The single top-level discriminator between the two hosting scopes: only the
+// repo-root manifest declares `product` (singular). Everything else — including
+// a minimal `{version, releases}` file — is treated as domain scope, which
+// picks the right scoped schema for readable error messages.
 function detectScope(data: unknown): Scope {
-  if (typeof data !== "object" || data === null) return "domain";
-  const keys = Object.keys(data as Record<string, unknown>);
-  if (keys.includes("product")) return "repo";
-  if (keys.some((k) => DOMAIN_KEYS.has(k))) return "domain";
+  if (typeof data === "object" && data !== null && "product" in data) return "repo";
   return "domain";
 }
 
@@ -136,9 +129,9 @@ function registryBinding(parsed: Record<string, unknown>): RegistryBinding | nul
   };
 }
 
-function buildSummary(parsed: Record<string, unknown>): DomainSummary | RepoSummary {
+function buildSummary(parsed: Record<string, unknown>, scope: Scope): DomainSummary | RepoSummary {
   const binding = registryBinding(parsed);
-  if ("product" in parsed) {
+  if (scope === "repo") {
     const product = parsed.product as { name?: string; slug?: string } | undefined;
     return {
       scope: "repo",
@@ -208,14 +201,15 @@ async function runValidate(target: string, opts: { json?: boolean }): Promise<vo
       `For now, save the file locally and validate the path:\n` +
       `  curl -s https://${target}/.well-known/releases.json | releases json validate -`;
     if (opts.json) {
-      await writeJson({
+      const result: ValidateResult = {
         target,
         valid: false,
         scope: null,
         issues: [],
         unsupported: "domain",
         message: message.replace(/\n\s*/g, " "),
-      });
+      };
+      await writeJson(result);
     } else {
       logger.error(message);
     }
@@ -230,12 +224,13 @@ async function runValidate(target: string, opts: { json?: boolean }): Promise<vo
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);
     if (opts.json) {
-      await writeJson({
+      const result: ValidateResult = {
         target,
         valid: false,
         scope: null,
         issues: [{ path: "(root)", message: `not valid JSON: ${detail}`, code: "invalid_json" }],
-      });
+      };
+      await writeJson(result);
     } else {
       logger.error(`Not valid JSON: ${detail}`);
     }
@@ -246,11 +241,11 @@ async function runValidate(target: string, opts: { json?: boolean }): Promise<vo
   const scope = detectScope(data);
 
   if (verdict.success) {
-    const summary = buildSummary(data as Record<string, unknown>);
+    const summary = buildSummary(data as Record<string, unknown>, scope);
     const result: ValidateResult = {
       target,
       valid: true,
-      scope: summary.scope,
+      scope,
       issues: [],
       summary,
     };
@@ -301,6 +296,10 @@ Examples:
 
 Validates either hosting scope (domain-hosted /.well-known/releases.json or a
 repo-root releases.json). Exit code 0 when valid, 1 when invalid.
+
+A bare hostname (e.g. acme.com) targets the domain form — live fetch plus
+materialization plan — which is deferred until the public dry-run endpoint
+lands (buildinternet/releases#1910); it exits 2 with guidance for now.
 Docs: https://releases.sh/docs/listing`,
     )
     .action(async (target: string, opts: { json?: boolean }) => {

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -51,6 +51,7 @@ import { registerWhoamiCommand } from "./commands/whoami.js";
 import { registerWebhookCommand } from "./commands/webhook.js";
 import { registerWebhookAdminCommand } from "./commands/admin/webhook.js";
 import { registerAgentContextCommand } from "./commands/agent-context.js";
+import { registerJsonCommand } from "./commands/json.js";
 import { registerCompletionCommand } from "./commands/completion.js";
 import { completionNotice } from "./completion/hint.js";
 import { registerSkillsCommand } from "./commands/skills.js";
@@ -262,6 +263,7 @@ registerLoginCommand(program);
 registerKeysCommand(program);
 registerFollowsCommands(program);
 registerAgentContextCommand(program);
+registerJsonCommand(program);
 registerCompletionCommand(program);
 registerSkillsCommand(program);
 // `webhook {list,add,…}` — self-serve `/v1/me/webhooks` (auth required).

--- a/tests/cli/json-validate.test.ts
+++ b/tests/cli/json-validate.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "bun:test";
+import { runCli } from "../utils.js";
+
+/**
+ * Integration coverage for `releases json validate` (releases-cli#351) — the
+ * owner-facing validator for the releases.json v2 manifest. Every path here is
+ * local (schema parse or stdin), so no network or credential is touched. The
+ * domain form is deferred until the public dry-run endpoint lands
+ * (buildinternet/releases#1910); we assert it exits cleanly with guidance.
+ */
+
+const VALID_DOMAIN = JSON.stringify({
+  $schema: "https://releases.sh/schemas/releases.json",
+  version: 2,
+  name: "Acme Inc",
+  category: "developer-tools",
+  products: [
+    {
+      name: "Acme API",
+      slug: "acme-api",
+      releases: [{ url: "https://acme.com/changelog", canonical: true }],
+    },
+  ],
+  registries: { "releases.sh": { org: "org_abc123", verification: "dns-txt-token" } },
+});
+
+const INVALID = JSON.stringify({
+  version: 3,
+  name: "Broken",
+  releases: [{ url: "http://insecure.com/feed" }, { title: "no locator" }],
+});
+
+describe("json validate (public CLI integration)", () => {
+  it("documents the command and its flags in help", () => {
+    const { stdout, exitCode } = runCli(["json", "validate", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("<target>");
+    expect(stdout).toContain("--json");
+    expect(stdout).toContain("releases.sh/docs/listing");
+  });
+
+  it("validates a repo-scope manifest from stdin", () => {
+    const repoManifest = JSON.stringify({
+      $schema: "https://releases.sh/schemas/releases.json",
+      version: 2,
+      product: { name: "CLI", slug: "cli" },
+      releases: [{ github: "self" }],
+    });
+    const { stdout, exitCode } = runCli(["json", "validate", "-"], { input: repoManifest });
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("valid releases.json");
+    expect(stdout).toContain("repo scope");
+    expect(stdout).toContain("cli");
+  });
+
+  it("validates a domain-scope manifest and reports --json summary", () => {
+    const { stdout, exitCode } = runCli(["json", "validate", "-", "--json"], {
+      input: VALID_DOMAIN,
+    });
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout) as {
+      valid: boolean;
+      scope: string;
+      summary: { scope: string; products: number; releaseLocations: number };
+    };
+    expect(parsed.valid).toBe(true);
+    expect(parsed.scope).toBe("domain");
+    expect(parsed.summary.products).toBe(1);
+    expect(parsed.summary.releaseLocations).toBe(1);
+  });
+
+  it("reports schema violations with paths and exits non-zero (--json)", () => {
+    const { stdout, exitCode } = runCli(["json", "validate", "-", "--json"], { input: INVALID });
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout) as {
+      valid: boolean;
+      scope: string;
+      issues: { path: string; message: string }[];
+    };
+    expect(parsed.valid).toBe(false);
+    expect(parsed.scope).toBe("domain");
+    const paths = parsed.issues.map((i) => i.path);
+    expect(paths).toContain("version");
+    expect(paths).toContain("releases.0.url");
+    expect(paths).toContain("releases.1");
+  });
+
+  it("rejects non-JSON input before schema validation", () => {
+    const { stderr, exitCode } = runCli(["json", "validate", "-"], { input: "{ not json" });
+    expect(exitCode).toBe(1);
+    expect(stderr.toLowerCase()).toContain("not valid json");
+  });
+
+  it("defers the domain form to the pending dry-run endpoint", () => {
+    const { stdout, stderr, exitCode } = runCli(["json", "validate", "acme.com"]);
+    expect(exitCode).toBe(2);
+    expect((stdout + stderr).toLowerCase()).toContain("domain validation isn't available yet");
+    expect(stdout + stderr).toContain("1910");
+  });
+});


### PR DESCRIPTION
Closes #351.

## What

Adds `releases json validate <path>` — owner tooling for iterating on a `releases.json` v2 manifest before publishing it. Phase-2 item from buildinternet/releases#1908 / buildinternet/releases#1910.

- **Path / stdin:** validates a local file (or `-`) against the published `ReleasesJsonConfigSchema` from `@buildinternet/releases-api-types` (a dependency since #349).
- **Scope-aware errors:** detects the hosting scope (domain-hosted `/.well-known/releases.json` vs. repo-root `releases.json`) so failures render as readable, path-anchored messages (`releases.0.url  locator must be an https URL`) instead of the noisy "matched neither union branch" dump.
- **Valid-file summary:** scope, org/product identity, release-locator count, and the `releases.sh` registry binding.
- **`--json`** for machine output. Exit `0` valid / `1` invalid / `2` domain-form-deferred.
- Top-level read-only verb (not under `admin`), per the CLI command-shape convention. No account or API key required.

## Scope / the deferred half

The issue's constraint (from buildinternet/releases#1910): the **domain form** should share the web fast-lane's validation backend (the public rate-limited dry-run endpoint) so web and CLI agree on verdicts and can render the materialization plan. That endpoint hasn't landed, so this PR ships **the schema-validate (local) half only**, as the issue explicitly allows. A domain-looking argument exits cleanly with guidance pointing at buildinternet/releases#1910; the `<target>` surface is kept stable so the domain form slots in without a breaking change.

## Testing

- `bun run check` — clean (lint + format + typecheck).
- New `tests/cli/json-validate.test.ts` (6 cases): help surface, valid repo-scope (stdin), valid domain-scope `--json` summary, invalid `--json` with path assertions, non-JSON rejection, domain-form deferral.
- Manual smoke: valid repo (this repo's own `releases.json`), valid/invalid domain manifests, stdin, bad JSON, missing file, `--help`.

## Example

```
$ releases json validate releases.json
✓ valid releases.json (repo scope)
  product         cli
  release locators1

$ releases json validate broken.json
✗ invalid releases.json (domain scope) — broken.json

  version         Invalid input: expected 2
  releases.0.url  locator must be an https URL
  releases.1      at least one release locator is required

  3 issues. Schema: https://releases.sh/docs/listing
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `releases json validate <path|->` to validate `releases.json` (v2) owner manifests with schema-based, read-only checks.
  * Accepts file input or stdin and supports both human-readable output and `--json` machine output (with clear exit codes for valid/invalid/unavailable cases).
  * Produces scope-aware, path-anchored validation feedback for repo- vs domain-scoped manifests.
* **Bug Fixes**
  * Improved handling and reporting of non-JSON and invalid JSON input.
* **Tests**
  * Added CLI integration coverage for help text, stdin validation, `--json` summaries, and domain validation deferral messaging.
* **Documentation**
  * Updated the contributor guide with the new `json validate` example and usage notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->