### PR TITLE
feat(cli): add admin release refetch command

### DIFF
--- a/.changeset/admin-release-refetch.md
+++ b/.changeset/admin-release-refetch.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": patch
+---
+
+Add `releases admin release refetch <releaseId>` to re-fetch a single release's live page and heal it in place (title/content/publishedAt, same `rel_` id). Supports `--url` for releases whose stored URL is a synthesized `#fragment` index anchor, defaults to a dry-run preview, and writes with `--apply`.

--- a/src/api/releases.ts
+++ b/src/api/releases.ts
@@ -55,6 +55,51 @@ export async function unsuppressRelease(releaseId: string): Promise<boolean> {
   return result?.unsuppressed ?? false;
 }
 
+// ── Release refetch (operator in-place healing, #2073) ──
+
+export interface RefetchReleaseSnapshot {
+  title: string;
+  contentChars: number;
+  mediaCount: number;
+  publishedAt: string | null;
+  url: string | null;
+}
+
+export interface RefetchReleaseDryRunResult {
+  dryRun: true;
+  releaseId: string;
+  fetchUrl: string;
+  via: string;
+  current: RefetchReleaseSnapshot;
+  proposed: RefetchReleaseSnapshot;
+}
+
+export interface RefetchReleaseWriteResult {
+  dryRun: false;
+  releaseId: string;
+  fetchUrl: string;
+  via: string;
+  updated: RefetchReleaseSnapshot;
+}
+
+export type RefetchReleaseResult = RefetchReleaseDryRunResult | RefetchReleaseWriteResult;
+
+/**
+ * Re-fetch a single release's live page and update the row in place (same
+ * `rel_` id). `dryRun` defaults to true server-side, so callers must pass it
+ * explicitly either way. See buildinternet/releases#2073.
+ */
+export async function refetchRelease(body: {
+  releaseId: string;
+  url?: string;
+  dryRun: boolean;
+}): Promise<RefetchReleaseResult> {
+  return apiFetch<RefetchReleaseResult>("/v1/workflows/refetch-release", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
 export async function deleteReleasesBatch(releaseIds: string[]): Promise<{ deleted: number }> {
   return apiFetch<{ deleted: number }>(`/v1/releases/batch`, {
     method: "DELETE",

--- a/src/cli/commands/release.ts
+++ b/src/cli/commands/release.ts
@@ -10,6 +10,8 @@ import {
   batchSuppressReleases,
   updateRelease,
   deleteReleasesForSource,
+  refetchRelease,
+  type RefetchReleaseSnapshot,
 } from "../../api/releases.js";
 import { findSource } from "../../api/sources.js";
 import { stripAnsi } from "../../lib/sanitize.js";
@@ -194,6 +196,57 @@ async function releaseUpdateAction(rawId: string, opts: ReleaseUpdateOpts): Prom
     console.log(chalk.green(`Updated release ${id}:`));
     for (const change of changes) console.log(`  ${change}`);
   }
+}
+
+type ReleaseRefetchOpts = {
+  url?: string;
+  apply?: boolean;
+  json?: boolean;
+};
+
+function renderRefetchSnapshot(label: string, snap: RefetchReleaseSnapshot): void {
+  console.log(`  ${label}:`);
+  console.log(`    Title:       ${stripAnsi(snap.title)}`);
+  console.log(`    Content:     ${snap.contentChars} chars`);
+  console.log(`    Media:       ${snap.mediaCount}`);
+  console.log(`    Published:   ${snap.publishedAt ?? chalk.dim("—")}`);
+  console.log(`    URL:         ${snap.url ?? chalk.dim("—")}`);
+}
+
+export async function releaseRefetchAction(rawId: string, opts: ReleaseRefetchOpts): Promise<void> {
+  const id = normalizeReleaseId(rawId);
+  if (!id.startsWith("rel_")) {
+    console.error(chalk.red(`Invalid release ID "${rawId}" — expected a release ID (rel_…).`));
+    process.exit(1);
+  }
+
+  const apply = !!opts.apply;
+  let result;
+  try {
+    result = await refetchRelease({ releaseId: id, url: opts.url, dryRun: !apply });
+  } catch (err) {
+    console.error(chalk.red(err instanceof Error ? err.message : String(err)));
+    process.exit(1);
+  }
+
+  if (opts.json) {
+    await writeJson(result);
+    return;
+  }
+
+  if (!result.dryRun) {
+    console.log(chalk.green(`Refetched release ${id} (via ${result.via}, ${result.fetchUrl}):`));
+    renderRefetchSnapshot("Updated", result.updated);
+    return;
+  }
+
+  console.log(
+    chalk.yellow(`[dry-run] Refetch preview for ${id} (via ${result.via}, ${result.fetchUrl}):`),
+  );
+  renderRefetchSnapshot("Current", result.current);
+  renderRefetchSnapshot("Proposed", result.proposed);
+  console.log();
+  console.log(chalk.dim("Re-run with --apply to persist these changes."));
 }
 
 // ── Command registration ──────────────────────────────────────────────────────
@@ -475,4 +528,29 @@ export function registerReleaseCommand(program: Command) {
         );
       }
     });
+
+  release
+    .command("refetch")
+    .description("Re-fetch a release's live page and update the row in place (rel_… id preserved)")
+    .argument("<releaseId>", "Release ID to refetch (rel_…)")
+    .option(
+      "--url <canonicalUrl>",
+      "Canonical permalink to fetch (required when the stored URL is a synthesized #fragment index anchor; must be on the source's host)",
+    )
+    .option("--apply", "Write the changes (default is a dry-run preview)")
+    .option("--json", "Output the raw response as JSON")
+    .addHelpText(
+      "after",
+      `
+Examples:
+  releases admin release refetch rel_abc123                          Dry-run preview
+  releases admin release refetch rel_abc123 --apply                  Write it
+  releases admin release refetch rel_abc123 --url https://example.com/posts/foo --apply
+                                                                       Required when the stored URL is a synthesized #fragment anchor
+
+Re-fetches ONE release's live page and updates the row in place: title,
+content, and publishedAt are replaced; summary/titleGenerated/titleShort are
+nulled for regeneration; media is replaced only when extraction returns items.`,
+    )
+    .action(releaseRefetchAction);
 }

--- a/tests/cli/release-refetch.test.ts
+++ b/tests/cli/release-refetch.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "bun:test";
+import { runCli } from "../utils.js";
+
+describe("release refetch (--help surface)", () => {
+  it("registers the refetch command with its flags", () => {
+    const { stdout, exitCode } = runCli(["admin", "release", "refetch", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("<releaseId>");
+    expect(stdout).toContain("--url");
+    expect(stdout).toContain("--apply");
+    expect(stdout).toContain("--json");
+  });
+
+  it("requires a release ID argument", () => {
+    const { exitCode, stderr } = runCli(["admin", "release", "refetch"], {
+      env: { RELEASES_API_URL: "https://test.example.com", RELEASES_API_KEY: "test" },
+    });
+    expect(exitCode).not.toBe(0);
+    expect(stderr.toLowerCase()).toContain("releaseid");
+  });
+
+  it("rejects a non-rel_ ID with a friendly error and no network call", () => {
+    const { exitCode, stderr } = runCli(["admin", "release", "refetch", "src_notarelease"], {
+      env: { RELEASES_API_URL: "https://test.example.com", RELEASES_API_KEY: "test" },
+    });
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("Invalid release ID");
+  });
+});

--- a/tests/unit/release-refetch.test.ts
+++ b/tests/unit/release-refetch.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Drive the real mode.ts via env (a top-level mock.module leaks across files —
+// see api-client.test.ts). getApiUrl() memoizes the base URL process-wide, so
+// this must be set before anything imports/calls into src/api.
+const prevEnv: { url?: string; key?: string } = {};
+beforeAll(() => {
+  prevEnv.url = process.env.RELEASES_API_URL;
+  prevEnv.key = process.env.RELEASES_API_KEY;
+  process.env.RELEASES_API_URL = "https://test.example.com";
+  process.env.RELEASES_API_KEY = "test-key";
+});
+afterAll(() => {
+  if (prevEnv.url === undefined) delete process.env.RELEASES_API_URL;
+  else process.env.RELEASES_API_URL = prevEnv.url;
+  if (prevEnv.key === undefined) delete process.env.RELEASES_API_KEY;
+  else process.env.RELEASES_API_KEY = prevEnv.key;
+});
+
+const { refetchRelease } = await import("../../src/api/releases.js");
+
+const DRY_RUN_RESPONSE = {
+  dryRun: true,
+  releaseId: "rel_abc123",
+  fetchUrl: "https://example.com/posts/foo",
+  via: "fetch",
+  current: {
+    title: "Old title",
+    contentChars: 120,
+    mediaCount: 0,
+    publishedAt: "2026-01-01T00:00:00.000Z",
+    url: "https://example.com/#foo",
+  },
+  proposed: {
+    title: "New title",
+    contentChars: 480,
+    mediaCount: 2,
+    publishedAt: "2026-06-01T00:00:00.000Z",
+    url: "https://example.com/posts/foo",
+  },
+};
+
+const WRITE_RESPONSE = {
+  dryRun: false,
+  releaseId: "rel_abc123",
+  fetchUrl: "https://example.com/posts/foo",
+  via: "fetch",
+  updated: DRY_RUN_RESPONSE.proposed,
+};
+
+// ── Client wire contract ───────────────────────────────────────────────────
+
+describe("refetchRelease client", () => {
+  let originalFetch: typeof globalThis.fetch;
+  let dir: string;
+  let capturedUrl = "";
+  let capturedBody: Record<string, unknown> | null = null;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    dir = mkdtempSync(join(tmpdir(), "rel-refetch-client-"));
+    process.env.RELEASES_RUN_DIR = dir;
+    capturedUrl = "";
+    capturedBody = null;
+    globalThis.fetch = (async (url: string, init?: RequestInit) => {
+      capturedUrl = url;
+      capturedBody = JSON.parse(String(init?.body ?? "{}"));
+      const body = capturedBody.dryRun === false ? WRITE_RESPONSE : DRY_RUN_RESPONSE;
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof globalThis.fetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    delete process.env.RELEASES_RUN_DIR;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("POSTs to /v1/workflows/refetch-release with releaseId and explicit dryRun:true", async () => {
+    const result = await refetchRelease({ releaseId: "rel_abc123", dryRun: true });
+    expect(capturedUrl).toBe("https://test.example.com/v1/workflows/refetch-release");
+    expect(capturedBody).toMatchObject({ releaseId: "rel_abc123", dryRun: true });
+    expect(result.dryRun).toBe(true);
+  });
+
+  it("sends explicit dryRun:false with --apply, forwarding a url override", async () => {
+    const result = await refetchRelease({
+      releaseId: "rel_abc123",
+      url: "https://example.com/posts/foo",
+      dryRun: false,
+    });
+    expect(capturedBody).toMatchObject({
+      releaseId: "rel_abc123",
+      url: "https://example.com/posts/foo",
+      dryRun: false,
+    });
+    expect(result.dryRun).toBe(false);
+  });
+
+  it("surfaces the endpoint's actionable message on a 400 fragment-URL rejection", async () => {
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          error: {
+            code: "bad_request",
+            type: "validation_error",
+            message:
+              "This release's stored URL is a synthesized index anchor (or missing) — fetching it would ingest the index page. Pass the post's canonical `url` explicitly.",
+          },
+        }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      )) as unknown as typeof globalThis.fetch;
+    await expect(refetchRelease({ releaseId: "rel_abc123", dryRun: true })).rejects.toThrow(
+      /canonical `url` explicitly/,
+    );
+  });
+});
+
+// ── Command behavior ─────────────────────────────────────────────────────────
+
+describe("releaseRefetchAction", () => {
+  let originalFetch: typeof globalThis.fetch;
+  let originalExit: typeof process.exit;
+  let dir: string;
+  let postBody: Record<string, unknown> | null = null;
+  let exitCode: number | undefined;
+
+  function mockRefetch(response: unknown = DRY_RUN_RESPONSE) {
+    globalThis.fetch = (async (url: string, init?: RequestInit) => {
+      postBody = JSON.parse(String(init?.body ?? "{}"));
+      return new Response(JSON.stringify(response), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof globalThis.fetch;
+  }
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    originalExit = process.exit;
+    dir = mkdtempSync(join(tmpdir(), "rel-refetch-cmd-"));
+    process.env.RELEASES_RUN_DIR = dir;
+    postBody = null;
+    exitCode = undefined;
+    process.exit = ((code?: number) => {
+      exitCode = code ?? 0;
+      throw new Error(`process.exit(${code})`);
+    }) as unknown as typeof process.exit;
+    mockRefetch();
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    process.exit = originalExit;
+    delete process.env.RELEASES_RUN_DIR;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("dry-runs by default, sending explicit dryRun:true", async () => {
+    const { releaseRefetchAction } = await import("../../src/cli/commands/release.js");
+    await releaseRefetchAction("rel_abc123", {});
+    expect(postBody).toMatchObject({ releaseId: "rel_abc123", dryRun: true });
+  });
+
+  it("--apply sends explicit dryRun:false", async () => {
+    mockRefetch(WRITE_RESPONSE);
+    const { releaseRefetchAction } = await import("../../src/cli/commands/release.js");
+    await releaseRefetchAction("rel_abc123", { apply: true });
+    expect((postBody as { dryRun?: boolean }).dryRun).toBe(false);
+  });
+
+  it("forwards --url", async () => {
+    const { releaseRefetchAction } = await import("../../src/cli/commands/release.js");
+    await releaseRefetchAction("rel_abc123", { url: "https://example.com/posts/foo" });
+    expect((postBody as { url?: string }).url).toBe("https://example.com/posts/foo");
+  });
+
+  it("rejects a non-rel_ id before making any network call", async () => {
+    const { releaseRefetchAction } = await import("../../src/cli/commands/release.js");
+    let threw = false;
+    try {
+      await releaseRefetchAction("src_notarelease", {});
+    } catch {
+      threw = true;
+    }
+    expect(threw).toBe(true);
+    expect(exitCode).toBe(1);
+    expect(postBody).toBeNull();
+  });
+});

--- a/tests/unit/release-refetch.test.ts
+++ b/tests/unit/release-refetch.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
+import { stripAnsi } from "../../src/lib/sanitize.js";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -126,9 +127,14 @@ describe("refetchRelease client", () => {
 describe("releaseRefetchAction", () => {
   let originalFetch: typeof globalThis.fetch;
   let originalExit: typeof process.exit;
+  let originalWrite: typeof process.stdout.write;
+  let originalLog: typeof console.log;
+  let originalError: typeof console.error;
   let dir: string;
   let postBody: Record<string, unknown> | null = null;
   let exitCode: number | undefined;
+  let out: string;
+  let errOut: string;
 
   function mockRefetch(response: unknown = DRY_RUN_RESPONSE) {
     globalThis.fetch = (async (url: string, init?: RequestInit) => {
@@ -143,10 +149,27 @@ describe("releaseRefetchAction", () => {
   beforeEach(() => {
     originalFetch = globalThis.fetch;
     originalExit = process.exit;
+    originalWrite = process.stdout.write;
+    originalLog = console.log;
+    originalError = console.error;
     dir = mkdtempSync(join(tmpdir(), "rel-refetch-cmd-"));
     process.env.RELEASES_RUN_DIR = dir;
     postBody = null;
     exitCode = undefined;
+    out = "";
+    errOut = "";
+    // The human view uses console.log; --json uses writeJson → stdout.write.
+    // Capture both so either path's output lands in `out`.
+    process.stdout.write = ((chunk: unknown) => {
+      out += typeof chunk === "string" ? chunk : String(chunk);
+      return true;
+    }) as typeof process.stdout.write;
+    console.log = (...args: unknown[]) => {
+      out += args.map(String).join(" ") + "\n";
+    };
+    console.error = (...args: unknown[]) => {
+      errOut += args.map(String).join(" ") + "\n";
+    };
     process.exit = ((code?: number) => {
       exitCode = code ?? 0;
       throw new Error(`process.exit(${code})`);
@@ -156,6 +179,9 @@ describe("releaseRefetchAction", () => {
   afterEach(() => {
     globalThis.fetch = originalFetch;
     process.exit = originalExit;
+    process.stdout.write = originalWrite;
+    console.log = originalLog;
+    console.error = originalError;
     delete process.env.RELEASES_RUN_DIR;
     rmSync(dir, { recursive: true, force: true });
   });
@@ -177,6 +203,64 @@ describe("releaseRefetchAction", () => {
     const { releaseRefetchAction } = await import("../../src/cli/commands/release.js");
     await releaseRefetchAction("rel_abc123", { url: "https://example.com/posts/foo" });
     expect((postBody as { url?: string }).url).toBe("https://example.com/posts/foo");
+  });
+
+  it("--json writes the raw response as pretty JSON and nothing else", async () => {
+    const { releaseRefetchAction } = await import("../../src/cli/commands/release.js");
+    await releaseRefetchAction("rel_abc123", { json: true });
+    expect(postBody).toMatchObject({ releaseId: "rel_abc123", dryRun: true });
+    expect(JSON.parse(out)).toEqual(DRY_RUN_RESPONSE);
+  });
+
+  it("renders the formatted dry-run preview with current and proposed snapshots", async () => {
+    const { releaseRefetchAction } = await import("../../src/cli/commands/release.js");
+    await releaseRefetchAction("rel_abc123", {});
+    const text = stripAnsi(out);
+    expect(text).toContain("[dry-run] Refetch preview for rel_abc123");
+    expect(text).toContain("via fetch, https://example.com/posts/foo");
+    expect(text).toContain("Current:");
+    expect(text).toContain("Proposed:");
+    expect(text).toContain("Old title");
+    expect(text).toContain("New title");
+    expect(text).toContain("480 chars");
+    expect(text).toContain("Re-run with --apply to persist these changes.");
+  });
+
+  it("renders the formatted updated snapshot after --apply", async () => {
+    mockRefetch(WRITE_RESPONSE);
+    const { releaseRefetchAction } = await import("../../src/cli/commands/release.js");
+    await releaseRefetchAction("rel_abc123", { apply: true });
+    const text = stripAnsi(out);
+    expect(text).toContain("Refetched release rel_abc123");
+    expect(text).toContain("Updated:");
+    expect(text).toContain("New title");
+    expect(text).not.toContain("[dry-run]");
+  });
+
+  it("prints the API error and exits 1 when refetchRelease rejects (400 fragment URL)", async () => {
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          error: {
+            code: "bad_request",
+            type: "validation_error",
+            message:
+              "This release's stored URL is a synthesized index anchor (or missing) — fetching it would ingest the index page. Pass the post's canonical `url` explicitly.",
+          },
+        }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      )) as unknown as typeof globalThis.fetch;
+    const { releaseRefetchAction } = await import("../../src/cli/commands/release.js");
+    let threw = false;
+    try {
+      await releaseRefetchAction("rel_abc123", {});
+    } catch {
+      threw = true; // the process.exit stub throws
+    }
+    expect(threw).toBe(true);
+    expect(exitCode).toBe(1);
+    expect(stripAnsi(errOut)).toContain("canonical `url` explicitly");
+    expect(out).toBe("");
   });
 
   it("rejects a non-rel_ id before making any network call", async () => {


### PR DESCRIPTION
## Motivation

Wraps buildinternet/releases#2073 — the backend admin endpoint
`POST /v1/workflows/refetch-release`. Lets curators heal a single
thin/stale release row (typically a teaser-body index-scrape row with a
synthesized `#fragment` URL) without a full source refetch: title,
content, and `publishedAt` get replaced from the live page, the row keeps
its `rel_` id (so links keep working), and the AI-generated fields
(`summary`/`titleGenerated`/`titleShort`) are nulled to regenerate over
the richer body.

## Usage

```sh
# Dry-run preview (default) — shows current vs. proposed
releases admin release refetch rel_abc123

# Apply the change
releases admin release refetch rel_abc123 --apply

# A release whose stored URL is a synthesized #fragment index anchor
# requires the canonical permalink explicitly; it must be on the
# source's host
releases admin release refetch rel_abc123 \
  --url https://example.com/posts/foo --apply

# Raw JSON response
releases admin release refetch rel_abc123 --json
```

Client-side validation: `releaseId` must start with `rel_` — the
command exits non-zero with a friendly message before any network call
otherwise.

## Test notes

- `tests/unit/release-refetch.test.ts` — wire contract for the
  `refetchRelease` API client (explicit `dryRun` true/false, `url`
  forwarding, error-message passthrough) and `releaseRefetchAction`
  command behavior (dry-run default, `--apply`, `--url`, and the
  client-side `rel_` prefix guard with no network call).
- `tests/cli/release-refetch.test.ts` — `--help` surface coverage and
  argument-required/invalid-id exit codes.
- `bun run check` (oxlint + oxfmt) passes.
- `bun test` — 1085 pass / 7 fail on this branch; the 7 failures are
  pre-existing on `main` (`tests/cli/auth.test.ts`, env-dependent) and
  unrelated to this change (confirmed by running the suite on `main`
  before these changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an administrative CLI command to refetch and repair a single release in place while preserving its existing ID.
  * Default preview mode; use `--apply` to persist updates.
  * Added optional URL override support for fragment-based stored URLs.
  * Added `--json` output option and improved human-readable summaries for current/proposed/updated release details.
  * Introduced a corresponding API client for the refetch operation.
* **Tests**
  * Added coverage for command help/flags, release ID validation, preview vs apply behavior, URL forwarding, JSON output, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->