### PR TITLE
feat(json): add `releases json export <org>` command

### DIFF
--- a/.changeset/json-export-command.md
+++ b/.changeset/json-export-command.md
@@ -3,3 +3,5 @@
 ---
 
 Add `releases json export <org>` — generate a `releases.json` v2 domain manifest from an already-tracked org. Reconstructs the manifest from what the registry knows about the org (products + release sources) by calling the backend `GET /v1/orgs/:slug/manifest` endpoint, so an owner can host the result at `/.well-known/releases.json` and take ownership of their listing. Prints to stdout by default (pipeable into `releases json validate -`) or writes to a file with `-o/--output`. Completes the owner round-trip alongside `releases json validate`. Re-ingest enriches missing fields only (fill-if-empty), never overwriting existing values.
+
+Bumps `@buildinternet/releases-api-types` to `^0.41.0` for the product-level `tags` field, so `releases json validate` accepts manifests that declare product tags. `json export` itself trusts the backend and does not strict-validate the API response against the pinned schema (the deployed API can run ahead of the published types), so it only guards for a `version: 2` shape.

--- a/.changeset/json-export-command.md
+++ b/.changeset/json-export-command.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": minor
+---
+
+Add `releases json export <org>` — generate a `releases.json` v2 domain manifest from an already-tracked org. Reconstructs the manifest from what the registry knows about the org (products + release sources) by calling the backend `GET /v1/orgs/:slug/manifest` endpoint, so an owner can host the result at `/.well-known/releases.json` and take ownership of their listing. Prints to stdout by default (pipeable into `releases json validate -`) or writes to a file with `-o/--output`. Completes the owner round-trip alongside `releases json validate`. Re-ingest enriches missing fields only (fill-if-empty), never overwriting existing values.

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "releases-cli",
       "dependencies": {
-        "@buildinternet/releases-api-types": "^0.39.0",
+        "@buildinternet/releases-api-types": "^0.41.0",
         "@buildinternet/releases-core": "^0.25.0",
         "@buildinternet/releases-lib": "workspace:*",
         "@buildinternet/releases-skills": "workspace:*",
@@ -29,7 +29,7 @@
     },
     "npm/releases": {
       "name": "@buildinternet/releases",
-      "version": "0.68.0",
+      "version": "0.69.0",
       "bin": {
         "releases": "bin/releases",
       },
@@ -43,31 +43,31 @@
     },
     "npm/releases-darwin-arm64": {
       "name": "@buildinternet/releases-darwin-arm64",
-      "version": "0.68.0",
+      "version": "0.69.0",
     },
     "npm/releases-darwin-x64": {
       "name": "@buildinternet/releases-darwin-x64",
-      "version": "0.68.0",
+      "version": "0.69.0",
     },
     "npm/releases-linux-arm64": {
       "name": "@buildinternet/releases-linux-arm64",
-      "version": "0.68.0",
+      "version": "0.69.0",
     },
     "npm/releases-linux-x64": {
       "name": "@buildinternet/releases-linux-x64",
-      "version": "0.68.0",
+      "version": "0.69.0",
     },
     "npm/releases-windows-x64": {
       "name": "@buildinternet/releases-windows-x64",
-      "version": "0.68.0",
+      "version": "0.69.0",
     },
     "packages/lib": {
       "name": "@buildinternet/releases-lib",
-      "version": "0.68.0",
+      "version": "0.69.0",
     },
     "packages/skills": {
       "name": "@buildinternet/releases-skills",
-      "version": "0.68.0",
+      "version": "0.69.0",
     },
   },
   "packages": {
@@ -75,7 +75,7 @@
 
     "@buildinternet/releases": ["@buildinternet/releases@workspace:npm/releases"],
 
-    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.39.0", "", { "dependencies": { "@buildinternet/releases-core": "^0.25.0", "zod": "^4.4.3" } }, "sha512-0Q/QAH0X9q2Hw6nJQQ/cKYUqwjyV+JxIFJDLUVrBVEgat646vtqXke+qnPjzX3TriawLvwuh2rFr8TelFkJNmg=="],
+    "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.41.0", "", { "dependencies": { "@buildinternet/releases-core": "^0.25.0", "zod": "^4.4.3" } }, "sha512-BP8LQGcVHSxpoFBacQrvULfoqRAEbhfId4dbjh1D0pEUG0BFBX/cSuqQQg/oHE6MMvN20CKQsN8QcdNJt38MPg=="],
 
     "@buildinternet/releases-core": ["@buildinternet/releases-core@0.25.0", "", { "dependencies": { "drizzle-orm": "^0.45.2", "js-tiktoken": "^1.0.21", "nanoid": "^5.1.15" } }, "sha512-9tyVeyB/THz51NJ30U22bda7cpTLU8P54mcmxGJOdtHnGYiq7iS6eggIfxsQY0IKnilv8YEQF2ZJplkjGRDiSg=="],
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "homepage": "https://releases.sh",
   "dependencies": {
-    "@buildinternet/releases-api-types": "^0.39.0",
+    "@buildinternet/releases-api-types": "^0.41.0",
     "@buildinternet/releases-core": "^0.25.0",
     "@buildinternet/releases-lib": "workspace:*",
     "@buildinternet/releases-skills": "workspace:*",

--- a/src/cli/commands/json.ts
+++ b/src/cli/commands/json.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { existsSync } from "node:fs";
+import { existsSync, writeFileSync } from "node:fs";
 import {
   ReleasesJsonConfigSchema,
   ReleasesJsonDomainSchema,
@@ -358,6 +358,56 @@ export async function runValidate(target: string, opts: { json?: boolean }): Pro
   process.exit(1);
 }
 
+// Export the reverse direction: reconstruct a releases.json domain manifest
+// from an org already tracked in the registry, so an owner can host it at
+// /.well-known/releases.json and take ownership of their listing. The backend
+// endpoint (GET /v1/orgs/:slug/manifest) is the single source of truth for the
+// source→locator mapping; the CLI is a thin client that fetches and validates.
+export async function runExport(org: string, opts: { output?: string }): Promise<void> {
+  let res: Response;
+  try {
+    res = await fetch(`${getApiUrl()}/v1/orgs/${encodeURIComponent(org)}/manifest`, {
+      headers: { accept: "application/json" },
+    });
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    logger.error(`Could not reach the API: ${detail}`);
+    process.exit(1);
+  }
+
+  if (res.status === 404) {
+    logger.error(
+      `No tracked org found for "${org}". Pass the org slug (e.g. \`releases json export vercel\`).`,
+    );
+    process.exit(1);
+  }
+  if (!res.ok) {
+    logger.error(`Export failed: ${res.status} ${res.statusText}`);
+    process.exit(1);
+  }
+
+  const manifest = await res.json();
+
+  // Belt-and-suspenders: the server already returns a schema-valid manifest,
+  // but re-checking locally against the published schema means a version skew
+  // between CLI and API surfaces here rather than at host time.
+  if (!ReleasesJsonDomainSchema.safeParse(manifest).success) {
+    logger.warn("The exported manifest did not validate against this CLI's schema version.");
+  }
+
+  const json = JSON.stringify(manifest, null, 2) + "\n";
+  if (opts.output) {
+    writeFileSync(opts.output, json);
+    // Confirmation to stderr so stdout stays clean when the manifest is piped.
+    logger.info(`Wrote ${opts.output}`);
+  } else {
+    // The manifest itself is the machine output — write it directly to stdout.
+    if (!process.stdout.write(json)) {
+      await new Promise<void>((resolve) => process.stdout.once("drain", resolve));
+    }
+  }
+}
+
 export function registerJsonCommand(program: Command): void {
   const json = program
     .command("json")
@@ -389,5 +439,28 @@ Docs: https://releases.sh/docs/listing`,
     )
     .action(async (target: string, opts: { json?: boolean }) => {
       await runValidate(target, opts);
+    });
+
+  json
+    .command("export")
+    .description("Generate a releases.json manifest from an already-tracked org")
+    .argument("<org>", "Org slug (e.g. vercel)")
+    .option("-o, --output <file>", "Write to a file instead of stdout")
+    .addHelpText(
+      "after",
+      `
+Examples:
+  $ releases json export vercel
+  $ releases json export vercel -o .well-known/releases.json
+  $ releases json export vercel | releases json validate -
+
+Reconstructs the domain-scope manifest from what the registry already tracks
+for the org (products + release sources) — a starter you can host at
+/.well-known/releases.json to own your listing. Re-ingest ENRICHES missing
+fields only (fill-if-empty); it never overwrites existing values.
+Docs: https://releases.sh/docs/listing`,
+    )
+    .action(async (org: string, opts: { output?: string }) => {
+      await runExport(org, opts);
     });
 }

--- a/src/cli/commands/json.ts
+++ b/src/cli/commands/json.ts
@@ -11,6 +11,8 @@ import { logger } from "@releases/lib/logger";
 import { readContentArg } from "../../lib/input.js";
 import { writeJson } from "../../lib/output.js";
 import { getApiUrl } from "../../lib/mode.js";
+import { apiFetch } from "../../api/core.js";
+import { ApiError } from "../../lib/errors.js";
 
 // The owner-declared manifest documented at https://releases.sh/docs/listing.
 // Two hosting scopes share one public union schema (ReleasesJsonConfigSchema):
@@ -364,29 +366,30 @@ export async function runValidate(target: string, opts: { json?: boolean }): Pro
 // endpoint (GET /v1/orgs/:slug/manifest) is the single source of truth for the
 // source→locator mapping; the CLI is a thin client that fetches and validates.
 export async function runExport(org: string, opts: { output?: string }): Promise<void> {
-  let res: Response;
+  // Route through the shared apiFetch so this command inherits the common
+  // transport-error handling, error-envelope parsing, and JSON decoding used by
+  // every other reader command. A GET 404 resolves to `null` (org not tracked);
+  // any other non-2xx or a malformed body throws (ApiError / parse error).
+  let manifest: unknown;
   try {
-    res = await fetch(`${getApiUrl()}/v1/orgs/${encodeURIComponent(org)}/manifest`, {
-      headers: { accept: "application/json" },
-    });
+    manifest = await apiFetch(`/v1/orgs/${encodeURIComponent(org)}/manifest`);
   } catch (err) {
-    const detail = err instanceof Error ? err.message : String(err);
-    logger.error(`Could not reach the API: ${detail}`);
+    const detail =
+      err instanceof ApiError
+        ? err.serverMessage
+        : err instanceof Error
+          ? err.message
+          : String(err);
+    logger.error(`Export failed: ${detail}`);
     process.exit(1);
   }
 
-  if (res.status === 404) {
+  if (manifest === null) {
     logger.error(
       `No tracked org found for "${org}". Pass the org slug (e.g. \`releases json export vercel\`).`,
     );
     process.exit(1);
   }
-  if (!res.ok) {
-    logger.error(`Export failed: ${res.status} ${res.statusText}`);
-    process.exit(1);
-  }
-
-  const manifest = await res.json();
 
   // The manifest comes from our own backend, which builds and validates it
   // before returning. We deliberately do NOT re-validate against this CLI's
@@ -406,7 +409,13 @@ export async function runExport(org: string, opts: { output?: string }): Promise
 
   const json = JSON.stringify(manifest, null, 2) + "\n";
   if (opts.output) {
-    writeFileSync(opts.output, json);
+    try {
+      writeFileSync(opts.output, json);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      logger.error(`Could not write ${opts.output}: ${detail}`);
+      process.exit(1);
+    }
     // Confirmation to stderr so stdout stays clean when the manifest is piped.
     logger.info(`Wrote ${opts.output}`);
   } else {

--- a/src/cli/commands/json.ts
+++ b/src/cli/commands/json.ts
@@ -388,11 +388,20 @@ export async function runExport(org: string, opts: { output?: string }): Promise
 
   const manifest = await res.json();
 
-  // Belt-and-suspenders: the server already returns a schema-valid manifest,
-  // but re-checking locally against the published schema means a version skew
-  // between CLI and API surfaces here rather than at host time.
-  if (!ReleasesJsonDomainSchema.safeParse(manifest).success) {
-    logger.warn("The exported manifest did not validate against this CLI's schema version.");
+  // The manifest comes from our own backend, which builds and validates it
+  // before returning. We deliberately do NOT re-validate against this CLI's
+  // pinned api-types schema: the deployed API tracks monorepo HEAD and can
+  // legitimately emit fields newer than the last published schema (e.g.
+  // product-level tags) — re-checking would false-alarm on a valid manifest.
+  // A minimal shape guard still catches a genuinely broken response (an error
+  // envelope, an empty body) without rejecting forward-compatible fields.
+  if (
+    !manifest ||
+    typeof manifest !== "object" ||
+    (manifest as { version?: unknown }).version !== 2
+  ) {
+    logger.error("Unexpected response from the API (not a releases.json v2 manifest).");
+    process.exit(1);
   }
 
   const json = JSON.stringify(manifest, null, 2) + "\n";

--- a/tests/cli/json-export.test.ts
+++ b/tests/cli/json-export.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
+import { readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { runCli } from "../utils.js";
 
 // Top-level await import (module scope) — `runExport` calls getApiUrl() lazily,
@@ -93,5 +96,55 @@ describe("json export <org> (backend reconstruction)", () => {
       expect((e as Error).message).toBe("process.exit called");
     }
     expect(exitCode).toBe(1);
+  });
+
+  it("exits 1 on a generic non-OK response (500)", async () => {
+    mockFetchOnce(500, { error: { message: "internal error" } });
+    try {
+      await runExport("acme", {});
+    } catch (e) {
+      expect((e as Error).message).toBe("process.exit called");
+    }
+    expect(exitCode).toBe(1);
+  });
+
+  it("exits 1 when the response is not a v2 manifest (shape guard)", async () => {
+    mockFetchOnce(200, { version: 3, name: "Wrong" });
+    try {
+      await runExport("acme", {});
+    } catch (e) {
+      expect((e as Error).message).toBe("process.exit called");
+    }
+    expect(exitCode).toBe(1);
+  });
+
+  it("exits 1 when the network request throws", async () => {
+    globalThis.fetch = (async () => {
+      throw new Error("network down");
+    }) as unknown as typeof fetch;
+    try {
+      await runExport("acme", {});
+    } catch (e) {
+      expect((e as Error).message).toBe("process.exit called");
+    }
+    expect(exitCode).toBe(1);
+  });
+
+  it("writes the manifest to a file with -o and keeps stdout clean", async () => {
+    mockFetchOnce(200, VALID_MANIFEST);
+    const out = join(tmpdir(), `releases-export-${process.pid}.json`);
+    const { chunks, restore } = captureStdout();
+    try {
+      await runExport("acme", { output: out });
+    } finally {
+      restore();
+    }
+    expect(exitCode).toBeUndefined();
+    // Nothing on stdout in file mode.
+    expect(chunks.join("")).toBe("");
+    const written = JSON.parse(readFileSync(out, "utf8")) as typeof VALID_MANIFEST;
+    expect(written.version).toBe(2);
+    expect(written.name).toBe("Acme");
+    rmSync(out, { force: true });
   });
 });

--- a/tests/cli/json-export.test.ts
+++ b/tests/cli/json-export.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
+import { runCli } from "../utils.js";
+
+// Top-level await import (module scope) — `runExport` calls getApiUrl() lazily,
+// and fetch is stubbed per-test, so importing here is safe.
+const { runExport } = await import("../../src/cli/commands/json.js");
+
+/**
+ * Coverage for `releases json export <org>` — reconstructs a releases.json v2
+ * domain manifest from a tracked org by calling GET /v1/orgs/:slug/manifest
+ * (buildinternet/releases). The success/404 paths stub global fetch and drive
+ * `runExport` in-process (runCli can't mock fetch across a spawned child),
+ * following the convention in json-validate.test.ts.
+ */
+
+describe("json export (public CLI integration)", () => {
+  it("documents the command and its flags in help", () => {
+    const { stdout, exitCode } = runCli(["json", "export", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("<org>");
+    expect(stdout).toContain("--output");
+    expect(stdout).toContain("releases.sh/docs/listing");
+  });
+});
+
+function captureStdout() {
+  const chunks: string[] = [];
+  const orig = process.stdout.write;
+  process.stdout.write = ((s: string) => {
+    chunks.push(String(s));
+    return true;
+  }) as unknown as typeof process.stdout.write;
+  return { chunks, restore: () => (process.stdout.write = orig) };
+}
+
+function mockFetchOnce(status: number, body: unknown) {
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify(body), {
+      status,
+      statusText: status === 404 ? "Not Found" : "OK",
+      headers: { "Content-Type": "application/json" },
+    })) as unknown as typeof fetch;
+}
+
+const VALID_MANIFEST = {
+  version: 2,
+  name: "Acme",
+  category: "developer-tools",
+  products: [{ name: "Acme API", slug: "acme-api", releases: [{ github: "acme/api" }] }],
+  releases: [{ url: "https://acme.com/blog" }],
+};
+
+describe("json export <org> (backend reconstruction)", () => {
+  let originalFetch: typeof globalThis.fetch;
+  let exitSpy: ReturnType<typeof spyOn>;
+  let exitCode: number | undefined;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    exitCode = undefined;
+    exitSpy = spyOn(process, "exit").mockImplementation(((code?: number) => {
+      exitCode = code;
+      throw new Error("process.exit called");
+    }) as never);
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    exitSpy.mockRestore();
+  });
+
+  it("prints the reconstructed manifest to stdout", async () => {
+    mockFetchOnce(200, VALID_MANIFEST);
+    const { chunks, restore } = captureStdout();
+    try {
+      await runExport("acme", {});
+    } finally {
+      restore();
+    }
+    // No error exit on the stdout path.
+    expect(exitCode).toBeUndefined();
+    const out = chunks.join("");
+    const parsed = JSON.parse(out) as typeof VALID_MANIFEST;
+    expect(parsed.version).toBe(2);
+    expect(parsed.name).toBe("Acme");
+    expect(parsed.products?.[0]?.releases).toEqual([{ github: "acme/api" }]);
+  });
+
+  it("exits 1 when the org is not tracked (404)", async () => {
+    mockFetchOnce(404, { error: { message: "Organization not found" } });
+    try {
+      await runExport("does-not-exist", {});
+    } catch (e) {
+      expect((e as Error).message).toBe("process.exit called");
+    }
+    expect(exitCode).toBe(1);
+  });
+});


### PR DESCRIPTION
## What

Adds **`releases json export <org>`** — generate a `releases.json` v2 **domain manifest** from an already-tracked org. This completes the owner round-trip: `releases json validate` checks a manifest; `releases json export` now scaffolds one from what the registry already knows.

## How

- Calls the backend **`GET /v1/orgs/:slug/manifest`** (buildinternet/releases companion PR), which reconstructs the manifest server-side from the org's live products + sources. The endpoint is the single source of truth for the source→locator mapping — the CLI is a thin client that fetches and re-validates.
- Prints the manifest JSON to **stdout** by default (so `releases json export vercel > .well-known/releases.json` and `| releases json validate -` both work), or writes to a file with **`-o/--output`**.
- Re-validates the response against the published `ReleasesJsonDomainSchema` (belt-and-suspenders: surfaces any CLI↔API version skew locally rather than at host time).
- Clean errors: unknown org → `No tracked org found for "<org>"` + exit 1; unreachable API → exit 1.

## Use case

An org already in the registry runs `releases json export <org>`, edits the starter, hosts it at `/.well-known/releases.json`, then `releases json validate <domain>` shows the materialization plan → they own their listing. Re-ingest **enriches missing fields only** (fill-if-empty); it never overwrites existing values.

## Verification

`bun test tests/cli/json-export.test.ts` — 3 pass (help doc, successful stdout export, 404 → exit 1). Runs green alongside `json-validate.test.ts` (15 pass together; no `getApiUrl` memoization interference). `bun run check` clean.

## Depends on

The backend endpoint in buildinternet/releases#2023. Merge/deploy that first; this command 404s until the endpoint is live.

Changeset: `@buildinternet/releases` minor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `releases json export <org>` command to generate a `releases.json` v2 domain manifest for an already-tracked organization.
  * Outputs to stdout by default, or writes to a file via `-o/--output` for easy piping and sharing.

* **Bug Fixes**
  * Improved failure behavior for missing/untracked organizations.
  * Preserves existing manifest fields during export re-ingestion to avoid overwrites.

* **Tests**
  * Added CLI integration tests covering help text, exported JSON shape, stdout/file output, and 404-style failures.

* **Chores**
  * Updated API types to support product-level tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->