### PR TITLE
fix(cli): age overview content from updatedAt, not generatedAt

### DIFF
--- a/.changeset/overview-content-freshness.md
+++ b/.changeset/overview-content-freshness.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": patch
+---
+
+Fix overview stale warning to use content write time (`updatedAt`) instead of original generation time. Amended overviews no longer show as months-old when recently rewritten.

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "releases-cli",
       "dependencies": {
         "@buildinternet/releases-api-types": "^0.41.0",
-        "@buildinternet/releases-core": "^0.25.0",
+        "@buildinternet/releases-core": "^0.25.2",
         "@buildinternet/releases-lib": "workspace:*",
         "@buildinternet/releases-skills": "workspace:*",
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -29,7 +29,7 @@
     },
     "npm/releases": {
       "name": "@buildinternet/releases",
-      "version": "0.69.0",
+      "version": "0.70.0",
       "bin": {
         "releases": "bin/releases",
       },
@@ -43,31 +43,31 @@
     },
     "npm/releases-darwin-arm64": {
       "name": "@buildinternet/releases-darwin-arm64",
-      "version": "0.69.0",
+      "version": "0.70.0",
     },
     "npm/releases-darwin-x64": {
       "name": "@buildinternet/releases-darwin-x64",
-      "version": "0.69.0",
+      "version": "0.70.0",
     },
     "npm/releases-linux-arm64": {
       "name": "@buildinternet/releases-linux-arm64",
-      "version": "0.69.0",
+      "version": "0.70.0",
     },
     "npm/releases-linux-x64": {
       "name": "@buildinternet/releases-linux-x64",
-      "version": "0.69.0",
+      "version": "0.70.0",
     },
     "npm/releases-windows-x64": {
       "name": "@buildinternet/releases-windows-x64",
-      "version": "0.69.0",
+      "version": "0.70.0",
     },
     "packages/lib": {
       "name": "@buildinternet/releases-lib",
-      "version": "0.69.0",
+      "version": "0.70.0",
     },
     "packages/skills": {
       "name": "@buildinternet/releases-skills",
-      "version": "0.69.0",
+      "version": "0.70.0",
     },
   },
   "packages": {
@@ -77,7 +77,7 @@
 
     "@buildinternet/releases-api-types": ["@buildinternet/releases-api-types@0.41.0", "", { "dependencies": { "@buildinternet/releases-core": "^0.25.0", "zod": "^4.4.3" } }, "sha512-BP8LQGcVHSxpoFBacQrvULfoqRAEbhfId4dbjh1D0pEUG0BFBX/cSuqQQg/oHE6MMvN20CKQsN8QcdNJt38MPg=="],
 
-    "@buildinternet/releases-core": ["@buildinternet/releases-core@0.25.0", "", { "dependencies": { "drizzle-orm": "^0.45.2", "js-tiktoken": "^1.0.21", "nanoid": "^5.1.15" } }, "sha512-9tyVeyB/THz51NJ30U22bda7cpTLU8P54mcmxGJOdtHnGYiq7iS6eggIfxsQY0IKnilv8YEQF2ZJplkjGRDiSg=="],
+    "@buildinternet/releases-core": ["@buildinternet/releases-core@0.25.2", "", { "dependencies": { "drizzle-orm": "^0.45.2", "js-tiktoken": "^1.0.21", "nanoid": "^5.1.16" } }, "sha512-ptIk/T0FxnELOpptomBp7TIYzqsnkRgLk3HJbhAV0DJvJqMZf4bWhnnUgDuyBZ82YHnOAO4bG9M1dIOj1dIqPA=="],
 
     "@buildinternet/releases-darwin-arm64": ["@buildinternet/releases-darwin-arm64@workspace:npm/releases-darwin-arm64"],
 
@@ -610,6 +610,8 @@
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "@buildinternet/releases-api-types/@buildinternet/releases-core": ["@buildinternet/releases-core@0.25.0", "", { "dependencies": { "drizzle-orm": "^0.45.2", "js-tiktoken": "^1.0.21", "nanoid": "^5.1.15" } }, "sha512-9tyVeyB/THz51NJ30U22bda7cpTLU8P54mcmxGJOdtHnGYiq7iS6eggIfxsQY0IKnilv8YEQF2ZJplkjGRDiSg=="],
 
     "@buildinternet/releases-api-types/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "homepage": "https://releases.sh",
   "dependencies": {
     "@buildinternet/releases-api-types": "^0.41.0",
-    "@buildinternet/releases-core": "^0.25.0",
+    "@buildinternet/releases-core": "^0.25.2",
     "@buildinternet/releases-lib": "workspace:*",
     "@buildinternet/releases-skills": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/src/cli/commands/admin/overview.ts
+++ b/src/cli/commands/admin/overview.ts
@@ -33,12 +33,16 @@ import {
   STALE_GRACE_DAYS_DEFAULT,
   type OrgWithOverview,
 } from "../../../lib/overview-stale-filter.js";
+import { formatOverviewFreshnessLine } from "../../../lib/overview-freshness.js";
 import type { OrgListItem } from "@buildinternet/releases-api-types";
 import { computePagination } from "@buildinternet/releases-core/cli-contracts";
 import { unescapeHtmlEntities } from "./overview/unescape-html.js";
 import { parseCitationsJson, ParseCitationsError } from "./overview/parse-citations.js";
 import { readContentArg } from "../../../lib/input.js";
 import { warnDeprecatedAlias } from "../../../lib/deprecated-alias.js";
+
+// Re-export for callers/tests that imported the helper from this command module.
+export { formatOverviewFreshnessLine } from "../../../lib/overview-freshness.js";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -84,57 +88,7 @@ interface OverviewPlanOpts {
   hasActivity?: boolean;
 }
 
-interface OverviewFreshnessInput {
-  generatedAt?: string | null;
-  updatedAt?: string | null;
-  releaseCount: number;
-  citationCount?: number;
-}
-
 // ── Action handlers ───────────────────────────────────────────────────────────
-
-/**
- * Formats an overview timestamp for compact status output.
- */
-function ageLabel(iso: string | null | undefined): string {
-  return iso ? (timeAgo(iso) ?? "?") : "?";
-}
-
-/**
- * Compares overview timestamps by instant, falling back to raw value comparison
- * when either value is missing or cannot be parsed.
- */
-function timestampsDifferMeaningfully(
-  first: string | null | undefined,
-  second: string | null | undefined,
-): boolean {
-  if (!first || !second) return first !== second;
-
-  const firstMs = Date.parse(first);
-  const secondMs = Date.parse(second);
-  if (!Number.isFinite(firstMs) || !Number.isFinite(secondMs)) return first !== second;
-
-  return firstMs !== secondMs;
-}
-
-/**
- * Builds the human-readable freshness line shown above an org overview.
- */
-export function formatOverviewFreshnessLine(overview: OverviewFreshnessInput): string {
-  const generatedLabel = ageLabel(overview.generatedAt);
-  const releaseLabel = `${overview.releaseCount} releases contributing`;
-  const citationLabel =
-    overview.citationCount === undefined ? "" : ` · ${overview.citationCount} citations`;
-
-  if (
-    overview.updatedAt &&
-    timestampsDifferMeaningfully(overview.updatedAt, overview.generatedAt)
-  ) {
-    return `updated ${ageLabel(overview.updatedAt)} · generated ${generatedLabel} · ${releaseLabel}${citationLabel}`;
-  }
-
-  return `generated ${generatedLabel} · ${releaseLabel}${citationLabel}`;
-}
 
 async function overviewGetAction(orgIdentifier: string, opts: OverviewGetOpts): Promise<void> {
   const org = await findOrg(orgIdentifier);

--- a/src/cli/commands/admin/playbook.ts
+++ b/src/cli/commands/admin/playbook.ts
@@ -5,7 +5,7 @@ import { getPlaybook, updatePlaybookNotes } from "../../../api/sources.js";
 import { orgNotFound } from "../../suggest.js";
 import { writeJson } from "../../../lib/output.js";
 import { readContentArg } from "../../../lib/input.js";
-import { timeAgo } from "@buildinternet/releases-core/dates";
+import { formatOverviewFreshnessHint } from "../../../lib/overview-freshness.js";
 
 interface PlaybookOpts {
   json?: boolean;
@@ -75,15 +75,10 @@ run by --notes-file also seeds a fresh header on first write.`,
         return;
       }
 
-      // Prefer content write time; generatedAt is fixed at first write.
-      const contentAt = playbook.updatedAt ?? playbook.generatedAt;
-      const contentAge = contentAt ? (timeAgo(contentAt) ?? "?") : "?";
-      const ageLabel =
-        playbook.updatedAt && playbook.generatedAt && playbook.updatedAt !== playbook.generatedAt
-          ? `updated ${contentAge} · generated ${timeAgo(playbook.generatedAt) ?? "?"}`
-          : `generated ${contentAge}`;
+      // Same content-write freshness rules as org overview (updatedAt over generatedAt).
+      const freshnessHint = formatOverviewFreshnessHint(playbook) ?? "generated ?";
       console.log(chalk.bold(`${org.name} — playbook`));
-      console.log(chalk.dim(`  ${ageLabel} · ${playbook.releaseCount} sources`));
+      console.log(chalk.dim(`  ${freshnessHint} · ${playbook.releaseCount} sources`));
       console.log();
       console.log(playbook.content);
       if (playbook.notes) {

--- a/src/cli/commands/admin/playbook.ts
+++ b/src/cli/commands/admin/playbook.ts
@@ -75,9 +75,15 @@ run by --notes-file also seeds a fresh header on first write.`,
         return;
       }
 
-      const ageLabel = playbook.generatedAt ? (timeAgo(playbook.generatedAt) ?? "?") : "?";
+      // Prefer content write time; generatedAt is fixed at first write.
+      const contentAt = playbook.updatedAt ?? playbook.generatedAt;
+      const contentAge = contentAt ? (timeAgo(contentAt) ?? "?") : "?";
+      const ageLabel =
+        playbook.updatedAt && playbook.generatedAt && playbook.updatedAt !== playbook.generatedAt
+          ? `updated ${contentAge} · generated ${timeAgo(playbook.generatedAt) ?? "?"}`
+          : `generated ${contentAge}`;
       console.log(chalk.bold(`${org.name} — playbook`));
-      console.log(chalk.dim(`  generated ${ageLabel} · ${playbook.releaseCount} sources`));
+      console.log(chalk.dim(`  ${ageLabel} · ${playbook.releaseCount} sources`));
       console.log();
       console.log(playbook.content);
       if (playbook.notes) {

--- a/src/cli/commands/org.ts
+++ b/src/cli/commands/org.ts
@@ -32,7 +32,6 @@ import { orgNotFound } from "../suggest.js";
 import { toSlug } from "@buildinternet/releases-core/slug";
 import { isValidCategory, CATEGORIES } from "@buildinternet/releases-core/categories";
 import { SOURCE_DISCOVERY } from "@buildinternet/releases-core/source-enums";
-import { timeAgo } from "@buildinternet/releases-core/dates";
 import { writeJson } from "../../lib/output.js";
 import { markDryRun } from "../../lib/dry-run.js";
 import { handlePageAll } from "../../lib/paginate.js";
@@ -42,12 +41,13 @@ import {
   formatTruncationWarning,
   type ListResponse,
 } from "@buildinternet/releases-core/cli-contracts";
+import { OVERVIEW_STALE_DAYS, overviewPreview } from "@buildinternet/releases-core/overview";
 import {
-  OVERVIEW_STALE_DAYS,
-  overviewAgeDays,
-  isOverviewStale,
-  overviewPreview,
-} from "@buildinternet/releases-core/overview";
+  formatOverviewFreshnessHint,
+  formatOverviewFreshnessLine,
+  isOverviewContentStale,
+  overviewContentAgeDays,
+} from "../../lib/overview-freshness.js";
 import { warnDeprecatedAlias } from "../../lib/deprecated-alias.js";
 import { parseTagList } from "../../lib/flags.js";
 import { buildNoticePatch, formatNotice, type EntityWithNotice } from "../../lib/notice.js";
@@ -213,8 +213,8 @@ async function orgGetAction(identifier: string, opts: OrgGetOpts): Promise<void>
   console.log(`  Domain:  ${found.domain ?? chalk.dim("—")}`);
   if (aliases.length > 0) console.log(`  Aliases: ${aliases.join(", ")}`);
   if (found.description) console.log(`  About:   ${found.description}`);
-  console.log(`  Created: ${found.createdAt}`);
-  console.log(`  Updated: ${found.updatedAt}`);
+  console.log(`  Created: ${found.createdAt ?? chalk.dim("—")}`);
+  console.log(`  Updated: ${found.updatedAt ?? chalk.dim("—")}`);
   if (found.category) console.log(`  Category: ${found.category}`);
   console.log(
     `  AI content: ${
@@ -264,10 +264,11 @@ async function orgGetAction(identifier: string, opts: OrgGetOpts): Promise<void>
 
   if (overview?.content) {
     const preview = overviewPreview(stripAnsi(overview.content));
-    const stale = overview.generatedAt ? isOverviewStale(overview.generatedAt) : false;
-    const generatedHint = overview.generatedAt
-      ? chalk.dim(`generated ${timeAgo(overview.generatedAt) ?? "?"}`)
-      : "";
+    // Content write time (updatedAt), not original generatedAt — amends refresh
+    // the body without resetting generation, so stale checks must follow the write.
+    const stale = isOverviewContentStale(overview);
+    const freshnessHint = formatOverviewFreshnessHint(overview);
+    const generatedHint = freshnessHint ? chalk.dim(freshnessHint) : "";
 
     console.log();
     console.log(`${chalk.bold("Overview")}  ${generatedHint}`);
@@ -737,8 +738,10 @@ Examples:
         return;
       }
 
-      const stale = overview.generatedAt ? isOverviewStale(overview.generatedAt) : false;
-      const ageDays = overview.generatedAt ? overviewAgeDays(overview.generatedAt) : null;
+      // Prefer updatedAt for age/stale: generatedAt is fixed at first write and
+      // stays old after amends (e.g. generated 3mo ago, updated 4d ago).
+      const stale = isOverviewContentStale(overview);
+      const ageDays = overviewContentAgeDays(overview);
 
       if (opts.json) {
         console.log(
@@ -762,13 +765,7 @@ Examples:
       }
 
       console.log(chalk.bold(`${found.name} — overview`));
-      if (overview.generatedAt) {
-        console.log(
-          chalk.dim(
-            `  generated ${timeAgo(overview.generatedAt) ?? "?"} · ${overview.releaseCount} releases`,
-          ),
-        );
-      }
+      console.log(chalk.dim(`  ${formatOverviewFreshnessLine(overview)}`));
       if (stale) {
         console.log(
           chalk.yellow(

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -436,6 +436,10 @@ export function overviewToMarkdown(
     lines.push(yamlLine("last_release", isoDateOnly(overview.lastContributingReleaseAt)));
   }
   lines.push(yamlLine("generated", isoDateOnly(overview.generatedAt)));
+  // Content write time when it differs from first generation (amends).
+  if (overview.updatedAt && overview.updatedAt !== overview.generatedAt) {
+    lines.push(yamlLine("updated", isoDateOnly(overview.updatedAt)));
+  }
   if (opts.baseUrl && opts.orgSlug) {
     lines.push(yamlLine("canonical", `${opts.baseUrl}/${opts.orgSlug}/overview.md`));
   }

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -16,6 +16,7 @@ import type {
   UnifiedSearchResponse,
   OverviewPageItem,
 } from "../api/types.js";
+import { timestampsDifferMeaningfully } from "./overview-freshness.js";
 
 // Re-exports under legacy/monorepo-compatible names so ported test suites and
 // external callers can import either name.
@@ -437,7 +438,11 @@ export function overviewToMarkdown(
   }
   lines.push(yamlLine("generated", isoDateOnly(overview.generatedAt)));
   // Content write time when it differs from first generation (amends).
-  if (overview.updatedAt && overview.updatedAt !== overview.generatedAt) {
+  // Compare by instant so equivalent ISO forms (Z vs +00:00) don't double-emit.
+  if (
+    overview.updatedAt &&
+    timestampsDifferMeaningfully(overview.generatedAt, overview.updatedAt)
+  ) {
     lines.push(yamlLine("updated", isoDateOnly(overview.updatedAt)));
   }
   if (opts.baseUrl && opts.orgSlug) {

--- a/src/lib/overview-freshness.ts
+++ b/src/lib/overview-freshness.ts
@@ -1,0 +1,110 @@
+import { timeAgo } from "@buildinternet/releases-core/dates";
+import { isOverviewStale, overviewAgeDays } from "@buildinternet/releases-core/overview";
+
+/**
+ * Timestamps that describe when an overview body was written.
+ *
+ * `generatedAt` is the original creation time and never moves on amend.
+ * `updatedAt` is the last content write (initial generate or later amend).
+ * Reader surfaces must use content freshness — not original generation —
+ * for "how old is this overview?" signals.
+ */
+export interface OverviewFreshnessInput {
+  generatedAt?: string | null;
+  updatedAt?: string | null;
+  releaseCount: number;
+  citationCount?: number;
+}
+
+/**
+ * Instant that reflects when the overview *content* was last written.
+ * Prefers `updatedAt` (amend/write), falls back to `generatedAt`.
+ */
+export function overviewContentAt(overview: {
+  generatedAt?: string | null;
+  updatedAt?: string | null;
+}): string | null {
+  return overview.updatedAt ?? overview.generatedAt ?? null;
+}
+
+/** Age in whole days of the overview content (updatedAt, else generatedAt). */
+export function overviewContentAgeDays(
+  overview: { generatedAt?: string | null; updatedAt?: string | null },
+  now: number = Date.now(),
+): number | null {
+  const at = overviewContentAt(overview);
+  return at ? overviewAgeDays(at, now) : null;
+}
+
+/**
+ * Whether the overview body is past the 30-day reader stale threshold.
+ * Uses content write time, not original generation.
+ */
+export function isOverviewContentStale(
+  overview: { generatedAt?: string | null; updatedAt?: string | null },
+  now: number = Date.now(),
+): boolean {
+  const at = overviewContentAt(overview);
+  return at ? isOverviewStale(at, now) : false;
+}
+
+function ageLabel(iso: string | null | undefined): string {
+  return iso ? (timeAgo(iso) ?? "?") : "?";
+}
+
+/**
+ * Compares overview timestamps by instant, falling back to raw value comparison
+ * when either value is missing or cannot be parsed.
+ */
+export function timestampsDifferMeaningfully(
+  first: string | null | undefined,
+  second: string | null | undefined,
+): boolean {
+  if (!first || !second) return first !== second;
+
+  const firstMs = Date.parse(first);
+  const secondMs = Date.parse(second);
+  if (!Number.isFinite(firstMs) || !Number.isFinite(secondMs)) return first !== second;
+
+  return firstMs !== secondMs;
+}
+
+/**
+ * Builds the human-readable freshness line shown above an org overview.
+ * When an overview has been amended, surfaces `updated` ahead of the original
+ * `generated` time so readers don't treat a fresh amend as 3 months old.
+ */
+export function formatOverviewFreshnessLine(overview: OverviewFreshnessInput): string {
+  const generatedLabel = ageLabel(overview.generatedAt);
+  const releaseLabel = `${overview.releaseCount} releases contributing`;
+  const citationLabel =
+    overview.citationCount === undefined ? "" : ` · ${overview.citationCount} citations`;
+
+  if (
+    overview.updatedAt &&
+    timestampsDifferMeaningfully(overview.updatedAt, overview.generatedAt)
+  ) {
+    return `updated ${ageLabel(overview.updatedAt)} · generated ${generatedLabel} · ${releaseLabel}${citationLabel}`;
+  }
+
+  return `generated ${generatedLabel} · ${releaseLabel}${citationLabel}`;
+}
+
+/**
+ * Compact freshness hint for the org-get overview preview (no release count).
+ */
+export function formatOverviewFreshnessHint(overview: {
+  generatedAt?: string | null;
+  updatedAt?: string | null;
+}): string | null {
+  if (
+    overview.updatedAt &&
+    timestampsDifferMeaningfully(overview.updatedAt, overview.generatedAt)
+  ) {
+    return `updated ${ageLabel(overview.updatedAt)} · generated ${ageLabel(overview.generatedAt)}`;
+  }
+  if (overview.generatedAt || overview.updatedAt) {
+    return `generated ${ageLabel(overviewContentAt(overview))}`;
+  }
+  return null;
+}

--- a/tests/cli/overview-freshness.test.ts
+++ b/tests/cli/overview-freshness.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from "bun:test";
 import { daysAgoIso } from "@buildinternet/releases-core/dates";
-import { formatOverviewFreshnessLine } from "../../src/cli/commands/admin/overview.js";
+import {
+  formatOverviewFreshnessHint,
+  formatOverviewFreshnessLine,
+  isOverviewContentStale,
+  overviewContentAgeDays,
+  overviewContentAt,
+} from "../../src/lib/overview-freshness.js";
 
 describe("overview freshness line", () => {
   it("keeps the generated-only label when the overview has not been amended", () => {
@@ -36,5 +42,49 @@ describe("overview freshness line", () => {
     });
 
     expect(line).toBe("updated just now · generated 12d ago · 10 releases contributing");
+  });
+});
+
+describe("overview content freshness (updatedAt over generatedAt)", () => {
+  it("prefers updatedAt as the content write timestamp", () => {
+    const overview = {
+      generatedAt: daysAgoIso(90),
+      updatedAt: daysAgoIso(4),
+    };
+    expect(overviewContentAt(overview)).toBe(overview.updatedAt);
+    expect(overviewContentAgeDays(overview)).toBe(4);
+    expect(isOverviewContentStale(overview)).toBe(false);
+  });
+
+  it("falls back to generatedAt when updatedAt is missing", () => {
+    const overview = { generatedAt: daysAgoIso(4), updatedAt: null };
+    expect(overviewContentAt(overview)).toBe(overview.generatedAt);
+    expect(isOverviewContentStale(overview)).toBe(false);
+  });
+
+  it("marks stale only when content write is past the threshold", () => {
+    // Anthropic-shaped case: first write 3 months ago, amend 4 days ago → not stale
+    expect(
+      isOverviewContentStale({
+        generatedAt: daysAgoIso(91),
+        updatedAt: daysAgoIso(4),
+      }),
+    ).toBe(false);
+
+    // Content last written 31+ days ago → stale
+    expect(
+      isOverviewContentStale({
+        generatedAt: daysAgoIso(91),
+        updatedAt: daysAgoIso(31),
+      }),
+    ).toBe(true);
+  });
+
+  it("formats the compact org-get hint with updated when amended", () => {
+    const hint = formatOverviewFreshnessHint({
+      generatedAt: daysAgoIso(90),
+      updatedAt: daysAgoIso(4),
+    });
+    expect(hint).toBe("updated 4d ago · generated 3mo ago");
   });
 });

--- a/tests/unit/formatters.test.ts
+++ b/tests/unit/formatters.test.ts
@@ -484,6 +484,19 @@ describe("knowledgeToMarkdown", () => {
     expect(md).toContain("updated: 2024-07-04");
   });
 
+  it("omits updated when timestamps are the same instant under different ISO forms", () => {
+    const md = knowledgeToMarkdown(
+      {
+        ...fullKnowledge,
+        generatedAt: "2024-06-16T00:00:00.000Z",
+        updatedAt: "2024-06-16T00:00:00+00:00",
+      },
+      { orgSlug: "vercel" },
+    );
+    expect(md).toContain("generated: 2024-06-16");
+    expect(md).not.toContain("updated:");
+  });
+
   it("includes the content body after frontmatter", () => {
     const md = knowledgeToMarkdown(fullKnowledge);
     expect(md).toContain("# Overview");

--- a/tests/unit/formatters.test.ts
+++ b/tests/unit/formatters.test.ts
@@ -467,6 +467,21 @@ describe("knowledgeToMarkdown", () => {
     expect(md).toContain("release_count: 42");
     expect(md).toContain("last_release: 2024-06-15");
     expect(md).toContain("generated: 2024-06-16");
+    // updated omitted when it matches generated
+    expect(md).not.toContain("updated:");
+  });
+
+  it("includes updated frontmatter when content was amended after generation", () => {
+    const md = knowledgeToMarkdown(
+      {
+        ...fullKnowledge,
+        generatedAt: "2024-04-01T00:00:00Z",
+        updatedAt: "2024-07-04T00:00:00Z",
+      },
+      { orgSlug: "vercel" },
+    );
+    expect(md).toContain("generated: 2024-04-01");
+    expect(md).toContain("updated: 2024-07-04");
   });
 
   it("includes the content body after frontmatter", () => {


### PR DESCRIPTION
## Summary
- Overview stale warnings and age labels used `generatedAt` (first write, never moves on amend). Amended overviews (e.g. Anthropic: generated 3mo ago, updated 4 days ago) incorrectly showed "older than 30 days".
- Prefer content write time (`updatedAt ?? generatedAt`) for age/stale on `org get` and `org overview`.
- When the timestamps differ, show `updated X · generated Y`.
- Same pattern for playbook age and overview markdown frontmatter (`updated:` when amended).
- Shared helper in `src/lib/overview-freshness.ts`; patch changeset included.

## Test plan
- [x] `bun test tests/cli/overview-freshness.test.ts tests/unit/formatters.test.ts`
- [x] `bun run check`
- [x] Manual: `releases org get anthropic` / `org overview anthropic --json` → `stale: false`, `ageDays: 4`, no yellow warning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Overview/preview freshness and age now use the most recent content update time (preferring amended content).
  * Added standardized freshness hints with “updated … · generated …” when applicable (including playbook headers).

* **Bug Fixes**
  * Prevented recently rewritten overviews from being flagged as stale based on older generation timestamps.
  * Organization “Created/Updated” fields now render cleanly when timestamps are missing.

* **Documentation**
  * Updated Changesets overview freshness guidance to reference content write time.
  * Markdown frontmatter now conditionally includes an `updated` field when the content update time meaningfully differs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->