### PR TITLE
docs: reference the now-public backend monorepo

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -2,4 +2,4 @@
 
 This folder holds pending version bumps. Each PR with user-visible behavior should add a new `.md` file via `bun run changeset`.
 
-Seven `@buildinternet/releases*` packages (`releases`, 4 platform binaries, `releases-lib`, `releases-skills`) are in a `fixed` group so they always bump together. `@buildinternet/releases-core` is published from the private monorepo and is not versioned here — bump its pin in `package.json` when adopting a new schema.
+Seven `@buildinternet/releases*` packages (`releases`, 4 platform binaries, `releases-lib`, `releases-skills`) are in a `fixed` group so they always bump together. `@buildinternet/releases-core` is published from the [backend monorepo](https://github.com/buildinternet/releases) and is not versioned here — bump its pin in `package.json` when adopting a new schema.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Agents guide — releases-cli
 
-This repo is the public, client-only CLI for the Releases registry. It talks to `api.releases.sh` over HTTP. Ingest, database access, and AI pipelines live in a separate private repo.
+This repo is the public, client-only CLI for the Releases registry. It talks to `api.releases.sh` over HTTP. Ingest, database access, and AI pipelines live in a separate open-source backend monorepo, [buildinternet/releases](https://github.com/buildinternet/releases).
 
 ## Stack
 
@@ -42,7 +42,7 @@ bun test                      # bun test (not part of check)
 ## Conventions
 
 - All logging to **stderr** via `@releases/lib/logger`. stdout is reserved for MCP JSON-RPC in `admin mcp serve` mode and for `--json` command output.
-- Reader commands (top-level `search`, `latest`, `list`, `show`, `stats`, `categories`) are unauthenticated GETs — safe to run without credentials. `summary` and `compare` are intentionally not in this CLI; they require AI provider calls and live in the private monorepo.
+- Reader commands (top-level `search`, `latest`, `list`, `show`, `stats`, `categories`) are unauthenticated GETs — safe to run without credentials. `summary` and `compare` are intentionally not in this CLI; they require AI provider calls and live in the backend monorepo.
 - Admin commands under `releases admin` are gated at CLI startup: missing `RELEASES_API_KEY` errors out before Commander dispatch.
 - IDs over slugs everywhere. Every `<identifier>` arg accepts a typed ID (`org_…`, `src_…`, `prod_…`, `rel_…`), a bare slug, or — for sources and products — an `org/slug` coordinate (e.g. `vercel/vercel-ai-sdk`). `findSource(identifier)` / `findProduct(identifier)` in `src/api/client.ts` branch on shape: typed IDs hit the bare API path (still safe — IDs stay globally unique), `org/slug` is split locally and routed to `/v1/orgs/{org}/sources/{slug}`, bare slugs round-trip through `GET /v1/lookups/{source,product}-by-slug` to resolve a canonical home before fetching (#698). Bare slugs cost one extra round-trip per command; coordinate and typed-ID forms skip the resolver. Mutation helpers take a typed-ID-bearing entity object (`{ id }`) and POST/PATCH/DELETE against the bare path with the ID — see existing call sites in `cli/commands/{edit,product,release,remove}.ts`.
 - `--json` supported on every reader command. Admin commands support it where it makes sense.
@@ -81,11 +81,11 @@ On merge to `main`, `.github/workflows/release.yml` opens or updates a `chore: v
 
 ## What's NOT in this repo
 
-Anything that touches a database, AI provider, or crawl infrastructure stays in the private monorepo:
+Anything that touches a database, AI provider, or crawl infrastructure stays in the backend monorepo ([buildinternet/releases](https://github.com/buildinternet/releases)):
 
 - `src/db/`, `src/ai/`, `src/adapters/` — ingest engine and DB queries
 - `workers/` — Cloudflare API, MCP, and discovery workers
 - `web/` — the public catalog
 - Managed agent config and deploy scripts
 
-The OSS CLI is a pure HTTP client. If a feature requires local Anthropic/Cloudflare calls, it lives in the private repo.
+The OSS CLI is a pure HTTP client. If a feature requires local Anthropic/Cloudflare calls, it lives in the backend monorepo.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thanks for your interest in contributing! This guide covers everything you need to build, test, and ship changes to the CLI and the packages it ships alongside (`@buildinternet/releases`, `@buildinternet/releases-lib`, `@buildinternet/releases-skills`).
 
-The CLI is a thin HTTP client for [releases.sh](https://releases.sh). The backend, web frontend, MCP server, and discovery agents live in a separate (private) monorepo and ship through the hosted API.
+The CLI is a thin HTTP client for [releases.sh](https://releases.sh). The backend, web frontend, MCP server, and discovery agents live in a separate open-source monorepo — [buildinternet/releases](https://github.com/buildinternet/releases) — and ship through the hosted API.
 
 ## Setup
 
@@ -30,12 +30,12 @@ The CLI is a thin HTTP client for [releases.sh](https://releases.sh). The backen
 
 The project is a Bun workspace. `@buildinternet/releases-lib` and `@buildinternet/releases-skills` are published from this repo alongside the CLI — those are open for direct contribution here.
 
-A couple of dependencies come from the upstream backend monorepo:
+A couple of dependencies come from the upstream backend monorepo, [buildinternet/releases](https://github.com/buildinternet/releases):
 
 - `@buildinternet/releases-core` — shared schema, helpers, and the FTS sanitizer.
 - `@buildinternet/releases-api-types` — wire-protocol types served by `api.releases.sh`.
 
-That monorepo is currently private (we plan to open-source it down the road), so those packages aren't open for direct PRs yet. If you hit a bug or need a missing field in either one, **open an issue here** describing what you need and we'll route it. In the meantime this repo just pins a published version and bumps when upstream cuts a release.
+Both are published from that repo, where the schema is the source of truth — so changes to either land there first, then this repo bumps its pinned version when upstream cuts a release. If you hit a bug or need a missing field in either one, open a PR or issue against [buildinternet/releases](https://github.com/buildinternet/releases); for anything CLI-only, this repo just pins the published version.
 
 ### Environment
 
@@ -97,7 +97,7 @@ A few things to know about how versioning works here:
 
 - The eight `@buildinternet/releases*` packages (meta + 5 platform binaries + `-lib` + `-skills`) live in a **fixed group** — they bump together. Targeting any one of them in a changeset cascades to all eight.
 - **Target `@buildinternet/releases`**, not `releases-cli`. The package isn't named `releases-cli` on npm.
-- `@buildinternet/releases-core` is published from the private monorepo and is **not** in the fixed group — don't include it in a changeset here.
+- `@buildinternet/releases-core` is published from the [backend monorepo](https://github.com/buildinternet/releases) and is **not** in the fixed group — don't include it in a changeset here.
 
 Pick the bump type by user impact:
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,13 @@
 [![Release](https://github.com/buildinternet/releases-cli/actions/workflows/release.yml/badge.svg)](https://github.com/buildinternet/releases-cli/actions/workflows/release.yml)
 [![Test](https://github.com/buildinternet/releases-cli/actions/workflows/test.yml/badge.svg)](https://github.com/buildinternet/releases-cli/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
+[![Backend](https://img.shields.io/badge/backend-buildinternet%2Freleases-24292e?logo=github)](https://github.com/buildinternet/releases)
 [![skills.sh](https://skills.sh/b/buildinternet/releases-cli)](https://skills.sh/buildinternet/releases-cli)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/buildinternet/releases-cli)
 
 The changelog & release-notes registry for developers and AI agents — a lean HTTP client for [releases.sh](https://releases.sh). Search and browse release notes from GitHub, RSS/Atom/JSON feeds, and product changelog pages, with no local infrastructure.
+
+This repo is the **CLI** only. The backend that powers `api.releases.sh` — the API worker, MCP server, web frontend, and ingest pipeline — is open source in its own repo: [buildinternet/releases](https://github.com/buildinternet/releases).
 
 The CLI talks to the hosted registry at `api.releases.sh`. **Search and browse work out of the box — no account or config.** Sign in with `releases login` to follow orgs and products, get a personalized feed, and manage outbound webhooks; it mints a personal **read-only** API key (and earns you higher rate limits as those roll out). Write/admin access (`releases admin …`) is a separate, closed beta — open an issue for early access.
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 [![skills.sh](https://skills.sh/b/buildinternet/releases-cli)](https://skills.sh/buildinternet/releases-cli)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/buildinternet/releases-cli)
 
+**[releases.sh](https://releases.sh)** &nbsp;·&nbsp; **[Backend monorepo →](https://github.com/buildinternet/releases)** &nbsp;·&nbsp; [Install](#install) &nbsp;·&nbsp; [Usage](#usage) &nbsp;·&nbsp; [Authentication](#authentication)
+
 The changelog & release-notes registry for developers and AI agents — a lean HTTP client for [releases.sh](https://releases.sh). Search and browse release notes from GitHub, RSS/Atom/JSON feeds, and product changelog pages, with no local infrastructure.
 
 This repo is the **CLI** only. The backend that powers `api.releases.sh` — the API worker, MCP server, web frontend, and ingest pipeline — is open source in its own repo: [buildinternet/releases](https://github.com/buildinternet/releases).

--- a/plans/README.md
+++ b/plans/README.md
@@ -56,5 +56,5 @@ Status values: TODO | IN PROGRESS | DONE | BLOCKED (one-line reason) | REJECTED 
   rotate them if the machine is ever shared. No code change planned.
 - **Bare-slug source lookup N+1 / bulk source delete** — both require new
   **API-side** endpoints (`/v1/lookups/source-by-slug`, a batch-delete route).
-  Out of scope for this client-only repo; file against the private monorepo
-  instead.
+  Out of scope for this client-only repo; file against the backend monorepo
+  ([buildinternet/releases](https://github.com/buildinternet/releases)) instead.


### PR DESCRIPTION
The backend monorepo [buildinternet/releases](https://github.com/buildinternet/releases) is open source now, so the CLI docs can reference it directly instead of describing it as a private repo. Reverse of the READMEcross-link added on the backend side.

### Changes
- **README** — new `backend` badge + a line up top clarifying this repo is the CLI only, with the backend (API worker, MCP, web, ingest) in its own repo.
- **CONTRIBUTING** — `releases-core` / `api-types` now take PRs and issues upstream in the monorepo (schema is the source of truth there), not just "open an issue here"; dropped the "currently private" caveat.
- **AGENTS.md**, **.changeset/README.md**, **plans/README.md** — "private monorepo/repo" → "backend monorepo" with links.

Historical `npm/releases/CHANGELOG.md` reference left untouched (immutable record).

Ref buildinternet/releases#1945

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated repository docs to reflect that the backend now lives in a separate open-source repo, with direct links added.
  * Clarified that this repo contains the CLI only, while backend-related work is tracked elsewhere.
  * Revised contributor and agent guidance to align with the new repository structure and dependency workflow.
  * Updated notes and references in planning and changeset documentation for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->