### PR TITLE
feat(cli): render stub orgs + declared locations in 'org get'

### DIFF
--- a/.changeset/org-get-stub-locations.md
+++ b/.changeset/org-get-stub-locations.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": minor
+---
+
+`releases org get` now renders stub-tier orgs (#1947): a `stub · not yet tracked` marker on the header and a `Declared locations` section listing each declared locator (kind, target, `canonical` flag), plus a hint to promote. Previously a stub printed as a bare identity block with no indication it was a declared-but-untracked listing. `--json` output is unchanged.

--- a/src/cli/commands/org-stub.ts
+++ b/src/cli/commands/org-stub.ts
@@ -15,7 +15,7 @@ import { markDryRun } from "../../lib/dry-run.js";
 //   POST /v1/orgs/stub-from-domain   → `admin org create-stub-from-domain`
 //   POST /v1/orgs/:slug/promote      → `admin org promote`
 
-const LOCATOR_KEYS = ["url", "feed", "github", "appstore", "file"] as const;
+export const LOCATOR_KEYS = ["url", "feed", "github", "appstore", "file"] as const;
 
 type Locator = NonNullable<CreateStubOrgBody["releases"]>[number];
 

--- a/src/cli/commands/org.ts
+++ b/src/cli/commands/org.ts
@@ -52,7 +52,7 @@ import {
 import { warnDeprecatedAlias } from "../../lib/deprecated-alias.js";
 import { parseTagList } from "../../lib/flags.js";
 import { buildNoticePatch, formatNotice, type EntityWithNotice } from "../../lib/notice.js";
-import { registerOrgStubCommands } from "./org-stub.js";
+import { registerOrgStubCommands, LOCATOR_KEYS } from "./org-stub.js";
 
 // ── Shared action handlers ────────────────────────────────────────────────────
 
@@ -178,10 +178,6 @@ async function orgCreateAction(name: string, opts: OrgCreateOpts): Promise<void>
   if (opts.json) await writeJson({ ...created, existed: false });
   else logger.info(chalk.green(`Organization created: ${name} (${slug})`));
 }
-
-// Mirrors LOCATOR_KEYS in org-stub.ts — kept local to avoid a re-export just
-// for display formatting.
-const LOCATOR_KEYS = ["url", "feed", "github", "appstore", "file"] as const;
 
 type OrgGetOpts = { json?: boolean };
 

--- a/src/cli/commands/org.ts
+++ b/src/cli/commands/org.ts
@@ -42,6 +42,7 @@ import {
   type ListResponse,
 } from "@buildinternet/releases-core/cli-contracts";
 import { OVERVIEW_STALE_DAYS, overviewPreview } from "@buildinternet/releases-core/overview";
+import type { ReleaseLocationItem } from "@buildinternet/releases-api-types";
 import {
   formatOverviewFreshnessHint,
   formatOverviewFreshnessLine,
@@ -178,6 +179,10 @@ async function orgCreateAction(name: string, opts: OrgCreateOpts): Promise<void>
   else logger.info(chalk.green(`Organization created: ${name} (${slug})`));
 }
 
+// Mirrors LOCATOR_KEYS in org-stub.ts — kept local to avoid a re-export just
+// for display formatting.
+const LOCATOR_KEYS = ["url", "feed", "github", "appstore", "file"] as const;
+
 type OrgGetOpts = { json?: boolean };
 
 async function orgGetAction(identifier: string, opts: OrgGetOpts): Promise<void> {
@@ -208,7 +213,14 @@ async function orgGetAction(identifier: string, opts: OrgGetOpts): Promise<void>
     return;
   }
 
-  console.log(chalk.bold(found.name));
+  // `status`/`locations` are stub-tier fields (#1947) added by the API detail
+  // route; `Organization` is the core DB row type, not api-types' OrgDetailSchema,
+  // so read defensively rather than widening the shared DB type.
+  const stubFields = found as { status?: string; locations?: ReleaseLocationItem[] };
+  const isStub = stubFields.status === "stub";
+  console.log(
+    `${chalk.bold(found.name)}${isStub ? `  ${chalk.yellow("stub · not yet tracked")}` : ""}`,
+  );
   console.log(`  Slug:    ${found.slug}`);
   console.log(`  Domain:  ${found.domain ?? chalk.dim("—")}`);
   if (aliases.length > 0) console.log(`  Aliases: ${aliases.join(", ")}`);
@@ -260,6 +272,22 @@ async function orgGetAction(identifier: string, opts: OrgGetOpts): Promise<void>
       console.log(`  ${chalk.cyan(s.slug.padEnd(30))} ${status} ${fetched}`);
       console.log(`  ${" ".repeat(30)} ${chalk.dim(s.url)}`);
     }
+  }
+
+  if (isStub && stubFields.locations && stubFields.locations.length > 0) {
+    console.log();
+    console.log(chalk.bold("Declared locations:"));
+    for (const loc of stubFields.locations) {
+      const kind = LOCATOR_KEYS.find((key) => typeof loc[key] === "string");
+      const target = kind ? loc[kind] : undefined;
+      const canonicalLabel = loc.canonical ? `  ${chalk.green("canonical")}` : "";
+      console.log(
+        `  ${chalk.cyan((kind ?? "unknown").padEnd(9))}${target ?? chalk.dim("—")}${canonicalLabel}`,
+      );
+      if (loc.title) console.log(`  ${" ".repeat(9)}${chalk.dim(loc.title)}`);
+    }
+    console.log();
+    console.log(chalk.dim(`  Enable tracking: releases admin org promote ${found.slug}`));
   }
 
   if (overview?.content) {


### PR DESCRIPTION
Resolves #365.

`releases org get <slug>` had no awareness of stub-tier orgs (#1947): the display path never read `status` or the declared `locations[]`, so a freshly-activated stub rendered as a bare identity block (its Sources/Products sections are guard-skipped because a stub has none) with no signal it was a declared-but-untracked listing.

## Before
```
$ releases org get acme

Acme
  Slug:    acme
  Domain:  acme.example
  Created: 2026-07-09T14:22:10Z
  Updated: 2026-07-09T14:22:10Z
  Category: Developer Tools
  AI content: off
```

## After
```
$ releases org get acme

Acme  stub · not yet tracked
  Slug:    acme
  Domain:  acme.example
  ...
  AI content: off

Declared locations:
  feed     acme.example/blog/rss.xml  canonical
  github   acme/platform
  url      acme.example/changelog

  Enable tracking: releases admin org promote acme
```

## Notes
- Reuses the exact locator-rendering style from `releases json validate` (`json.ts`): `chalk.cyan(kind.padEnd(9))` + target, `canonical` in green.
- api-types handling: `status`/`locations` are stub-tier detail fields on the API response, not on the core `Organization` DB-row type. Rather than widen the shared type, they're read via a narrow local cast, with `locations` typed as the already-exported `ReleaseLocationItem[]` from `@buildinternet/releases-api-types` (a declared dependency). No api-types publish needed.
- `--json` output is unchanged (already spreads all fields through).

## Verification
- `bun run check` (lint + oxfmt) — clean (pre-existing warning only).
- `bun run build` — compiles.
- Changeset added (`@buildinternet/releases` minor).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `releases org get` now clearly marks stub organizations as “stub · not yet tracked.”
  * Stub organizations with declared locations now show a new “Declared locations” section, including locator details, target, and canonical status.
  * The output now includes a prompt to enable tracking for these organizations.
  * `--json` output remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->