### PR TITLE
feat: hint at NODE_EXTRA_CA_CERTS on TLS cert verification failures

### DIFF
--- a/.changeset/ca-bundle-hint.md
+++ b/.changeset/ca-bundle-hint.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/releases": patch
+---
+
+Surface a NODE_EXTRA_CA_CERTS / SSL_CERT_FILE hint on TLS certificate verification failures, and document custom-CA support (TLS-intercepting proxies) in the README.

--- a/README.md
+++ b/README.md
@@ -133,6 +133,18 @@ Reader access requires nothing. Useful overrides:
 
 See [`.env.example`](./.env.example) for the full list.
 
+### Custom CA certificates (TLS-intercepting proxies)
+
+The compiled binary ships with the standard Mozilla CA store. If your network re-terminates TLS with its own CA (corporate proxy, sandboxed agent environment), point the standard Node/OpenSSL variables at the proxy's CA certificate — the binary honors both:
+
+```sh
+NODE_EXTRA_CA_CERTS=/path/to/proxy-ca.pem releases search "bun"
+# or
+SSL_CERT_FILE=/path/to/proxy-ca.pem releases search "bun"
+```
+
+No `--ca-bundle` flag is needed; certificate errors from the CLI include this hint.
+
 ## Exit codes
 
 | Code  | Meaning                                                      |

--- a/src/api/core.ts
+++ b/src/api/core.ts
@@ -38,6 +38,23 @@ export type {
   OrgDependentsResponse,
 } from "./types.js";
 
+// OpenSSL verification-failure codes Bun's fetch surfaces when the server's
+// chain doesn't anchor to a trusted CA — the signature of a TLS-intercepting
+// proxy whose CA isn't in the bundled Mozilla store.
+const CERT_ERROR_CODES = new Set([
+  "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
+  "UNABLE_TO_GET_ISSUER_CERT",
+  "UNABLE_TO_GET_ISSUER_CERT_LOCALLY",
+  "SELF_SIGNED_CERT_IN_CHAIN",
+  "DEPTH_ZERO_SELF_SIGNED_CERT",
+  "CERT_UNTRUSTED",
+]);
+
+function isCertVerificationError(err: unknown): boolean {
+  const code = (err as { code?: unknown } | null)?.code;
+  return typeof code === "string" && CERT_ERROR_CODES.has(code);
+}
+
 export async function apiFetch<T>(path: string, opts?: RequestInit): Promise<T> {
   // Defense-in-depth: reject raw control characters in the assembled path. By
   // this point user identifiers are already percent-encoded, so a clean path
@@ -78,7 +95,10 @@ export async function apiFetch<T>(path: string, opts?: RequestInit): Promise<T> 
       });
     }
     const detail = err instanceof Error ? err.message : String(err);
-    throw new Error(`API request failed on ${opts?.method ?? "GET"} ${path}: ${detail}`, {
+    const hint = isCertVerificationError(err)
+      ? " (TLS certificate verification failed — if you're behind a TLS-intercepting proxy, set NODE_EXTRA_CA_CERTS or SSL_CERT_FILE to the proxy's CA certificate)"
+      : "";
+    throw new Error(`API request failed on ${opts?.method ?? "GET"} ${path}: ${detail}${hint}`, {
       cause: err,
     });
   }

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -68,7 +68,10 @@ import { writeJson } from "../lib/output.js";
 export { VERSION };
 
 const IS_DEV = !!process.argv[1]?.endsWith(".ts");
-const VERSION_DISPLAY = IS_DEV ? `${VERSION}-dev` : VERSION;
+const VERSION_SHORT = IS_DEV ? `${VERSION}-dev` : VERSION;
+// Include the runtime so agents in unfamiliar environments can tell this is a
+// Bun binary (and thus that NODE_EXTRA_CA_CERTS / SSL_CERT_FILE etc. apply).
+const VERSION_DISPLAY = `${VERSION_SHORT} (bun ${Bun.version}, ${process.platform}-${process.arch})`;
 
 function adminKeyError(name = "admin"): never {
   console.error(
@@ -133,7 +136,7 @@ function printStyledHelp(): string {
   const lines: string[] = [];
 
   lines.push("");
-  lines.push(`${chalk.bold("releases")} ${chalk.dim(`v${VERSION_DISPLAY}`)}`);
+  lines.push(`${chalk.bold("releases")} ${chalk.dim(`v${VERSION_SHORT}`)}`);
   lines.push(chalk.dim("The changelog & release-notes registry for developers and AI agents"));
   lines.push(chalk.dim("Web catalog: ") + chalk.cyan("https://releases.sh"));
   lines.push("");


### PR DESCRIPTION
## Why

A remote agent environment that re-terminates TLS with its own proxy CA reported the compiled binary as unusable ("needs a --ca-bundle flag or RELEASES_CA_BUNDLE env var") and fell back to curl. The capability already exists — compiled Bun binaries honor `NODE_EXTRA_CA_CERTS` and `SSL_CERT_FILE` (verified empirically against a self-signed server with the same Bun 1.3.13 the release CI pins) — but nothing surfaced it, so the agent had no way to discover it.

## What

- `apiFetch` transport errors now detect OpenSSL cert-verification codes (`DEPTH_ZERO_SELF_SIGNED_CERT`, `SELF_SIGNED_CERT_IN_CHAIN`, `UNABLE_TO_VERIFY_LEAF_SIGNATURE`, …) and append a hint pointing at `NODE_EXTRA_CA_CERTS` / `SSL_CERT_FILE`.
- README gains a "Custom CA certificates" subsection under Environment.
- Patch changeset.

No new flag or env var — the standard Node/OpenSSL conventions already work; this is a discoverability fix.

## Verified

Against a local self-signed HTTPS server:

```
error: API request failed on GET /v1/search?q=test&limit=10: self signed certificate (TLS certificate verification failed — if you're behind a TLS-intercepting proxy, set NODE_EXTRA_CA_CERTS or SSL_CERT_FILE to the proxy's CA certificate)
```

and the same command succeeds with `NODE_EXTRA_CA_CERTS=cert.pem`. The 7 failing tests in `bun test` are pre-existing on main (local stored-credential interference), unrelated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * TLS certificate verification failures now include a troubleshooting hint for configuring custom CA certificates.
* **Documentation**
  * Added a “Custom CA certificates (TLS-intercepting proxies)” section explaining how to use `NODE_EXTRA_CA_CERTS` or `SSL_CERT_FILE`.
  * Clarified that no extra CLI flag is required for custom CA configuration.
* **Chores**
  * Added a patch release entry for the guidance and documentation improvements.
* **Style**
  * Updated CLI help/version display to use a shorter version identifier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Runtime identity

`releases --version` now prints the runtime and platform — `0.72.0 (bun 1.3.13, darwin-arm64)` — so an agent in an unfamiliar environment can tell this is a Bun binary and infer that the standard Node CA env vars apply. The styled help header keeps the short version.