### PR TITLE
feat(search): add --category and --collection filters

### DIFF
--- a/.changeset/search-category-collection-filters.md
+++ b/.changeset/search-category-collection-filters.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": minor
+---
+
+`releases search` gains `--category <slug>` and `--collection <slug>` filters. `--category` scopes hits to organizations in a category (validated client-side against `releases categories`; the API resolves aliases and is the source of truth); `--collection` scopes to a curated collection's member orgs (unknown slugs report "no collection matching …", mirroring `--domain`). Both forward to the new `/v1/search` params and compose with the existing `--domain` / `--product` / `--kind` / `--since` / `--until` scopes.

--- a/.changeset/search-category-collection-filters.md
+++ b/.changeset/search-category-collection-filters.md
@@ -2,4 +2,4 @@
 "@buildinternet/releases": minor
 ---
 
-`releases search` gains `--category <slug>` and `--collection <slug>` filters. `--category` scopes hits to organizations in a category (validated client-side against `releases categories`; the API resolves aliases and is the source of truth); `--collection` scopes to a curated collection's member orgs (unknown slugs report "no collection matching …", mirroring `--domain`). Both forward to the new `/v1/search` params and compose with the existing `--domain` / `--product` / `--kind` / `--since` / `--until` scopes.
+`releases search` gains `--category <slug>` and `--collection <slug>` filters. `--category` scopes hits to organizations in a category (the API validates and resolves curator aliases like `e-commerce` → `commerce`, so the value is forwarded as-is); `--collection` scopes to a curated collection's member orgs (unknown slugs report "no collection matching …", mirroring `--domain`). Both forward to the new `/v1/search` params and compose with the existing `--domain` / `--product` / `--kind` / `--since` / `--until` scopes.

--- a/src/api/sources.ts
+++ b/src/api/sources.ts
@@ -216,6 +216,12 @@ export async function unifiedSearch(
     /** Product identifier (org/slug coordinate, prod_… id, or product slug);
      *  scopes hits to that product's sources. Resolved server-side (#1218). */
     product?: string;
+    /** Org category slug (validated against `releases categories`); scopes
+     *  orgs/catalog/release hits to that category. Unknown → 400 (#371). */
+    category?: string;
+    /** Curated collection slug; scopes hits to the collection's member orgs.
+     *  Unknown → empty envelope with `collectionStatus: "not_found"` (#371). */
+    collection?: string;
     mode?: "lexical" | "semantic" | "hybrid";
     kind?: Kind;
     /** ISO date or relative shorthand (90d/4w/6m/2y); resolved server-side. */
@@ -227,6 +233,8 @@ export async function unifiedSearch(
   if (opts?.org) params.set("org", opts.org);
   if (opts?.domain) params.set("domain", opts.domain);
   if (opts?.product) params.set("product", opts.product);
+  if (opts?.category) params.set("category", opts.category);
+  if (opts?.collection) params.set("collection", opts.collection);
   if (opts?.mode) params.set("mode", opts.mode);
   if (opts?.kind) params.set("kind", opts.kind);
   if (opts?.since) params.set("since", opts.since);

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -4,6 +4,7 @@ import { unifiedSearch } from "../../api/sources.js";
 import { stripAnsi } from "../../lib/sanitize.js";
 import { logger } from "@releases/lib/logger";
 import { isValidKind, KIND_VALUES, type Kind } from "@buildinternet/releases-core/kinds";
+import { isValidCategory, CATEGORIES } from "@buildinternet/releases-core/categories";
 import type { LookupResultPayload, UnifiedSearchResponse } from "../../api/types.js";
 import { writeJson } from "../../lib/output.js";
 import { parseFieldsFlag, projectFields, unmatchedFields } from "../../lib/fields.js";
@@ -127,6 +128,14 @@ export function registerSearchCommand(program: Command) {
       "Scope hits to one product's sources (org/slug coordinate, prod_… id, or product slug)",
     )
     .option(
+      "--category <slug>",
+      `Scope hits to organizations in a category (${CATEGORIES.join(", ")}). See 'releases categories'.`,
+    )
+    .option(
+      "--collection <slug>",
+      "Scope hits to a curated collection's member orgs (e.g. coding-agents)",
+    )
+    .option(
       "--kind <kind>",
       `Filter by taxonomy (${KIND_VALUES.join(", ")}). Release hits use COALESCE(source.kind, product.kind); catalog hits match the row's own kind only.`,
     )
@@ -153,6 +162,8 @@ Examples:
   releases search "breaking change" --kind sdk    Narrow to SDK sources
   releases search "slack integration" --since 90d Only hits from the last 90 days
   releases search webhooks --product vercel/next-js   Scope a term to one product
+  releases search mcp --category developer-tools  Scope to dev-tools companies
+  releases search agents --collection coding-agents   Scope to a collection
   releases search vercel --type orgs              Show only org matches
   releases search shopify/hydrogen                Coordinate lookup (GitHub)`,
     )
@@ -165,6 +176,8 @@ Examples:
           mode?: string;
           domain?: string;
           product?: string;
+          category?: string;
+          collection?: string;
           kind?: string;
           since?: string;
           until?: string;
@@ -194,6 +207,16 @@ Examples:
         }
         const kind = opts.kind as Kind | undefined;
 
+        // Cheap client-side check against the canonical category slugs; the API
+        // is the source of truth (and also resolves curator aliases), but a
+        // typo shouldn't cost a round-trip. Aliases fall through to the API.
+        if (opts.category !== undefined && !isValidCategory(opts.category)) {
+          logger.error(
+            `Invalid --category value: "${opts.category}". Must be one of: ${CATEGORIES.join(", ")}`,
+          );
+          process.exit(1);
+        }
+
         let types: readonly SearchSection[];
         try {
           types = opts.type
@@ -213,6 +236,8 @@ Examples:
           mode?: SearchMode;
           domain?: string;
           product?: string;
+          category?: string;
+          collection?: string;
           kind?: Kind;
           since?: string;
           until?: string;
@@ -220,6 +245,8 @@ Examples:
         if (mode) searchOpts.mode = mode;
         if (opts.domain) searchOpts.domain = opts.domain;
         if (opts.product) searchOpts.product = opts.product;
+        if (opts.category) searchOpts.category = opts.category;
+        if (opts.collection) searchOpts.collection = opts.collection;
         if (kind) searchOpts.kind = kind;
         if (since) searchOpts.since = since;
         if (until) searchOpts.until = until;
@@ -252,6 +279,27 @@ Examples:
             logger.warn(`No product matching "${scopedProduct}". Showing no results.`);
           } else if (productEcho.productStatus === "matched") {
             logger.info(`Scoped to product ${scopedProduct}.`);
+          }
+        }
+
+        // `?category=` / `?collection=` echoes (#371). Read loosely, same
+        // pattern as the `?product=` echo above — the api-types pin here may
+        // predate the shape landing on UnifiedSearchResponse.
+        const scopeEcho = response as unknown as {
+          category?: string;
+          categoryStatus?: "matched";
+          collection?: string;
+          collectionStatus?: "matched" | "not_found";
+        };
+        if (!opts.json && scopeEcho.categoryStatus === "matched") {
+          logger.info(`Scoped to category ${scopeEcho.category ?? opts.category}.`);
+        }
+        if (!opts.json && scopeEcho.collectionStatus !== undefined) {
+          const scopedCollection = scopeEcho.collection ?? opts.collection;
+          if (scopeEcho.collectionStatus === "not_found") {
+            logger.warn(`No collection matching "${scopedCollection}". Showing no results.`);
+          } else if (scopeEcho.collectionStatus === "matched") {
+            logger.info(`Scoped to collection ${scopedCollection}.`);
           }
         }
 

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -4,7 +4,7 @@ import { unifiedSearch } from "../../api/sources.js";
 import { stripAnsi } from "../../lib/sanitize.js";
 import { logger } from "@releases/lib/logger";
 import { isValidKind, KIND_VALUES, type Kind } from "@buildinternet/releases-core/kinds";
-import { isValidCategory, CATEGORIES } from "@buildinternet/releases-core/categories";
+import { CATEGORIES } from "@buildinternet/releases-core/categories";
 import type { LookupResultPayload, UnifiedSearchResponse } from "../../api/types.js";
 import { writeJson } from "../../lib/output.js";
 import { parseFieldsFlag, projectFields, unmatchedFields } from "../../lib/fields.js";
@@ -207,15 +207,11 @@ Examples:
         }
         const kind = opts.kind as Kind | undefined;
 
-        // Cheap client-side check against the canonical category slugs; the API
-        // is the source of truth (and also resolves curator aliases), but a
-        // typo shouldn't cost a round-trip. Aliases fall through to the API.
-        if (opts.category !== undefined && !isValidCategory(opts.category)) {
-          logger.error(
-            `Invalid --category value: "${opts.category}". Must be one of: ${CATEGORIES.join(", ")}`,
-          );
-          process.exit(1);
-        }
+        // No client-side --category gate: the API is the source of truth and
+        // resolves curator aliases (e.g. "e-commerce" → "commerce"), which the
+        // canonical `CATEGORIES` list here can't see. A local `isValidCategory`
+        // check would wrongly reject valid aliases, so we forward the value and
+        // let the API 400 on a genuinely unknown category.
 
         let types: readonly SearchSection[];
         try {

--- a/tests/unit/api-client.test.ts
+++ b/tests/unit/api-client.test.ts
@@ -458,6 +458,23 @@ describe("since/until query params", () => {
     expect(capturedUrl).toContain("since=30d");
     expect(capturedUrl).toContain("until=2026-05-01");
   });
+
+  it("unifiedSearch forwards category and collection", async () => {
+    captureWith({ orgs: [], catalog: [], releases: [], collections: [] });
+    await client.unifiedSearch("q", 10, {
+      category: "developer-tools",
+      collection: "coding-agents",
+    });
+    expect(capturedUrl).toContain("category=developer-tools");
+    expect(capturedUrl).toContain("collection=coding-agents");
+  });
+
+  it("unifiedSearch omits category/collection when not supplied", async () => {
+    captureWith({ orgs: [], catalog: [], releases: [], collections: [] });
+    await client.unifiedSearch("q", 10);
+    expect(capturedUrl).not.toContain("category=");
+    expect(capturedUrl).not.toContain("collection=");
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`releases search` gains two curation-axis filters, alongside the existing `--domain` / `--product` / `--kind` / `--since` / `--until` scopes:

- **`--category <slug>`** — scopes orgs, catalog, and release hits to organizations in a category (`developer-tools`, `cloud`, … — the values `releases categories` lists).
- **`--collection <slug>`** — scopes to a curated cross-org collection's member orgs (e.g. `coding-agents`).

```
releases search mcp --category developer-tools     Scope to dev-tools companies
releases search agents --collection coding-agents  Scope to a collection
```

## Why

The CLI could scope by source/product taxonomy (`--kind`), org domain, product, and date window, but not by the two curation axes people actually browse by — org **category** and curated **collection**. The motivating case (homepage CLI demo, buildinternet/releases#2084) was "search this term across the subset of companies relevant to our space," for which `--kind` was the closest-but-wrong flag.

## Depends on

The API side landed in buildinternet/releases#2106 (merged) — `/v1/search` now accepts `category` / `collection` and echoes `categoryStatus` / `collectionStatus`.

## How

- `--category` is validated **client-side** against the canonical `CATEGORIES` list (fast, clear error on a typo); curator aliases fall through to the API, which is the source of truth.
- `--collection` has no cheap local list, so it forwards to the API; an unknown slug comes back as `collectionStatus: "not_found"` and the CLI prints "No collection matching …", mirroring the `--domain` miss message.
- Both params are forwarded by `unifiedSearch()`, and the response echoes drive a one-line scope confirmation in non-`--json` output.

## Reviewer notes

- **`tail --collection` deferred.** The issue flags it as a secondary "likely also makes sense." `/v1/releases/latest` only supports `source`/`org` scopes and rides a KV cache, so it needs its own endpoint work rather than reusing the search plumbing — worth a follow-up.

## Tests

`tests/unit/api-client.test.ts` — `unifiedSearch` forwards `category`/`collection` when supplied and omits them otherwise. `bun run check` green; help output + client-side validation smoke-tested.

Closes #371


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--category <slug>` and `--collection <slug>` filters to `releases search`.
  * Category and collection filters can be combined with existing search filters.
  * Search results now display matching scope information and warn when a collection is not found.
  * Added usage examples for the new filters.

* **Bug Fixes**
  * Improved validation and handling of category and collection search scopes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->