### PR TITLE
feat(admin-org): add stub-tier verbs — create-stub, create-stub-from-domain, promote

### DIFF
--- a/.changeset/stub-org-verbs.md
+++ b/.changeset/stub-org-verbs.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": minor
+---
+
+Add stub-tier org verbs (buildinternet/releases#1947): `releases admin org create-stub` (curator-authored stub org with repeatable `--location` JSON locators and/or `--from-file`), `releases admin org create-stub-from-domain <domain>` (stub from a domain's `/.well-known/releases.json` manifest, `--dry-run` supported), and `releases admin org promote <slug>` (materialize declared locations into sources and flip the org to tracked, `--dry-run` supported). Bumps `@buildinternet/releases-api-types` to ^0.38.0 for the stub-tier wire types.

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "releases-cli",
       "dependencies": {
-        "@buildinternet/releases-api-types": "^0.37.0",
+        "@buildinternet/releases-api-types": "^0.38.0",
         "@buildinternet/releases-core": "^0.25.0",
         "@buildinternet/releases-lib": "workspace:*",
         "@buildinternet/releases-skills": "workspace:*",
@@ -29,7 +29,7 @@
     },
     "npm/releases": {
       "name": "@buildinternet/releases",
-      "version": "0.67.3",
+      "version": "0.68.0",
       "bin": {
         "releases": "bin/releases",
       },
@@ -43,31 +43,31 @@
     },
     "npm/releases-darwin-arm64": {
       "name": "@buildinternet/releases-darwin-arm64",
-      "version": "0.67.3",
+      "version": "0.68.0",
     },
     "npm/releases-darwin-x64": {
       "name": "@buildinternet/releases-darwin-x64",
-      "version": "0.67.3",
+      "version": "0.68.0",
     },
     "npm/releases-linux-arm64": {
       "name": "@buildinternet/releases-linux-arm64",
-      "version": "0.67.3",
+      "version": "0.68.0",
     },
     "npm/releases-linux-x64": {
       "name": "@buildinternet/releases-linux-x64",
-      "version": "0.67.3",
+      "version": "0.68.0",
     },
     "npm/releases-windows-x64": {
       "name": "@buildinternet/releases-windows-x64",
-      "version": "0.67.3",
+      "version": "0.68.0",
     },
     "packages/lib": {
       "name": "@buildinternet/releases-lib",
-      "version": "0.67.3",
+      "version": "0.68.0",
     },
     "packages/skills": {
       "name": "@buildinternet/releases-skills",
-      "version": "0.67.3",
+      "version": "0.68.0",
     },
   },
   "packages": {
@@ -75,7 +75,7 @@
 
     "@buildinternet/releases": ["@buildinternet/releases@workspace:npm/releases"],
 
-    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.37.0", "", { "dependencies": { "@buildinternet/releases-core": "^0.25.0", "zod": "^4.4.3" } }, "sha512-/UXXkx1suIicIC5l3brWOxF2HCRHRAFN6ozYwIhDCIi92VGb7ml3d8U/1mfY+m4qwIpmDZwrQReEIVej6s3vew=="],
+    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.38.0", "", { "dependencies": { "@buildinternet/releases-core": "^0.25.0", "zod": "^4.4.3" } }, "sha512-0FxpzH4kzGkINQ5dPSOHaBdpAbNR/d0tOS04klyQXBt+fHYXO4jP8Vdj5edn4y3NzNjAB2DAQOsd/SQiSdzT3A=="],
 
     "@buildinternet/releases-core": ["@buildinternet/releases-core@0.25.0", "", { "dependencies": { "drizzle-orm": "^0.45.2", "js-tiktoken": "^1.0.21", "nanoid": "^5.1.15" } }, "sha512-9tyVeyB/THz51NJ30U22bda7cpTLU8P54mcmxGJOdtHnGYiq7iS6eggIfxsQY0IKnilv8YEQF2ZJplkjGRDiSg=="],
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "homepage": "https://releases.sh",
   "dependencies": {
-    "@buildinternet/releases-api-types": "^0.37.0",
+    "@buildinternet/releases-api-types": "^0.38.0",
     "@buildinternet/releases-core": "^0.25.0",
     "@buildinternet/releases-lib": "workspace:*",
     "@buildinternet/releases-skills": "workspace:*",

--- a/skills/releases-cli/references/admin.md
+++ b/skills/releases-cli/references/admin.md
@@ -251,6 +251,19 @@ releases admin org delete vercel --hard --yes             # permanent purge + FK
 
 There is no `org refresh` command. To refresh an org: fetch its sources with `releases admin source fetch --org <slug>` (see **Fetch** above), then regenerate the overview with the `overview` subcommands — `releases admin overview inputs <slug>` → generate the body → `releases admin overview update <slug>` (or `releases admin overview batch` for a server-side sweep). Overview generation is agent-driven; no single command does both.
 
+### Stub-tier orgs
+
+A stub org carries identity + declared release locations but no sources (buildinternet/releases#1947):
+
+```bash
+releases admin org create-stub "Example" --domain example.com --location '{"url":"https://example.com/changelog"}'
+releases admin org create-stub "Example" --from-file locations.json      # locations array or full body JSON
+releases admin org create-stub-from-domain example.com --dry-run         # from /.well-known/releases.json
+releases admin org promote example --dry-run                             # materialize locations → sources, tier → tracked
+```
+
+`--location` is repeatable and takes one JSON locator per flag (`url` / `feed` / `github` / `appstore` / `file`, plus optional `title` / `canonical`). `promote` is idempotent — an already-tracked org is a no-op.
+
 `org delete` soft-deletes by default (a reversible tombstone). `--hard` purges the row and cascade-deletes every dependent source, release, fetch-log, changelog file/chunk, summary, media asset, and webhook subscription; it prompts for a slug typeback unless `--yes` is passed (required in non-TTY/scripted contexts). You can pass a slug or an `org_…` ID either way — the CLI resolves to the typed ID the destructive path requires.
 
 ## Products

--- a/src/api/orgs.ts
+++ b/src/api/orgs.ts
@@ -6,7 +6,7 @@ import type {
   Tag,
 } from "@buildinternet/releases-core/schema";
 import type { OrgCatalogResponse, OrgDependentsResponse } from "./types.js";
-import type { SetOrgAvatarResponse } from "@buildinternet/releases-api-types";
+import type { CreateStubOrgBody, SetOrgAvatarResponse } from "@buildinternet/releases-api-types";
 import { apiFetch, suggestEntities } from "./core.js";
 import { assertCleanIdentifier } from "../lib/validate-input.js";
 import { type ListResponse } from "@buildinternet/releases-core/cli-contracts";
@@ -167,6 +167,66 @@ export async function getOrgDependents(identifier: string): Promise<OrgDependent
     throw new Error(`Org dependents preview not available for "${identifier}" (org not found).`);
   }
   return result;
+}
+
+// ── Stub-tier orgs (#1947) ──
+
+/** POST /v1/orgs/stub — create a curator-authored stub org (identity +
+ *  declared release locations, no sources). Admin scope required. */
+export async function createStubOrg(
+  body: CreateStubOrgBody,
+): Promise<Organization & { productCount: number; locationCount: number }> {
+  return apiFetch<Organization & { productCount: number; locationCount: number }>("/v1/orgs/stub", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+export interface StubFromDomainResult {
+  created: boolean;
+  orgId?: string;
+  skippedReason?: string;
+  productCount?: number;
+  locationCount?: number;
+  /** Populated on dryRun: the stub input that WOULD be written. */
+  plan?: Record<string, unknown>;
+}
+
+/** POST /v1/orgs/stub-from-domain — create a stub org from a domain's
+ *  /.well-known/releases.json manifest. `dryRun` rides as a query param. */
+export async function createStubOrgFromDomain(
+  domain: string,
+  opts?: { dryRun?: boolean },
+): Promise<StubFromDomainResult> {
+  const qs = opts?.dryRun ? "?dryRun=1" : "";
+  return apiFetch<StubFromDomainResult>(`/v1/orgs/stub-from-domain${qs}`, {
+    method: "POST",
+    body: JSON.stringify({ domain }),
+  });
+}
+
+export interface PromoteOrgResult {
+  promoted: boolean;
+  /** True when the org was already `tracked` — a no-op success (idempotent). */
+  alreadyTracked?: boolean;
+  sourcesCreated: number;
+  sourcesMatched: number;
+  locatorsStamped: number;
+  /** The materialization plan (the whole payload under dryRun). */
+  plan?: Record<string, unknown>;
+}
+
+/** POST /v1/orgs/:slug/promote — materialize a stub's locations into sources
+ *  and flip the org to `tier: "tracked"`. `dryRun` rides as a query param. */
+export async function promoteOrg(
+  identifier: string,
+  opts?: { dryRun?: boolean },
+): Promise<PromoteOrgResult> {
+  assertCleanIdentifier(identifier, "org");
+  const qs = opts?.dryRun ? "?dryRun=1" : "";
+  return apiFetch<PromoteOrgResult>(`/v1/orgs/${encodeURIComponent(identifier)}/promote${qs}`, {
+    method: "POST",
+  });
 }
 
 export async function updateOrg(

--- a/src/cli/commands/org-stub.ts
+++ b/src/cli/commands/org-stub.ts
@@ -1,0 +1,189 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { readFileSync } from "node:fs";
+import type { CreateStubOrgBody } from "@buildinternet/releases-api-types";
+import { createStubOrg, createStubOrgFromDomain, promoteOrg } from "../../api/orgs.js";
+import { logger } from "@releases/lib/logger";
+import { writeJson } from "../../lib/output.js";
+import { markDryRun } from "../../lib/dry-run.js";
+
+// ── Stub-tier org verbs (#1947 / releases-cli#355) ───────────────────────────
+//
+// A "stub" org is known only by its declared release locations — identity +
+// locators, no processed sources. Three admin routes back these verbs:
+//   POST /v1/orgs/stub               → `admin org create-stub`
+//   POST /v1/orgs/stub-from-domain   → `admin org create-stub-from-domain`
+//   POST /v1/orgs/:slug/promote      → `admin org promote`
+
+const LOCATOR_KEYS = ["url", "feed", "github", "appstore", "file"] as const;
+
+type Locator = NonNullable<CreateStubOrgBody["releases"]>[number];
+
+/** Parse one `--location` value: a JSON object carrying at least one locator
+ *  key (`url` / `feed` / `github` / `appstore` / `file`). Fails fast before
+ *  any network call, mirroring the category-validation pattern in org.ts. */
+function parseLocation(value: string): Locator {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    logger.error(
+      `Invalid --location (not valid JSON): ${value}\n` +
+        `Expected a JSON object, e.g. --location '{"url":"https://example.com/changelog"}'`,
+    );
+    process.exit(1);
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    logger.error(`Invalid --location (must be a JSON object): ${value}`);
+    process.exit(1);
+  }
+  const record = parsed as Record<string, unknown>;
+  if (!LOCATOR_KEYS.some((key) => typeof record[key] === "string")) {
+    logger.error(
+      `Invalid --location (needs at least one locator key: ${LOCATOR_KEYS.join(", ")}): ${value}`,
+    );
+    process.exit(1);
+  }
+  return record as Locator;
+}
+
+/** Read `--from-file`: either a bare JSON array of locators, or a full
+ *  CreateStubOrgBody object (name/slug/domain/products/releases…). */
+function readFromFile(path: string): Partial<CreateStubOrgBody> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf8"));
+  } catch (err) {
+    logger.error(`Could not read --from-file "${path}": ${(err as Error).message}`);
+    process.exit(1);
+  }
+  if (Array.isArray(parsed)) return { releases: parsed as Locator[] };
+  if (typeof parsed === "object" && parsed !== null) return parsed as Partial<CreateStubOrgBody>;
+  logger.error(`--from-file "${path}" must contain a JSON object or array`);
+  process.exit(1);
+}
+
+export type OrgCreateStubOpts = {
+  slug?: string;
+  domain?: string;
+  description?: string;
+  location: string[];
+  fromFile?: string;
+  json?: boolean;
+};
+
+export async function orgCreateStubAction(name: string, opts: OrgCreateStubOpts): Promise<void> {
+  // File first, explicit flags win over file-provided fields when both given.
+  const fileBody = opts.fromFile ? readFromFile(opts.fromFile) : {};
+  const flagLocations = (opts.location ?? []).map(parseLocation);
+  const releases =
+    flagLocations.length > 0 ? [...(fileBody.releases ?? []), ...flagLocations] : fileBody.releases;
+
+  const body: CreateStubOrgBody = {
+    ...fileBody,
+    name,
+    ...(opts.slug ? { slug: opts.slug } : {}),
+    ...(opts.domain ? { domain: opts.domain } : {}),
+    ...(opts.description ? { description: opts.description } : {}),
+    ...(releases ? { releases } : {}),
+  };
+
+  const created = await createStubOrg(body);
+  if (opts.json) {
+    await writeJson(created);
+    return;
+  }
+  logger.info(
+    `Created stub organization: ${created.name} (${created.slug})` +
+      ` — ${created.locationCount} location${created.locationCount === 1 ? "" : "s"},` +
+      ` ${created.productCount} product${created.productCount === 1 ? "" : "s"}`,
+  );
+  logger.info(chalk.dim(`Promote it later with: releases admin org promote ${created.slug}`));
+}
+
+export type OrgStubFromDomainOpts = { dryRun?: boolean; json?: boolean };
+
+export async function orgCreateStubFromDomainAction(
+  domain: string,
+  opts: OrgStubFromDomainOpts,
+): Promise<void> {
+  const result = await createStubOrgFromDomain(domain, { dryRun: opts.dryRun });
+  if (opts.json) {
+    await writeJson(opts.dryRun ? markDryRun(result) : result);
+    return;
+  }
+  if (opts.dryRun) {
+    if (result.plan) logger.warn(`[dry-run] Would create stub org from ${domain}:`);
+    else logger.warn(`[dry-run] Would skip ${domain}: ${result.skippedReason}`);
+    if (result.plan) console.log(JSON.stringify(result.plan, null, 2));
+    return;
+  }
+  if (!result.created) {
+    logger.error(`Stub not created for ${domain}: ${result.skippedReason}`);
+    process.exit(1);
+  }
+  logger.info(
+    `Created stub organization from ${domain} (${result.orgId})` +
+      ` — ${result.locationCount ?? 0} locations, ${result.productCount ?? 0} products`,
+  );
+}
+
+export type OrgPromoteOpts = { dryRun?: boolean; json?: boolean };
+
+export async function orgPromoteAction(slug: string, opts: OrgPromoteOpts): Promise<void> {
+  const result = await promoteOrg(slug, { dryRun: opts.dryRun });
+  if (opts.json) {
+    await writeJson(opts.dryRun ? markDryRun(result) : result);
+    return;
+  }
+  if (opts.dryRun) {
+    logger.warn(`[dry-run] Would promote ${slug}:`);
+    console.log(JSON.stringify(result.plan ?? result, null, 2));
+    return;
+  }
+  if (result.alreadyTracked) {
+    logger.info(`Organization "${slug}" is already tracked — no-op.`);
+    return;
+  }
+  logger.info(
+    `Promoted ${slug} to tracked — ${result.sourcesCreated} source${result.sourcesCreated === 1 ? "" : "s"} created,` +
+      ` ${result.sourcesMatched} matched, ${result.locatorsStamped} locators stamped`,
+  );
+}
+
+const collect = (value: string, previous: string[]) => [...previous, value];
+
+export function registerOrgStubCommands(org: Command): void {
+  org
+    .command("create-stub")
+    .description("Create a stub-tier organization (declared locations, no sources)")
+    .argument("<name>", "Organization name")
+    .option("--slug <slug>", "Custom slug")
+    .option("--domain <domain>", "Primary domain")
+    .option("--description <text>", "Brief product description")
+    .option(
+      "--location <json>",
+      'Release locator as JSON (repeatable), e.g. \'{"url":"https://example.com/changelog"}\'',
+      collect,
+      [] as string[],
+    )
+    .option("--from-file <path>", "JSON file with a locations array or a full stub-org body")
+    .option("--json", "Output as JSON")
+    .action(orgCreateStubAction);
+
+  org
+    .command("create-stub-from-domain")
+    .description("Create a stub org from a domain's /.well-known/releases.json manifest")
+    .argument("<domain>", "Domain to fetch the manifest from")
+    .option("--dry-run", "Preview the stub that would be created without writing")
+    .option("--json", "Output as JSON")
+    .action(orgCreateStubFromDomainAction);
+
+  org
+    .command("promote")
+    .description("Promote a stub org to tracked (materialize locations into sources)")
+    .argument("<slug>", "Organization slug or org_… ID")
+    .option("--dry-run", "Preview the materialization plan without writing")
+    .option("--json", "Output as JSON")
+    .action(orgPromoteAction);
+}

--- a/src/cli/commands/org.ts
+++ b/src/cli/commands/org.ts
@@ -51,6 +51,7 @@ import {
 import { warnDeprecatedAlias } from "../../lib/deprecated-alias.js";
 import { parseTagList } from "../../lib/flags.js";
 import { buildNoticePatch, formatNotice, type EntityWithNotice } from "../../lib/notice.js";
+import { registerOrgStubCommands } from "./org-stub.js";
 
 // ── Shared action handlers ────────────────────────────────────────────────────
 
@@ -546,6 +547,9 @@ async function resolveAvatarSource(
 
 export function registerOrgCommand(program: Command) {
   const org = program.command("org").description("Manage organizations");
+
+  // Stub-tier verbs — create-stub / create-stub-from-domain / promote (#1947)
+  registerOrgStubCommands(org);
 
   // ── org create (canonical) / org add (deprecated) ──
   org

--- a/tests/cli/org-stub-surface.test.ts
+++ b/tests/cli/org-stub-surface.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "bun:test";
+import { runCli } from "../utils.js";
+
+/**
+ * Surface coverage for the stub-tier org verbs (releases-cli#355, backend
+ * buildinternet/releases#1947): registration, flags, and the local --location
+ * validation that fires before any network call.
+ */
+describe("admin org stub verbs (CLI surface)", () => {
+  it("registers create-stub with its flags", () => {
+    const { stdout, exitCode } = runCli(["admin", "org", "create-stub", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--location <json>");
+    expect(stdout).toContain("--from-file <path>");
+    expect(stdout).toContain("--domain <domain>");
+  });
+
+  it("registers create-stub-from-domain with --dry-run", () => {
+    const { stdout, exitCode } = runCli(["admin", "org", "create-stub-from-domain", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("<domain>");
+    expect(stdout).toContain("--dry-run");
+  });
+
+  it("registers promote with --dry-run", () => {
+    const { stdout, exitCode } = runCli(["admin", "org", "promote", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("<slug>");
+    expect(stdout).toContain("--dry-run");
+  });
+});
+
+describe("admin org create-stub --location validation", () => {
+  it("rejects invalid JSON before any API call", () => {
+    const { stderr, exitCode } = runCli([
+      "admin",
+      "org",
+      "create-stub",
+      "Example",
+      "--location",
+      "not-json",
+    ]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("Invalid --location");
+  });
+
+  it("rejects an object with no locator key before any API call", () => {
+    const { stderr, exitCode } = runCli([
+      "admin",
+      "org",
+      "create-stub",
+      "Example",
+      "--location",
+      '{"title":"no locator"}',
+    ]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("locator key");
+  });
+});

--- a/tests/unit/org-stub.test.ts
+++ b/tests/unit/org-stub.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Drive the real mode.ts via env (a top-level mock.module leaks across files —
+// see api-client.test.ts; getApiUrl() also memoizes its base process-wide).
+const prevEnv: { url?: string; key?: string } = {};
+beforeAll(() => {
+  prevEnv.url = process.env.RELEASES_API_URL;
+  prevEnv.key = process.env.RELEASES_API_KEY;
+  process.env.RELEASES_API_URL = "https://test.example.com";
+  process.env.RELEASES_API_KEY = "test-key";
+});
+afterAll(() => {
+  if (prevEnv.url === undefined) delete process.env.RELEASES_API_URL;
+  else process.env.RELEASES_API_URL = prevEnv.url;
+  if (prevEnv.key === undefined) delete process.env.RELEASES_API_KEY;
+  else process.env.RELEASES_API_KEY = prevEnv.key;
+});
+
+const { createStubOrg, createStubOrgFromDomain, promoteOrg } =
+  await import("../../src/api/orgs.js");
+const { orgCreateStubAction, orgCreateStubFromDomainAction, orgPromoteAction } =
+  await import("../../src/cli/commands/org-stub.js");
+
+const STUB_ORG = {
+  id: "org_abc",
+  name: "Example",
+  slug: "example",
+  productCount: 1,
+  locationCount: 2,
+};
+
+const PROMOTE_RESULT = {
+  promoted: true,
+  sourcesCreated: 2,
+  sourcesMatched: 0,
+  locatorsStamped: 2,
+};
+
+function mockFetch(status: number, payload: unknown) {
+  const captured: { url: string; method: string; body: Record<string, unknown> | null } = {
+    url: "",
+    method: "",
+    body: null,
+  };
+  globalThis.fetch = (async (url: string, init?: RequestInit) => {
+    captured.url = url;
+    captured.method = init?.method ?? "GET";
+    captured.body = init?.body ? JSON.parse(String(init.body)) : null;
+    return new Response(JSON.stringify(payload), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as unknown as typeof globalThis.fetch;
+  return captured;
+}
+
+let originalFetch: typeof globalThis.fetch;
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+});
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+// ── Client wire contracts ─────────────────────────────────────────────────────
+
+describe("stub-org clients", () => {
+  it("createStubOrg POSTs the body to /v1/orgs/stub", async () => {
+    const captured = mockFetch(201, STUB_ORG);
+    const body = { name: "Example", releases: [{ url: "https://example.com/changelog" }] };
+    const created = await createStubOrg(body);
+    expect(captured.url).toBe("https://test.example.com/v1/orgs/stub");
+    expect(captured.method).toBe("POST");
+    expect(captured.body).toMatchObject(body);
+    expect(created.locationCount).toBe(2);
+  });
+
+  it("createStubOrgFromDomain POSTs {domain} and carries dryRun as a query param", async () => {
+    const captured = mockFetch(200, { created: false, skippedReason: "dry_run", plan: {} });
+    await createStubOrgFromDomain("example.com", { dryRun: true });
+    expect(captured.url).toBe("https://test.example.com/v1/orgs/stub-from-domain?dryRun=1");
+    expect(captured.body).toEqual({ domain: "example.com" });
+  });
+
+  it("createStubOrgFromDomain omits the query param without dryRun", async () => {
+    const captured = mockFetch(200, { created: true, orgId: "org_abc" });
+    await createStubOrgFromDomain("example.com");
+    expect(captured.url).toBe("https://test.example.com/v1/orgs/stub-from-domain");
+  });
+
+  it("promoteOrg POSTs to /v1/orgs/:slug/promote with dryRun as a query param", async () => {
+    const captured = mockFetch(200, PROMOTE_RESULT);
+    const result = await promoteOrg("example", { dryRun: true });
+    expect(captured.url).toBe("https://test.example.com/v1/orgs/example/promote?dryRun=1");
+    expect(captured.method).toBe("POST");
+    expect(result.sourcesCreated).toBe(2);
+  });
+
+  it("surfaces the nested error envelope message on a non-2xx", async () => {
+    mockFetch(409, {
+      error: { code: "conflict", type: "conflict", message: "already exists" },
+    });
+    await expect(createStubOrg({ name: "Example" })).rejects.toThrow(/already exists/);
+  });
+});
+
+// ── Command actions ───────────────────────────────────────────────────────────
+
+async function captureStdout(run: () => Promise<void>): Promise<string> {
+  let out = "";
+  const spy = ((s: string) => {
+    out += s;
+    return true;
+  }) as unknown as typeof process.stdout.write;
+  const orig = process.stdout.write;
+  process.stdout.write = spy;
+  try {
+    await run();
+  } finally {
+    process.stdout.write = orig;
+  }
+  return out;
+}
+
+describe("orgCreateStubAction", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "rel-org-stub-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("assembles the body from flags and repeated --location JSON", async () => {
+    const captured = mockFetch(201, STUB_ORG);
+    await orgCreateStubAction("Example", {
+      slug: "example",
+      domain: "example.com",
+      location: [
+        '{"url":"https://example.com/changelog","canonical":true}',
+        '{"github":"example/repo"}',
+      ],
+    });
+    expect(captured.body).toMatchObject({
+      name: "Example",
+      slug: "example",
+      domain: "example.com",
+      releases: [
+        { url: "https://example.com/changelog", canonical: true },
+        { github: "example/repo" },
+      ],
+    });
+  });
+
+  it("reads --from-file (bare locations array) and appends --location flags", async () => {
+    const captured = mockFetch(201, STUB_ORG);
+    const file = join(dir, "locations.json");
+    writeFileSync(file, JSON.stringify([{ feed: "https://example.com/feed.xml" }]));
+    await orgCreateStubAction("Example", {
+      location: ['{"url":"https://example.com/changelog"}'],
+      fromFile: file,
+    });
+    expect(captured.body?.releases).toEqual([
+      { feed: "https://example.com/feed.xml" },
+      { url: "https://example.com/changelog" },
+    ]);
+  });
+
+  it("reads --from-file (full body object) with explicit flags winning", async () => {
+    const captured = mockFetch(201, STUB_ORG);
+    const file = join(dir, "body.json");
+    writeFileSync(
+      file,
+      JSON.stringify({
+        name: "File Name",
+        domain: "file.example.com",
+        releases: [{ url: "https://example.com/changelog" }],
+      }),
+    );
+    await orgCreateStubAction("Example", { location: [], fromFile: file, domain: "example.com" });
+    expect(captured.body).toMatchObject({
+      name: "Example",
+      domain: "example.com",
+      releases: [{ url: "https://example.com/changelog" }],
+    });
+  });
+
+  it("--json emits the created org", async () => {
+    mockFetch(201, STUB_ORG);
+    const out = await captureStdout(() =>
+      orgCreateStubAction("Example", { location: [], json: true }),
+    );
+    expect(JSON.parse(out)).toMatchObject({ slug: "example", locationCount: 2 });
+  });
+});
+
+describe("orgCreateStubFromDomainAction", () => {
+  it("threads --dry-run and marks the JSON payload", async () => {
+    const captured = mockFetch(200, { created: false, skippedReason: "dry_run", plan: {} });
+    const out = await captureStdout(() =>
+      orgCreateStubFromDomainAction("example.com", { dryRun: true, json: true }),
+    );
+    expect(captured.url).toContain("?dryRun=1");
+    expect(JSON.parse(out)).toMatchObject({ dryRun: true, skippedReason: "dry_run" });
+  });
+
+  it("--json emits the created result", async () => {
+    mockFetch(200, { created: true, orgId: "org_abc", productCount: 0, locationCount: 3 });
+    const out = await captureStdout(() =>
+      orgCreateStubFromDomainAction("example.com", { json: true }),
+    );
+    expect(JSON.parse(out)).toMatchObject({ created: true, locationCount: 3 });
+  });
+});
+
+describe("orgPromoteAction", () => {
+  it("threads --dry-run through to the query param and marks JSON output", async () => {
+    const captured = mockFetch(200, { ...PROMOTE_RESULT, promoted: false, plan: {} });
+    const out = await captureStdout(() =>
+      orgPromoteAction("example", { dryRun: true, json: true }),
+    );
+    expect(captured.url).toBe("https://test.example.com/v1/orgs/example/promote?dryRun=1");
+    expect(JSON.parse(out)).toMatchObject({ dryRun: true });
+  });
+
+  it("--json emits the promote result", async () => {
+    mockFetch(200, PROMOTE_RESULT);
+    const out = await captureStdout(() => orgPromoteAction("example", { json: true }));
+    expect(JSON.parse(out)).toMatchObject({ promoted: true, sourcesCreated: 2 });
+  });
+
+  it("handles the already-tracked no-op without throwing", async () => {
+    mockFetch(200, {
+      promoted: false,
+      alreadyTracked: true,
+      sourcesCreated: 0,
+      sourcesMatched: 0,
+      locatorsStamped: 0,
+    });
+    await orgPromoteAction("example", {});
+  });
+});


### PR DESCRIPTION
## Summary

Adds the three stub-tier admin verbs from #355, wrapping the routes shipped in buildinternet/releases#1956 (stub-tier epic buildinternet/releases#1947):

- `releases admin org create-stub <name>` — `POST /v1/orgs/stub`. Repeatable `--location '<json>'` locators and/or `--from-file <path>` (bare locator array or a full `CreateStubOrgBody`; explicit flags win). Fail-fast local validation before any network call.
- `releases admin org create-stub-from-domain <domain> [--dry-run]` — `POST /v1/orgs/stub-from-domain`; `dryRun` rides as `?dryRun=1` (the route reads it from the query string).
- `releases admin org promote <slug> [--dry-run]` — `POST /v1/orgs/:slug/promote`; already-tracked orgs report the idempotent no-op.

Bumps `@buildinternet/releases-api-types` to `^0.38.0` for the stub-tier wire types.

## Spec notes (deviations from the issue text, matched to the actual API)

- The body field is `releases[]`, not `locations[]` — `CreateStubOrgBodySchema` uses the domain-manifest shape. The CLI flag stays `--location` per the issue and maps into `releases`.
- No `--dry-run` on `create-stub` — the route has none (issue said add only if API-side).
- No `--product` flag — product entries are rich objects; the full-body `--from-file` form covers them. Locator editing / demotion verbs remain a separate follow-up per the issue's non-goals.

## Testing

- `bun run check` green (two pre-existing warnings in untouched files).
- New tests: 19 pass — wire-contract tests (mocked fetch, `https://test.example.com` base) + CLI surface/validation tests.
- Full `bun test`: the 7 failures are pre-existing on `main` (local-credential-dependent auth tests), unrelated to this change.

Closes #355. Tracks buildinternet/releases#1947.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new organization admin commands to create stub organizations, create them from a domain, and promote a stub organization to a tracked one.
  * Expanded CLI support for structured location inputs, file-based input, dry-run mode, and JSON output.

* **Bug Fixes**
  * Added validation to catch invalid location input before making a request.
  * Improved error handling and user feedback for failed organization actions.

* **Documentation**
  * Updated CLI docs with the new stub-organization workflow and command options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->