### PR TITLE
docs(skills): document signed-in personal-account MCP tools in releases-mcp

### DIFF
--- a/skills/releases-mcp/SKILL.md
+++ b/skills/releases-mcp/SKILL.md
@@ -30,6 +30,8 @@ The hosted server exposes these tools. There is no AI summarization or compariso
 - `list_collections` / `get_collection` / `get_collection_releases` — curated cross-org "playlists" (e.g. "Frontier AI Labs", "Coding Agents") independent of the category taxonomy.
 - `lookup_domain` — resolve a URL/domain to the org that owns it. Use when you have a URL-shaped input rather than a name.
 
+The server also exposes **signed-in personal-account tools** — `follow` / `unfollow` / `list_follows`, `get_personalized_feed`, and `whats_changed` (releases since the user's last check across their follows). They require an authenticated connection (OAuth or a user API key) and error for anonymous clients; the reader tools above need no auth. Reach for them only when the user asks about *their* follows or feed — for general "what's new in X" questions, the reader tools answer without sign-in.
+
 ## How to Look Up Releases
 
 ### Step 1: Resolve the entity


### PR DESCRIPTION
Phase 3 of buildinternet/releases#1090 (skills reconciliation). The `releases-mcp` skill reads as the complete hosted-server tool reference but omitted the five signed-in personal-account tools (`follow`/`unfollow`/`list_follows`, `get_personalized_feed`, `whats_changed`). Adds a short note: they exist, they're auth-gated (OAuth / user API key; anonymous clients get an auth error), and they're for questions about *the user's* follows/feed — reader tools stay the default for general lookups.

Skill prose only; no changeset (skills ship from the repo tree via the plugin / `npx skills add`, not the npm package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented additional signed-in tools for following releases and viewing personalized feeds or recent changes.
  * Clarified authentication requirements for personal-account features.
  * Added guidance distinguishing personalized tools from unauthenticated general release and changelog lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->