### PR TITLE
feat(release): add --url flag to admin release update

### DIFF
--- a/.changeset/release-update-url-flag.md
+++ b/.changeset/release-update-url-flag.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": minor
+---
+
+`releases admin release update` (and its deprecated `release edit` alias) now accept a `--url <url>` flag to set a release's canonical URL. Passing a non-empty value sets the URL; passing an empty string (`--url ""`) clears it. The backend `PATCH /v1/releases/:id` route already accepted the `url` field — this wires it through the CLI.

--- a/src/cli/commands/release.ts
+++ b/src/cli/commands/release.ts
@@ -111,6 +111,8 @@ type ReleaseUpdateOpts = {
   title?: string;
   version?: string;
   content?: string;
+  /** Canonical human-readable URL (empty string clears it). */
+  url?: string;
   /** AI-generated self-contained headline (#860). */
   titleGenerated?: string;
   /** AI-generated smart-brevity headline (#860). */
@@ -164,6 +166,11 @@ async function releaseUpdateAction(rawId: string, opts: ReleaseUpdateOpts): Prom
     const v = opts.summary.length === 0 ? null : opts.summary;
     updates.summary = v;
     changes.push(v === null ? "summary → (cleared)" : `summary → (${opts.summary.length} chars)`);
+  }
+  if (opts.url !== undefined) {
+    const v = opts.url.length === 0 ? null : opts.url;
+    updates.url = v;
+    changes.push(v === null ? "url → (cleared)" : `url → ${v}`);
   }
 
   if (changes.length === 0) {
@@ -345,6 +352,7 @@ export function registerReleaseCommand(program: Command) {
       "Update AI-generated smart-brevity headline (pass empty string to clear)",
     )
     .option("--summary <summary>", "Update AI-generated summary (pass empty string to clear)")
+    .option("--url <url>", "Set the release's canonical URL (pass empty string to clear)")
     .option("--json", "Output as JSON")
     .option("--dry-run", "Show what would change without writing")
     .action(releaseUpdateAction);
@@ -365,6 +373,7 @@ export function registerReleaseCommand(program: Command) {
       "Update AI-generated smart-brevity headline (pass empty string to clear)",
     )
     .option("--summary <summary>", "Update AI-generated summary (pass empty string to clear)")
+    .option("--url <url>", "Set the release's canonical URL (pass empty string to clear)")
     .option("--json", "Output as JSON")
     .option("--dry-run", "Show what would change without writing")
     .action(


### PR DESCRIPTION
## What

Adds a `--url <url>` flag to `releases admin release update` (and its deprecated `release edit` alias). The backend `PATCH /v1/releases/:id` already accepts and writes a release's `url`, but the CLI exposed no way to set it — `release update` only offered `--content`, `--title`, `--version`, and the AI text fields.

## Why

When a release's stored `url` is a weak anchor link (e.g. `https://example.com/changelog#slug`) that should point at a dedicated per-entry page (`/changelog/<slug>`), the only prior way to correct it was delete + re-create — which regenerates the release's `rel_` id and breaks existing share links. `--url` fixes the URL in place, preserving the id.

## Behavior

- `--url <value>` sets the canonical URL.
- `--url ""` clears it (maps to `null`), mirroring how the AI text fields already treat empty string.
- Added to both the `update` command and the `edit` alias for parity.
- API client helper (`updateRelease`) needed no change — it already forwards an arbitrary updates object.

## Verification

- `bun run check` (oxlint + oxfmt) passes; only pre-existing unrelated warnings remain.
- Exercised against prod on 20 Vercel changelog releases: `--dry-run` produced the correct `{ updates: { url }, changes: ["url → …"] }` payload; real writes returned the updated `url` and read-back confirmed the change stuck.

Changeset included (minor).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--url` option to the release update command, including the deprecated edit alias.
  * You can now set a release’s canonical URL during updates, or clear it by passing an empty value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->