### PR TITLE
feat(json): validate <domain> live via /v1/listing/validate

### DIFF
--- a/.changeset/json-validate-domain-live.md
+++ b/.changeset/json-validate-domain-live.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": minor
+---
+
+`releases json validate <domain>` now validates live against the registry's listing endpoint (previously deferred). The domain form POSTs the public `/v1/listing/validate` endpoint and renders the verdict plus the materialization plan — identity, products, and each release locator with its classification ("goes live" / "reviewed first") — ending with an activation pointer for unlisted domains. Exit codes: 0 valid, 1 invalid or check failed (the old unconditional exit 2 is gone). `--json` emits the raw `ListingValidationResult` merged with `{ target }`. Bumps `@buildinternet/releases-api-types` to ^0.39.0 for the listing wire types.

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "releases-cli",
       "dependencies": {
-        "@buildinternet/releases-api-types": "^0.38.0",
+        "@buildinternet/releases-api-types": "^0.39.0",
         "@buildinternet/releases-core": "^0.25.0",
         "@buildinternet/releases-lib": "workspace:*",
         "@buildinternet/releases-skills": "workspace:*",
@@ -75,7 +75,7 @@
 
     "@buildinternet/releases": ["@buildinternet/releases@workspace:npm/releases"],
 
-    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.38.0", "", { "dependencies": { "@buildinternet/releases-core": "^0.25.0", "zod": "^4.4.3" } }, "sha512-0FxpzH4kzGkINQ5dPSOHaBdpAbNR/d0tOS04klyQXBt+fHYXO4jP8Vdj5edn4y3NzNjAB2DAQOsd/SQiSdzT3A=="],
+    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.39.0", "", { "dependencies": { "@buildinternet/releases-core": "^0.25.0", "zod": "^4.4.3" } }, "sha512-0Q/QAH0X9q2Hw6nJQQ/cKYUqwjyV+JxIFJDLUVrBVEgat646vtqXke+qnPjzX3TriawLvwuh2rFr8TelFkJNmg=="],
 
     "@buildinternet/releases-core": ["@buildinternet/releases-core@0.25.0", "", { "dependencies": { "drizzle-orm": "^0.45.2", "js-tiktoken": "^1.0.21", "nanoid": "^5.1.15" } }, "sha512-9tyVeyB/THz51NJ30U22bda7cpTLU8P54mcmxGJOdtHnGYiq7iS6eggIfxsQY0IKnilv8YEQF2ZJplkjGRDiSg=="],
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "homepage": "https://releases.sh",
   "dependencies": {
-    "@buildinternet/releases-api-types": "^0.38.0",
+    "@buildinternet/releases-api-types": "^0.39.0",
     "@buildinternet/releases-core": "^0.25.0",
     "@buildinternet/releases-lib": "workspace:*",
     "@buildinternet/releases-skills": "workspace:*",

--- a/src/cli/commands/json.ts
+++ b/src/cli/commands/json.ts
@@ -229,7 +229,18 @@ async function runDomainValidate(target: string, opts: { json?: boolean }): Prom
     process.exit(1);
   }
 
-  const result = (await res.json()) as ListingValidationResult;
+  let result: ListingValidationResult;
+  try {
+    result = (await res.json()) as ListingValidationResult;
+  } catch {
+    const message = "The listing endpoint returned an unreadable response. Please try again.";
+    if (opts.json) {
+      await writeJson({ target, valid: false, scope: null, issues: [], message });
+    } else {
+      console.log(chalk.red(message));
+    }
+    process.exit(1);
+  }
 
   if (opts.json) {
     // Raw wire shape merged with the target — deliberately NOT the local-file

--- a/src/cli/commands/json.ts
+++ b/src/cli/commands/json.ts
@@ -6,9 +6,11 @@ import {
   ReleasesJsonDomainSchema,
   ReleasesJsonRepoSchema,
 } from "@buildinternet/releases-api-types";
+import type { ListingValidationResult } from "@buildinternet/releases-api-types";
 import { logger } from "@releases/lib/logger";
 import { readContentArg } from "../../lib/input.js";
 import { writeJson } from "../../lib/output.js";
+import { getApiUrl } from "../../lib/mode.js";
 
 // The owner-declared manifest documented at https://releases.sh/docs/listing.
 // Two hosting scopes share one public union schema (ReleasesJsonConfigSchema):
@@ -30,11 +32,6 @@ interface ValidateResult {
   scope: Scope | null;
   issues: Issue[];
   summary?: DomainSummary | RepoSummary;
-  // Set only on the deferred domain form (exit 2): the outcome is neither a
-  // pass nor a schema failure, so it carries a marker plus operator guidance
-  // rather than issues. Keeps every `--json` outcome on one documented shape.
-  unsupported?: "domain";
-  message?: string;
 }
 
 interface DomainSummary {
@@ -188,32 +185,110 @@ function printIssues(target: string, scope: Scope, issues: Issue[]): void {
   );
 }
 
-async function runValidate(target: string, opts: { json?: boolean }): Promise<void> {
-  if (looksLikeDomain(target)) {
-    // The domain form fetches https://<domain>/.well-known/releases.json and
-    // renders the materialization plan. Its verdict must come from the shared
-    // web fast-lane backend (the public rate-limited dry-run endpoint) so web
-    // and CLI never disagree — that endpoint is buildinternet/releases#1910 and
-    // hasn't landed. Ship the local-file half first; keep the surface stable.
-    const message =
-      `Domain validation isn't available yet — it needs the public dry-run ` +
-      `endpoint (buildinternet/releases#1910). ` +
-      `For now, save the file locally and validate the path:\n` +
-      `  curl -s https://${target}/.well-known/releases.json | releases json validate -`;
+// The domain form. The verdict comes from the shared web fast-lane backend
+// (POST /v1/listing/validate — buildinternet/releases#1910/#1947 phase 2) so
+// web and CLI never disagree: the API fetches https://<domain>/.well-known/
+// releases.json live and returns the validation verdict plus the
+// materialization plan. Anonymous, per-IP rate-limited; no auth header.
+async function runDomainValidate(target: string, opts: { json?: boolean }): Promise<never> {
+  let res: Response;
+  try {
+    res = await fetch(`${getApiUrl()}/v1/listing/validate`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ domain: target }),
+    });
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    const message = `Could not reach the listing endpoint: ${detail}`;
     if (opts.json) {
-      const result: ValidateResult = {
-        target,
-        valid: false,
-        scope: null,
-        issues: [],
-        unsupported: "domain",
-        message: message.replace(/\n\s*/g, " "),
-      };
-      await writeJson(result);
+      await writeJson({ target, valid: false, scope: null, issues: [], message });
     } else {
       logger.error(message);
     }
-    process.exit(2);
+    process.exit(1);
+  }
+
+  if (!res.ok) {
+    let message = "Validation request failed. Please try again.";
+    if (res.status === 429) {
+      message = "Too many checks — please try again in a minute.";
+    } else {
+      try {
+        const body = (await res.json()) as { error?: { message?: string } };
+        if (typeof body?.error?.message === "string") message = body.error.message;
+      } catch {
+        // keep the generic fallback
+      }
+    }
+    if (opts.json) {
+      await writeJson({ target, valid: false, scope: null, issues: [], message });
+    } else {
+      console.log(chalk.red(message));
+    }
+    process.exit(1);
+  }
+
+  const result = (await res.json()) as ListingValidationResult;
+
+  if (opts.json) {
+    // Raw wire shape merged with the target — deliberately NOT the local-file
+    // ValidateResult: the domain form's verdict carries the materialization
+    // plan (domainStatus/identity/products/locations), not zod issues.
+    await writeJson({ target, ...result });
+    process.exit(result.valid ? 0 : 1);
+  }
+
+  if (!result.valid) {
+    printIssues(
+      target,
+      "domain",
+      result.errors.map((e) => ({ path: e.path, message: e.message, code: "invalid" })),
+    );
+    process.exit(1);
+  }
+
+  console.log(chalk.green("✓ valid releases.json") + chalk.dim(` (domain — ${target})`));
+  if (result.identity) {
+    line("org", result.identity.name);
+    line("slug", result.identity.slug);
+    line("domain", result.identity.domain);
+  }
+  if (result.products?.length) {
+    line(
+      "products",
+      result.products
+        .map((p) => `${p.name} (${p.locationCount} locator${p.locationCount === 1 ? "" : "s"})`)
+        .join(", "),
+    );
+  }
+  line("status", result.domainStatus);
+  if (result.locations.length) {
+    console.log("");
+    console.log(chalk.dim("  release locators"));
+    for (const loc of result.locations) {
+      const classification =
+        loc.classification === "tier1-live"
+          ? chalk.green("goes live")
+          : chalk.yellow("reviewed first");
+      console.log(`    ${chalk.cyan(loc.kind.padEnd(9))}${loc.locator}`);
+      console.log(`    ${" ".repeat(9)}${classification}${chalk.dim(` — ${loc.becomes}`)}`);
+    }
+  }
+  console.log("");
+  if (result.domainStatus === "unlisted") {
+    console.log(`Activate at https://releases.sh/submit`);
+  } else {
+    console.log(
+      `This domain is already listed.${result.org ? ` ${chalk.dim(result.org.webUrl)}` : ""}`,
+    );
+  }
+  process.exit(0);
+}
+
+export async function runValidate(target: string, opts: { json?: boolean }): Promise<void> {
+  if (looksLikeDomain(target)) {
+    await runDomainValidate(target, opts);
   }
 
   const raw = await readContentArg(target);
@@ -297,9 +372,8 @@ Examples:
 Validates either hosting scope (domain-hosted /.well-known/releases.json or a
 repo-root releases.json). Exit code 0 when valid, 1 when invalid.
 
-A bare hostname (e.g. acme.com) targets the domain form — live fetch plus
-materialization plan — which is deferred until the public dry-run endpoint
-lands (buildinternet/releases#1910); it exits 2 with guidance for now.
+A bare hostname (e.g. acme.com) targets the domain form — validates live
+against the registry's listing endpoint and prints the materialization plan.
 Docs: https://releases.sh/docs/listing`,
     )
     .action(async (target: string, opts: { json?: boolean }) => {

--- a/tests/cli/json-validate.test.ts
+++ b/tests/cli/json-validate.test.ts
@@ -1,12 +1,17 @@
-import { describe, it, expect } from "bun:test";
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, spyOn } from "bun:test";
 import { runCli } from "../utils.js";
 
 /**
  * Integration coverage for `releases json validate` (releases-cli#351) — the
- * owner-facing validator for the releases.json v2 manifest. Every path here is
- * local (schema parse or stdin), so no network or credential is touched. The
- * domain form is deferred until the public dry-run endpoint lands
- * (buildinternet/releases#1910); we assert it exits cleanly with guidance.
+ * owner-facing validator for the releases.json v2 manifest. The local-file /
+ * stdin paths are exercised via the real spawned CLI (runCli) — no network or
+ * credential is touched there.
+ *
+ * The domain form now validates live against `POST /v1/listing/validate`
+ * (buildinternet/releases#1910/#1947 phase 2, api-types 0.39.0). That path
+ * can't be exercised via runCli (no way to mock fetch across a spawned child
+ * process), so those cases drive `runValidate` in-process instead, following
+ * the fetch-stubbing convention in tests/unit/api-client.test.ts.
  */
 
 const VALID_DOMAIN = JSON.stringify({
@@ -90,11 +95,210 @@ describe("json validate (public CLI integration)", () => {
     expect(exitCode).toBe(1);
     expect(stderr.toLowerCase()).toContain("not valid json");
   });
+});
 
-  it("defers the domain form to the pending dry-run endpoint", () => {
-    const { stdout, stderr, exitCode } = runCli(["json", "validate", "acme.com"]);
-    expect(exitCode).toBe(2);
-    expect((stdout + stderr).toLowerCase()).toContain("domain validation isn't available yet");
-    expect(stdout + stderr).toContain("1910");
+// ---------------------------------------------------------------------------
+// Domain form — live validation against POST /v1/listing/validate.
+//
+// Set RELEASES_API_URL before any code calls getApiUrl() (it memoizes
+// process-wide on first call). runValidate calls getApiUrl() lazily inside the
+// domain branch, so this is safe even though other test files in the suite
+// may also touch mode.ts.
+// ---------------------------------------------------------------------------
+
+const prevEnv: { url?: string } = {};
+beforeAll(() => {
+  prevEnv.url = process.env.RELEASES_API_URL;
+  process.env.RELEASES_API_URL = "https://test.example.com";
+});
+afterAll(() => {
+  if (prevEnv.url === undefined) delete process.env.RELEASES_API_URL;
+  else process.env.RELEASES_API_URL = prevEnv.url;
+});
+
+const { runValidate } = await import("../../src/cli/commands/json.js");
+
+// Capture both console.log (human output) and process.stdout.write (writeJson
+// — the repo's machine-output helper writes to stdout directly, not console).
+function captureLogs() {
+  const logs: string[] = [];
+  const logSpy = spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+    logs.push(args.map(String).join(" "));
+  });
+  const errorSpy = spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+    logs.push(args.map(String).join(" "));
+  });
+  const origWrite = process.stdout.write;
+  process.stdout.write = ((s: string) => {
+    logs.push(String(s));
+    return true;
+  }) as unknown as typeof process.stdout.write;
+  return {
+    logs,
+    restore: () => {
+      logSpy.mockRestore();
+      errorSpy.mockRestore();
+      process.stdout.write = origWrite;
+    },
+  };
+}
+
+function mockFetchOnce(status: number, body: unknown) {
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    })) as any;
+}
+
+describe("json validate <domain> (live listing validation)", () => {
+  let originalFetch: typeof globalThis.fetch;
+  let exitSpy: ReturnType<typeof spyOn>;
+  let exitCode: number | undefined;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    exitCode = undefined;
+    exitSpy = spyOn(process, "exit").mockImplementation(((code?: number) => {
+      exitCode = code;
+      throw new Error("process.exit called");
+    }) as any);
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    exitSpy.mockRestore();
+  });
+
+  it("prints a valid summary with locations and exits 0", async () => {
+    mockFetchOnce(200, {
+      valid: true,
+      errors: [],
+      domainStatus: "unlisted",
+      identity: { name: "Acme Inc", slug: "acme-inc", domain: "acme.com" },
+      products: [{ name: "Acme API", locationCount: 1 }],
+      locations: [
+        {
+          locator: "https://acme.com/changelog.xml",
+          kind: "feed",
+          classification: "tier1-live",
+          becomes: "a live github/feed source",
+          productName: "Acme API",
+        },
+      ],
+    });
+    const { logs, restore } = captureLogs();
+    try {
+      await runValidate("acme.com", {});
+    } catch (e) {
+      expect((e as Error).message).toBe("process.exit called");
+    } finally {
+      restore();
+    }
+    expect(exitCode).toBe(0);
+    const out = logs.join("\n");
+    expect(out.toLowerCase()).toContain("valid");
+    expect(out).toContain("acme.com");
+    expect(out).toContain("Acme API");
+    expect(out).toContain("https://acme.com/changelog.xml");
+    expect(out).toContain("releases.sh/submit");
+  });
+
+  it("prints invalid-manifest errors and exits 1", async () => {
+    mockFetchOnce(200, {
+      valid: false,
+      errors: [{ path: "products.0.releases", message: "at least one release locator required" }],
+      domainStatus: "unlisted",
+      locations: [],
+    });
+    const { logs, restore } = captureLogs();
+    try {
+      await runValidate("broken.com", {});
+    } catch (e) {
+      expect((e as Error).message).toBe("process.exit called");
+    } finally {
+      restore();
+    }
+    expect(exitCode).toBe(1);
+    const out = logs.join("\n");
+    expect(out).toContain("products.0.releases");
+    expect(out).toContain("at least one release locator required");
+    expect(out).toContain("releases.sh/docs/listing");
+  });
+
+  it("prints a friendly retry message on 429 and exits 1", async () => {
+    mockFetchOnce(429, {
+      error: { code: "rate_limited", type: "rate_limit", message: "Too many requests" },
+    });
+    const { logs, restore } = captureLogs();
+    try {
+      await runValidate("acme.com", {});
+    } catch (e) {
+      expect((e as Error).message).toBe("process.exit called");
+    } finally {
+      restore();
+    }
+    expect(exitCode).toBe(1);
+    const out = logs.join("\n").toLowerCase();
+    expect(out).toContain("minute");
+  });
+
+  it("emits the raw result merged with target under --json, exit 0 when valid", async () => {
+    mockFetchOnce(200, {
+      valid: true,
+      errors: [],
+      domainStatus: "listed",
+      org: { slug: "acme", name: "Acme Inc", webUrl: "https://releases.sh/acme" },
+      identity: { name: "Acme Inc", slug: "acme-inc", domain: "acme.com" },
+      products: [],
+      locations: [],
+    });
+    const { logs, restore } = captureLogs();
+    try {
+      await runValidate("acme.com", { json: true });
+    } catch (e) {
+      expect((e as Error).message).toBe("process.exit called");
+    } finally {
+      restore();
+    }
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(logs.join("\n"));
+    expect(parsed.target).toBe("acme.com");
+    expect(parsed.valid).toBe(true);
+    expect(parsed.domainStatus).toBe("listed");
+    expect(parsed.org.slug).toBe("acme");
+  });
+
+  it("emits a --json error result on non-2xx, exit 1", async () => {
+    mockFetchOnce(500, {
+      error: { code: "internal_error", type: "internal", message: "Something broke" },
+    });
+    const { logs, restore } = captureLogs();
+    try {
+      await runValidate("acme.com", { json: true });
+    } catch (e) {
+      expect((e as Error).message).toBe("process.exit called");
+    } finally {
+      restore();
+    }
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(logs.join("\n"));
+    expect(parsed.target).toBe("acme.com");
+    expect(parsed.valid).toBe(false);
+    expect(parsed.message).toContain("Something broke");
+  });
+
+  it("exits 1 with a clear message when fetch throws (network failure)", async () => {
+    globalThis.fetch = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as any;
+    const { logs, restore } = captureLogs();
+    try {
+      await runValidate("acme.com", {});
+    } catch (e) {
+      expect((e as Error).message).toBe("process.exit called");
+    } finally {
+      restore();
+    }
+    expect(exitCode).toBe(1);
   });
 });

--- a/tests/cli/json-validate.test.ts
+++ b/tests/cli/json-validate.test.ts
@@ -225,6 +225,24 @@ describe("json validate <domain> (live listing validation)", () => {
     expect(out).toContain("releases.sh/docs/listing");
   });
 
+  it("exits 1 cleanly on a 2xx response with an unparseable body", async () => {
+    globalThis.fetch = (async () =>
+      new Response("not json at all", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })) as any;
+    const { logs, restore } = captureLogs();
+    try {
+      await runValidate("acme.com", {});
+    } catch (e) {
+      expect((e as Error).message).toBe("process.exit called");
+    } finally {
+      restore();
+    }
+    expect(exitCode).toBe(1);
+    expect(logs.join("\n")).toContain("unreadable response");
+  });
+
   it("prints a friendly retry message on 429 and exits 1", async () => {
     mockFetchOnce(429, {
       error: { code: "rate_limited", type: "rate_limit", message: "Too many requests" },


### PR DESCRIPTION
## Summary

Wires the deferred domain form of `releases json validate <domain>` to the registry's live anonymous endpoint (`POST /v1/listing/validate`, buildinternet/releases#1967) — the CLI half of the #1910 front door and phase 3 of buildinternet/releases#1947. Previously the domain form exited 2 with "not available yet" guidance; that path is gone.

- **2xx valid** → renders identity (org/slug/domain/status), products, and the per-locator materialization plan ("goes live" / "reviewed first" + the server's `becomes` text). Unlisted domains end with `Activate at https://releases.sh/submit`; listed/stub domains show "already listed" + the org URL. Exit 0.
- **2xx invalid** → issue list with paths (same rendering as the local-file form) + docs link. Exit 1.
- **429** → friendly retry-in-a-minute message; other non-2xx parse the nested error envelope; network failure → clean error. All exit 1.
- **`--json`** emits the raw `ListingValidationResult` merged with `{ target }`.
- The local-file/stdin schema-validation path is untouched.
- `@buildinternet/releases-api-types` bumped to `^0.39.0` for the listing wire types; changeset included (minor).

## Testing

- `tests/cli/json-validate.test.ts`: 11/11 pass — 6 new in-process domain-form cases (mocked `globalThis.fetch`, exported `runValidate`, `process.exit` spy) alongside the 4 unchanged local-file `runCli` cases.
- `bun run check` clean. Full-suite failures (7) confirmed pre-existing on main (local credential-env state, unrelated).
- Live smoke against prod: `releases json validate releases.sh` → full plan + already-listed, exit 0; `releases json validate example.com` → not-found issue, exit 1.

Companion web slice: buildinternet/releases#1972.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Live validation is now available for domain targets in `releases json validate`.
  * The command can now output machine-readable JSON for domain validation results.
  * Successful validation now shows a clearer materialization plan and activation details for unlisted domains.

* **Bug Fixes**
  * Updated exit codes so valid results return `0` and invalid or failed checks return `1`.
  * Improved handling of validation failures, including network issues and rate-limit responses, with clearer user-facing messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->